### PR TITLE
Add Scholia as external registry

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4186,7 +4186,8 @@
       "go": "CAS",
       "miriam": "cas",
       "n2t": "cas",
-      "prefixcommons": "CAS"
+      "prefixcommons": "CAS",
+      "scholia": "cas"
     },
     "miriam": {
       "deprecated": false,
@@ -9057,7 +9058,8 @@
       "go": "DOI",
       "miriam": "doi",
       "n2t": "doi",
-      "prefixcommons": "DOI"
+      "prefixcommons": "DOI",
+      "scholia": "doi"
     },
     "miriam": {
       "deprecated": false,
@@ -18147,7 +18149,8 @@
     "mappings": {
       "miriam": "inchikey",
       "n2t": "inchikey",
-      "prefixcommons": "INCHIKEY"
+      "prefixcommons": "INCHIKEY",
+      "scholia": "inchikey"
     },
     "miriam": {
       "deprecated": false,
@@ -20401,7 +20404,8 @@
     "mappings": {
       "miriam": "lipidmaps",
       "n2t": "lipidmaps",
-      "prefixcommons": "LIPIDMAPS"
+      "prefixcommons": "LIPIDMAPS",
+      "scholia": "lipidmaps"
     },
     "miriam": {
       "deprecated": false,
@@ -32015,7 +32019,8 @@
       "go": "PMID",
       "miriam": "pubmed",
       "n2t": "pubmed",
-      "prefixcommons": "PMID"
+      "prefixcommons": "PMID",
+      "scholia": "pubmed"
     },
     "miriam": {
       "deprecated": false,

--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -142,6 +142,15 @@
       "provider_url": "https://prefixcommons.org/?q=id:$1"
     },
     {
+      "contact": "faan@dtu.dk",
+      "description": "A frontend to Wikidata",
+      "example": "doi",
+      "homepage": "https://scholia.toolforge.org/",
+      "name": "Scholia",
+      "prefix": "scholia",
+      "resolver_url": "https://scholia.toolforge.org/$1/$2"
+    },
+    {
       "description": "The cross-references section of UniProtKB entries displays explicit and implicit links to databases such as nucleotide sequence databases, model organism databases and genomics and proteomics resources.",
       "download": "https://www.uniprot.org/database/?format=rdf",
       "example": "0174",

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -292,7 +292,7 @@ def get_scholia_prefix(prefix: str) -> Optional[str]:
     entry = get_resource(prefix)
     if entry is None:
         return None
-    return entry.get_ols_prefix()
+    return entry.get_scholia_prefix()
 
 
 def get_banana(prefix: str) -> Optional[str]:

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -278,6 +278,23 @@ def get_fairsharing_prefix(prefix: str) -> Optional[str]:
     return entry.get_mapped_prefix("fairsharing")
 
 
+def get_scholia_prefix(prefix: str) -> Optional[str]:
+    """Get the Scholia prefix if available.
+
+    :param prefix: The prefix to lookup.
+    :returns: The Scholia prefix corresponding to the prefix, if mappable.
+
+    >>> get_scholia_prefix("pubmed")
+    'pubmed'
+    >>> get_scholia_prefix("pdb")
+    None
+    """
+    entry = get_resource(prefix)
+    if entry is None:
+        return None
+    return entry.get_ols_prefix()
+
+
 def get_banana(prefix: str) -> Optional[str]:
     """Get the optional redundant prefix to go before an identifier.
 

--- a/src/bioregistry/resolve_identifier.py
+++ b/src/bioregistry/resolve_identifier.py
@@ -15,6 +15,7 @@ from .resolve import (
     get_ols_prefix,
     get_pattern_re,
     get_resource,
+    get_scholia_prefix,
     namespace_in_lui,
     normalize_parsed_curie,
     parse_curie,
@@ -267,6 +268,25 @@ def get_ols_iri(prefix: str, identifier: str) -> Optional[str]:
     return f"https://www.ebi.ac.uk/ols/ontologies/{ols_prefix}/terms?iri={obo_iri}"
 
 
+def get_scholia_iri(prefix: str, identifier: str) -> Optional[str]:
+    """Get a Scholia IRI, if possible.
+
+    :param prefix: The prefix in the CURIE
+    :param identifier: The identifier in the CURIE
+    :return: A link to the Scholia page
+
+    >>> get_scholia_iri("pubmed", "1234")
+    'https://scholia.toolforge.org/pubmed/1234'
+
+    >>> get_scholia_iri("pdb", "1234")
+    None
+    """
+    scholia_prefix = get_scholia_prefix(prefix)
+    if scholia_prefix is None:
+        return None
+    return f"https://scholia.toolforge.org/{prefix}/{identifier}"
+
+
 def get_bioregistry_iri(prefix: str, identifier: str) -> Optional[str]:
     """Get the bioregistry link.
 
@@ -314,6 +334,7 @@ PROVIDER_FUNCTIONS: Mapping[str, Callable[[str, str], Optional[str]]] = {
     "ols": get_ols_iri,
     "n2t": get_n2t_iri,
     "bioportal": get_bioportal_iri,
+    "scholia": get_scholia_iri,
 }
 
 LINK_PRIORITY = [
@@ -324,6 +345,7 @@ LINK_PRIORITY = [
     "obofoundry",
     "n2t",
     "bioportal",
+    "scholia",
 ]
 
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -627,6 +627,10 @@ class Resource(BaseModel):
             return None
         return f"{miriam_url_prefix}$1"
 
+    def get_scholia_prefix(self):
+        """Get the Scholia prefix, if available."""
+        return self.get_mapped_prefix("scholia")
+
     def get_ols_prefix(self) -> Optional[str]:
         """Get the OLS prefix if available."""
         return self.get_mapped_prefix("ols")


### PR DESCRIPTION
Closes #177, closes #171, closes #172, closes #173, closes #174, closes #175

- [x] curate mappings to scholia (ea3bd89)
- [x] curate registry information (ea3bd89)
- [x] add functions for getting links and stuff (ad823ae)
- [x] make it work!!!!

This screenshot shows what happens on the DOI page. It now knows how to build scholia pages assuming you mapped the right endpoint in scholia inside the "mappings" field in a given prefix. Interestingly, the Identifiers.org style for adding endpoints like this (e.g., see OLS providers) would be to massively duplicate this, even though there's a single resource that can be handled uniformly. Glad we don't have to do so much duplicate effort!

<img width="1339" alt="Screen Shot 2021-09-28 at 22 01 59" src="https://user-images.githubusercontent.com/5069736/135157549-762aa05d-73e9-469e-9c77-c8397c20265d.png">


