### PR TITLE
Scholia can resolve Wikidata Q/P identifiers too

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -42450,8 +42450,7 @@
       "cellosaurus": "Wikidata",
       "miriam": "wikidata",
       "n2t": "wikidata",
-      "prefixcommons": "WD_Entity",
-      "scholia": "scholia"
+      "prefixcommons": "WD_Entity"
     },
     "miriam": {
       "deprecated": false,

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -42513,7 +42513,16 @@
       "is_identifiers": false,
       "is_obo": false,
       "prefix": "WD_Prop"
-    }
+    },
+    "providers": [
+      {
+        "code": "scholia",
+        "description": "Scholia can generally resolve many Wikidata entries in the biomedical and bibliometric domains",
+        "homepage": "https://scholia.toolforge.org",
+        "name": "Scholia",
+        "url": "https://scholia.toolforge.org/$1"
+      }
+    ]
   },
   "wikigenes": {
     "mappings": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -41200,7 +41200,8 @@
       "cellosaurus": "Wikidata",
       "miriam": "wikidata",
       "n2t": "wikidata",
-      "prefixcommons": "WD_Entity"
+      "prefixcommons": "WD_Entity",
+      "scholia": "scholia"
     },
     "miriam": {
       "deprecated": false,
@@ -41229,6 +41230,11 @@
       "is_identifiers": false,
       "is_obo": false,
       "prefix": "WD_Entity"
+    },
+    "scholia": {
+      "formatter": "https://scholia.toolforge.org/$1",
+      "pattern": "^(Q|P)\\d+$",
+      "prefix": "wikidata"
     },
     "synonyms": [
       "wd",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -42481,11 +42481,15 @@
       "is_obo": false,
       "prefix": "WD_Entity"
     },
-    "scholia": {
-      "formatter": "https://scholia.toolforge.org/$1",
-      "pattern": "^(Q|P)\\d+$",
-      "prefix": "wikidata"
-    },
+    "providers": [
+      {
+        "code": "scholia",
+        "description": "Scholia can generally resolve many Wikidata entries in the biomedical and bibliometric domains",
+        "homepage": "https://scholia.toolforge.org",
+        "name": "Scholia",
+        "url": "https://scholia.toolforge.org/$1"
+      }
+    ],
     "synonyms": [
       "wd",
       "WD_Entity"


### PR DESCRIPTION
@cthoyt, not sure if I did this right. The formatter URL is different, and does not use a prefix in the URL. I tried to learn from the other content, and saw `n2t` under mappings and as separate submap too.