### PR TITLE
Add provider data model and example

### DIFF
--- a/docs/img/providers.svg
+++ b/docs/img/providers.svg
@@ -1,0 +1,1031 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg height="252pt" version="1.1" viewBox="0 0 576 252" width="576pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata>
+  <rdf:RDF xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2021-10-01T15:35:17.291226</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.4.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linecap:butt;stroke-linejoin:round;}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 252 
+L 576 252 
+L 576 0 
+L 0 0 
+z
+" style="fill:#ffffff;"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 48.127408 210.04 
+L 565.2 210.04 
+L 565.2 10.8 
+L 48.127408 10.8 
+z
+" style="fill:#ffffff;"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="text_1">
+      <!-- 0 -->
+      <g style="fill:#262626;" transform="translate(88.436322 224.197812)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 266 2259 
+Q 266 3072 433 3567 
+Q 600 4063 929 4331 
+Q 1259 4600 1759 4600 
+Q 2128 4600 2406 4451 
+Q 2684 4303 2865 4023 
+Q 3047 3744 3150 3342 
+Q 3253 2941 3253 2259 
+Q 3253 1453 3087 958 
+Q 2922 463 2592 192 
+Q 2263 -78 1759 -78 
+Q 1097 -78 719 397 
+Q 266 969 266 2259 
+z
+M 844 2259 
+Q 844 1131 1108 757 
+Q 1372 384 1759 384 
+Q 2147 384 2411 759 
+Q 2675 1134 2675 2259 
+Q 2675 3391 2411 3762 
+Q 2147 4134 1753 4134 
+Q 1366 4134 1134 3806 
+Q 844 3388 844 2259 
+z
+" id="ArialMT-30" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#ArialMT-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="text_2">
+      <!-- 1 -->
+      <g style="fill:#262626;" transform="translate(174.615087 224.197812)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 2384 0 
+L 1822 0 
+L 1822 3584 
+Q 1619 3391 1289 3197 
+Q 959 3003 697 2906 
+L 697 3450 
+Q 1169 3672 1522 3987 
+Q 1875 4303 2022 4600 
+L 2384 4600 
+L 2384 0 
+z
+" id="ArialMT-31" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#ArialMT-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="text_3">
+      <!-- 2 -->
+      <g style="fill:#262626;" transform="translate(260.793853 224.197812)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 3222 541 
+L 3222 0 
+L 194 0 
+Q 188 203 259 391 
+Q 375 700 629 1000 
+Q 884 1300 1366 1694 
+Q 2113 2306 2375 2664 
+Q 2638 3022 2638 3341 
+Q 2638 3675 2398 3904 
+Q 2159 4134 1775 4134 
+Q 1369 4134 1125 3890 
+Q 881 3647 878 3216 
+L 300 3275 
+Q 359 3922 746 4261 
+Q 1134 4600 1788 4600 
+Q 2447 4600 2831 4234 
+Q 3216 3869 3216 3328 
+Q 3216 3053 3103 2787 
+Q 2991 2522 2730 2228 
+Q 2469 1934 1863 1422 
+Q 1356 997 1212 845 
+Q 1069 694 975 541 
+L 3222 541 
+z
+" id="ArialMT-32" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#ArialMT-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="text_4">
+      <!-- 3 -->
+      <g style="fill:#262626;" transform="translate(346.972618 224.197812)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 269 1209 
+L 831 1284 
+Q 928 806 1161 595 
+Q 1394 384 1728 384 
+Q 2125 384 2398 659 
+Q 2672 934 2672 1341 
+Q 2672 1728 2419 1979 
+Q 2166 2231 1775 2231 
+Q 1616 2231 1378 2169 
+L 1441 2663 
+Q 1497 2656 1531 2656 
+Q 1891 2656 2178 2843 
+Q 2466 3031 2466 3422 
+Q 2466 3731 2256 3934 
+Q 2047 4138 1716 4138 
+Q 1388 4138 1169 3931 
+Q 950 3725 888 3313 
+L 325 3413 
+Q 428 3978 793 4289 
+Q 1159 4600 1703 4600 
+Q 2078 4600 2393 4439 
+Q 2709 4278 2876 4000 
+Q 3044 3722 3044 3409 
+Q 3044 3113 2884 2869 
+Q 2725 2625 2413 2481 
+Q 2819 2388 3044 2092 
+Q 3269 1797 3269 1353 
+Q 3269 753 2831 336 
+Q 2394 -81 1725 -81 
+Q 1122 -81 723 278 
+Q 325 638 269 1209 
+z
+" id="ArialMT-33" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#ArialMT-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="text_5">
+      <!-- 4 -->
+      <g style="fill:#262626;" transform="translate(433.151383 224.197812)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 2069 0 
+L 2069 1097 
+L 81 1097 
+L 81 1613 
+L 2172 4581 
+L 2631 4581 
+L 2631 1613 
+L 3250 1613 
+L 3250 1097 
+L 2631 1097 
+L 2631 0 
+L 2069 0 
+z
+M 2069 1613 
+L 2069 3678 
+L 634 1613 
+L 2069 1613 
+z
+" id="ArialMT-34" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#ArialMT-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="text_6">
+      <!-- 5 -->
+      <g style="fill:#262626;" transform="translate(519.330149 224.197812)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 266 1200 
+L 856 1250 
+Q 922 819 1161 601 
+Q 1400 384 1738 384 
+Q 2144 384 2425 690 
+Q 2706 997 2706 1503 
+Q 2706 1984 2436 2262 
+Q 2166 2541 1728 2541 
+Q 1456 2541 1237 2417 
+Q 1019 2294 894 2097 
+L 366 2166 
+L 809 4519 
+L 3088 4519 
+L 3088 3981 
+L 1259 3981 
+L 1013 2750 
+Q 1425 3038 1878 3038 
+Q 2478 3038 2890 2622 
+Q 3303 2206 3303 1553 
+Q 3303 931 2941 478 
+Q 2500 -78 1738 -78 
+Q 1113 -78 717 272 
+Q 322 622 266 1200 
+z
+" id="ArialMT-35" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#ArialMT-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Number Providers -->
+     <g style="fill:#262626;" transform="translate(266.375423 237.343125)scale(0.1 -0.1)">
+      <defs>
+       <path d="M 488 0 
+L 488 4581 
+L 1109 4581 
+L 3516 984 
+L 3516 4581 
+L 4097 4581 
+L 4097 0 
+L 3475 0 
+L 1069 3600 
+L 1069 0 
+L 488 0 
+z
+" id="ArialMT-4e" transform="scale(0.015625)"/>
+       <path d="M 2597 0 
+L 2597 488 
+Q 2209 -75 1544 -75 
+Q 1250 -75 995 37 
+Q 741 150 617 320 
+Q 494 491 444 738 
+Q 409 903 409 1263 
+L 409 3319 
+L 972 3319 
+L 972 1478 
+Q 972 1038 1006 884 
+Q 1059 663 1231 536 
+Q 1403 409 1656 409 
+Q 1909 409 2131 539 
+Q 2353 669 2445 892 
+Q 2538 1116 2538 1541 
+L 2538 3319 
+L 3100 3319 
+L 3100 0 
+L 2597 0 
+z
+" id="ArialMT-75" transform="scale(0.015625)"/>
+       <path d="M 422 0 
+L 422 3319 
+L 925 3319 
+L 925 2853 
+Q 1081 3097 1340 3245 
+Q 1600 3394 1931 3394 
+Q 2300 3394 2536 3241 
+Q 2772 3088 2869 2813 
+Q 3263 3394 3894 3394 
+Q 4388 3394 4653 3120 
+Q 4919 2847 4919 2278 
+L 4919 0 
+L 4359 0 
+L 4359 2091 
+Q 4359 2428 4304 2576 
+Q 4250 2725 4106 2815 
+Q 3963 2906 3769 2906 
+Q 3419 2906 3187 2673 
+Q 2956 2441 2956 1928 
+L 2956 0 
+L 2394 0 
+L 2394 2156 
+Q 2394 2531 2256 2718 
+Q 2119 2906 1806 2906 
+Q 1569 2906 1367 2781 
+Q 1166 2656 1075 2415 
+Q 984 2175 984 1722 
+L 984 0 
+L 422 0 
+z
+" id="ArialMT-6d" transform="scale(0.015625)"/>
+       <path d="M 941 0 
+L 419 0 
+L 419 4581 
+L 981 4581 
+L 981 2947 
+Q 1338 3394 1891 3394 
+Q 2197 3394 2470 3270 
+Q 2744 3147 2920 2923 
+Q 3097 2700 3197 2384 
+Q 3297 2069 3297 1709 
+Q 3297 856 2875 390 
+Q 2453 -75 1863 -75 
+Q 1275 -75 941 416 
+L 941 0 
+z
+M 934 1684 
+Q 934 1088 1097 822 
+Q 1363 388 1816 388 
+Q 2184 388 2453 708 
+Q 2722 1028 2722 1663 
+Q 2722 2313 2464 2622 
+Q 2206 2931 1841 2931 
+Q 1472 2931 1203 2611 
+Q 934 2291 934 1684 
+z
+" id="ArialMT-62" transform="scale(0.015625)"/>
+       <path d="M 2694 1069 
+L 3275 997 
+Q 3138 488 2766 206 
+Q 2394 -75 1816 -75 
+Q 1088 -75 661 373 
+Q 234 822 234 1631 
+Q 234 2469 665 2931 
+Q 1097 3394 1784 3394 
+Q 2450 3394 2872 2941 
+Q 3294 2488 3294 1666 
+Q 3294 1616 3291 1516 
+L 816 1516 
+Q 847 969 1125 678 
+Q 1403 388 1819 388 
+Q 2128 388 2347 550 
+Q 2566 713 2694 1069 
+z
+M 847 1978 
+L 2700 1978 
+Q 2663 2397 2488 2606 
+Q 2219 2931 1791 2931 
+Q 1403 2931 1139 2672 
+Q 875 2413 847 1978 
+z
+" id="ArialMT-65" transform="scale(0.015625)"/>
+       <path d="M 416 0 
+L 416 3319 
+L 922 3319 
+L 922 2816 
+Q 1116 3169 1280 3281 
+Q 1444 3394 1641 3394 
+Q 1925 3394 2219 3213 
+L 2025 2691 
+Q 1819 2813 1613 2813 
+Q 1428 2813 1281 2702 
+Q 1134 2591 1072 2394 
+Q 978 2094 978 1738 
+L 978 0 
+L 416 0 
+z
+" id="ArialMT-72" transform="scale(0.015625)"/>
+       <path id="ArialMT-20" transform="scale(0.015625)"/>
+       <path d="M 494 0 
+L 494 4581 
+L 2222 4581 
+Q 2678 4581 2919 4538 
+Q 3256 4481 3484 4323 
+Q 3713 4166 3852 3881 
+Q 3991 3597 3991 3256 
+Q 3991 2672 3619 2267 
+Q 3247 1863 2275 1863 
+L 1100 1863 
+L 1100 0 
+L 494 0 
+z
+M 1100 2403 
+L 2284 2403 
+Q 2872 2403 3119 2622 
+Q 3366 2841 3366 3238 
+Q 3366 3525 3220 3729 
+Q 3075 3934 2838 4000 
+Q 2684 4041 2272 4041 
+L 1100 4041 
+L 1100 2403 
+z
+" id="ArialMT-50" transform="scale(0.015625)"/>
+       <path d="M 213 1659 
+Q 213 2581 725 3025 
+Q 1153 3394 1769 3394 
+Q 2453 3394 2887 2945 
+Q 3322 2497 3322 1706 
+Q 3322 1066 3130 698 
+Q 2938 331 2570 128 
+Q 2203 -75 1769 -75 
+Q 1072 -75 642 372 
+Q 213 819 213 1659 
+z
+M 791 1659 
+Q 791 1022 1069 705 
+Q 1347 388 1769 388 
+Q 2188 388 2466 706 
+Q 2744 1025 2744 1678 
+Q 2744 2294 2464 2611 
+Q 2184 2928 1769 2928 
+Q 1347 2928 1069 2612 
+Q 791 2297 791 1659 
+z
+" id="ArialMT-6f" transform="scale(0.015625)"/>
+       <path d="M 1344 0 
+L 81 3319 
+L 675 3319 
+L 1388 1331 
+Q 1503 1009 1600 663 
+Q 1675 925 1809 1294 
+L 2547 3319 
+L 3125 3319 
+L 1869 0 
+L 1344 0 
+z
+" id="ArialMT-76" transform="scale(0.015625)"/>
+       <path d="M 425 3934 
+L 425 4581 
+L 988 4581 
+L 988 3934 
+L 425 3934 
+z
+M 425 0 
+L 425 3319 
+L 988 3319 
+L 988 0 
+L 425 0 
+z
+" id="ArialMT-69" transform="scale(0.015625)"/>
+       <path d="M 2575 0 
+L 2575 419 
+Q 2259 -75 1647 -75 
+Q 1250 -75 917 144 
+Q 584 363 401 755 
+Q 219 1147 219 1656 
+Q 219 2153 384 2558 
+Q 550 2963 881 3178 
+Q 1213 3394 1622 3394 
+Q 1922 3394 2156 3267 
+Q 2391 3141 2538 2938 
+L 2538 4581 
+L 3097 4581 
+L 3097 0 
+L 2575 0 
+z
+M 797 1656 
+Q 797 1019 1065 703 
+Q 1334 388 1700 388 
+Q 2069 388 2326 689 
+Q 2584 991 2584 1609 
+Q 2584 2291 2321 2609 
+Q 2059 2928 1675 2928 
+Q 1300 2928 1048 2622 
+Q 797 2316 797 1656 
+z
+" id="ArialMT-64" transform="scale(0.015625)"/>
+       <path d="M 197 991 
+L 753 1078 
+Q 800 744 1014 566 
+Q 1228 388 1613 388 
+Q 2000 388 2187 545 
+Q 2375 703 2375 916 
+Q 2375 1106 2209 1216 
+Q 2094 1291 1634 1406 
+Q 1016 1563 777 1677 
+Q 538 1791 414 1992 
+Q 291 2194 291 2438 
+Q 291 2659 392 2848 
+Q 494 3038 669 3163 
+Q 800 3259 1026 3326 
+Q 1253 3394 1513 3394 
+Q 1903 3394 2198 3281 
+Q 2494 3169 2634 2976 
+Q 2775 2784 2828 2463 
+L 2278 2388 
+Q 2241 2644 2061 2787 
+Q 1881 2931 1553 2931 
+Q 1166 2931 1000 2803 
+Q 834 2675 834 2503 
+Q 834 2394 903 2306 
+Q 972 2216 1119 2156 
+Q 1203 2125 1616 2013 
+Q 2213 1853 2448 1751 
+Q 2684 1650 2818 1456 
+Q 2953 1263 2953 975 
+Q 2953 694 2789 445 
+Q 2625 197 2315 61 
+Q 2006 -75 1616 -75 
+Q 969 -75 630 194 
+Q 291 463 197 991 
+z
+" id="ArialMT-73" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#ArialMT-4e"/>
+      <use x="72.216797" xlink:href="#ArialMT-75"/>
+      <use x="127.832031" xlink:href="#ArialMT-6d"/>
+      <use x="211.132812" xlink:href="#ArialMT-62"/>
+      <use x="266.748047" xlink:href="#ArialMT-65"/>
+      <use x="322.363281" xlink:href="#ArialMT-72"/>
+      <use x="355.664062" xlink:href="#ArialMT-20"/>
+      <use x="383.447266" xlink:href="#ArialMT-50"/>
+      <use x="450.146484" xlink:href="#ArialMT-72"/>
+      <use x="483.447266" xlink:href="#ArialMT-6f"/>
+      <use x="539.0625" xlink:href="#ArialMT-76"/>
+      <use x="589.0625" xlink:href="#ArialMT-69"/>
+      <use x="611.279297" xlink:href="#ArialMT-64"/>
+      <use x="666.894531" xlink:href="#ArialMT-65"/>
+      <use x="722.509766" xlink:href="#ArialMT-72"/>
+      <use x="755.810547" xlink:href="#ArialMT-73"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1">
+      <path clip-path="url(#pa2b7e8e69d)" d="M 48.127408 162.424209 
+L 565.2 162.424209 
+" style="fill:none;stroke:#cccccc;stroke-linecap:round;stroke-width:0.8;"/>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g style="fill:#262626;" transform="translate(25.427408 167.580459)scale(0.1 -0.1)">
+       <use transform="translate(0 0.99375)" xlink:href="#ArialMT-31"/>
+       <use transform="translate(55.615234 0.99375)" xlink:href="#ArialMT-30"/>
+       <use transform="translate(112.972813 70.6875)scale(0.7)" xlink:href="#ArialMT-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2">
+      <path clip-path="url(#pa2b7e8e69d)" d="M 48.127408 77.851441 
+L 565.2 77.851441 
+" style="fill:none;stroke:#cccccc;stroke-linecap:round;stroke-width:0.8;"/>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g style="fill:#262626;" transform="translate(25.427408 83.007691)scale(0.1 -0.1)">
+       <use transform="translate(0 0.99375)" xlink:href="#ArialMT-31"/>
+       <use transform="translate(55.615234 0.99375)" xlink:href="#ArialMT-30"/>
+       <use transform="translate(112.972813 70.6875)scale(0.7)" xlink:href="#ArialMT-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3"/>
+    <g id="ytick_4"/>
+    <g id="ytick_5"/>
+    <g id="ytick_6"/>
+    <g id="ytick_7"/>
+    <g id="ytick_8"/>
+    <g id="ytick_9"/>
+    <g id="ytick_10"/>
+    <g id="ytick_11"/>
+    <g id="ytick_12"/>
+    <g id="ytick_13"/>
+    <g id="ytick_14"/>
+    <g id="ytick_15"/>
+    <g id="ytick_16"/>
+    <g id="ytick_17"/>
+    <g id="ytick_18"/>
+    <g id="ytick_19"/>
+    <g id="ytick_20"/>
+    <g id="ytick_21"/>
+    <g id="ytick_22"/>
+    <g id="text_10">
+     <!-- Count -->
+     <g style="fill:#262626;" transform="translate(19.439908 123.761406)rotate(-90)scale(0.1 -0.1)">
+      <defs>
+       <path d="M 3763 1606 
+L 4369 1453 
+Q 4178 706 3683 314 
+Q 3188 -78 2472 -78 
+Q 1731 -78 1267 223 
+Q 803 525 561 1097 
+Q 319 1669 319 2325 
+Q 319 3041 592 3573 
+Q 866 4106 1370 4382 
+Q 1875 4659 2481 4659 
+Q 3169 4659 3637 4309 
+Q 4106 3959 4291 3325 
+L 3694 3184 
+Q 3534 3684 3231 3912 
+Q 2928 4141 2469 4141 
+Q 1941 4141 1586 3887 
+Q 1231 3634 1087 3207 
+Q 944 2781 944 2328 
+Q 944 1744 1114 1308 
+Q 1284 872 1643 656 
+Q 2003 441 2422 441 
+Q 2931 441 3284 734 
+Q 3638 1028 3763 1606 
+z
+" id="ArialMT-43" transform="scale(0.015625)"/>
+       <path d="M 422 0 
+L 422 3319 
+L 928 3319 
+L 928 2847 
+Q 1294 3394 1984 3394 
+Q 2284 3394 2536 3286 
+Q 2788 3178 2913 3003 
+Q 3038 2828 3088 2588 
+Q 3119 2431 3119 2041 
+L 3119 0 
+L 2556 0 
+L 2556 2019 
+Q 2556 2363 2490 2533 
+Q 2425 2703 2258 2804 
+Q 2091 2906 1866 2906 
+Q 1506 2906 1245 2678 
+Q 984 2450 984 1813 
+L 984 0 
+L 422 0 
+z
+" id="ArialMT-6e" transform="scale(0.015625)"/>
+       <path d="M 1650 503 
+L 1731 6 
+Q 1494 -44 1306 -44 
+Q 1000 -44 831 53 
+Q 663 150 594 308 
+Q 525 466 525 972 
+L 525 2881 
+L 113 2881 
+L 113 3319 
+L 525 3319 
+L 525 4141 
+L 1084 4478 
+L 1084 3319 
+L 1650 3319 
+L 1650 2881 
+L 1084 2881 
+L 1084 941 
+Q 1084 700 1114 631 
+Q 1144 563 1211 522 
+Q 1278 481 1403 481 
+Q 1497 481 1650 503 
+z
+" id="ArialMT-74" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#ArialMT-43"/>
+      <use x="72.216797" xlink:href="#ArialMT-6f"/>
+      <use x="127.832031" xlink:href="#ArialMT-75"/>
+      <use x="183.447266" xlink:href="#ArialMT-6e"/>
+      <use x="239.0625" xlink:href="#ArialMT-74"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path clip-path="url(#pa2b7e8e69d)" d="M 56.745285 84819.765094 
+L 125.688297 84819.765094 
+L 125.688297 83.605255 
+L 56.745285 83.605255 
+z
+" style="fill:#2020df;opacity:0.4;stroke:#ffffff;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_4">
+    <path clip-path="url(#pa2b7e8e69d)" d="M 142.92405 84819.765094 
+L 211.867062 84819.765094 
+L 211.867062 19.856364 
+L 142.92405 19.856364 
+z
+" style="fill:#2020df;opacity:0.4;stroke:#ffffff;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_5">
+    <path clip-path="url(#pa2b7e8e69d)" d="M 229.102815 84819.765094 
+L 298.045828 84819.765094 
+L 298.045828 128.04198 
+L 229.102815 128.04198 
+z
+" style="fill:#2020df;opacity:0.4;stroke:#ffffff;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_6">
+    <path clip-path="url(#pa2b7e8e69d)" d="M 315.281581 84819.765094 
+L 384.224593 84819.765094 
+L 384.224593 168.393446 
+L 315.281581 168.393446 
+z
+" style="fill:#2020df;opacity:0.4;stroke:#ffffff;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_7">
+    <path clip-path="url(#pa2b7e8e69d)" d="M 401.460346 84819.765094 
+L 470.403358 84819.765094 
+L 470.403358 184.382455 
+L 401.460346 184.382455 
+z
+" style="fill:#2020df;opacity:0.4;stroke:#ffffff;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_8">
+    <path clip-path="url(#pa2b7e8e69d)" d="M 487.639111 84819.765094 
+L 556.582123 84819.765094 
+L 556.582123 200.983636 
+L 487.639111 200.983636 
+z
+" style="fill:#2020df;opacity:0.4;stroke:#ffffff;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 48.127408 210.04 
+L 48.127408 10.8 
+" style="fill:none;stroke:#cccccc;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 565.2 210.04 
+L 565.2 10.8 
+" style="fill:none;stroke:#cccccc;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 48.127408 210.04 
+L 565.2 210.04 
+" style="fill:none;stroke:#cccccc;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 48.127408 10.8 
+L 565.2 10.8 
+" style="fill:none;stroke:#cccccc;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;"/>
+   </g>
+  </g>
+  <g id="text_11">
+   <!-- https://github.com/biopragmatics/bioregistry (2021-10-01) -->
+   <g style="fill:#808080;opacity:0.5;" transform="translate(574.31625 227.375)rotate(-90)scale(0.08 -0.08)">
+    <defs>
+     <path d="M 422 0 
+L 422 4581 
+L 984 4581 
+L 984 2938 
+Q 1378 3394 1978 3394 
+Q 2347 3394 2619 3248 
+Q 2891 3103 3008 2847 
+Q 3125 2591 3125 2103 
+L 3125 0 
+L 2563 0 
+L 2563 2103 
+Q 2563 2525 2380 2717 
+Q 2197 2909 1863 2909 
+Q 1613 2909 1392 2779 
+Q 1172 2650 1078 2428 
+Q 984 2206 984 1816 
+L 984 0 
+L 422 0 
+z
+" id="ArialMT-68" transform="scale(0.015625)"/>
+     <path d="M 422 -1272 
+L 422 3319 
+L 934 3319 
+L 934 2888 
+Q 1116 3141 1344 3267 
+Q 1572 3394 1897 3394 
+Q 2322 3394 2647 3175 
+Q 2972 2956 3137 2557 
+Q 3303 2159 3303 1684 
+Q 3303 1175 3120 767 
+Q 2938 359 2589 142 
+Q 2241 -75 1856 -75 
+Q 1575 -75 1351 44 
+Q 1128 163 984 344 
+L 984 -1272 
+L 422 -1272 
+z
+M 931 1641 
+Q 931 1000 1190 694 
+Q 1450 388 1819 388 
+Q 2194 388 2461 705 
+Q 2728 1022 2728 1688 
+Q 2728 2322 2467 2637 
+Q 2206 2953 1844 2953 
+Q 1484 2953 1207 2617 
+Q 931 2281 931 1641 
+z
+" id="ArialMT-70" transform="scale(0.015625)"/>
+     <path d="M 578 2678 
+L 578 3319 
+L 1219 3319 
+L 1219 2678 
+L 578 2678 
+z
+M 578 0 
+L 578 641 
+L 1219 641 
+L 1219 0 
+L 578 0 
+z
+" id="ArialMT-3a" transform="scale(0.015625)"/>
+     <path d="M 0 -78 
+L 1328 4659 
+L 1778 4659 
+L 453 -78 
+L 0 -78 
+z
+" id="ArialMT-2f" transform="scale(0.015625)"/>
+     <path d="M 319 -275 
+L 866 -356 
+Q 900 -609 1056 -725 
+Q 1266 -881 1628 -881 
+Q 2019 -881 2231 -725 
+Q 2444 -569 2519 -288 
+Q 2563 -116 2559 434 
+Q 2191 0 1641 0 
+Q 956 0 581 494 
+Q 206 988 206 1678 
+Q 206 2153 378 2554 
+Q 550 2956 876 3175 
+Q 1203 3394 1644 3394 
+Q 2231 3394 2613 2919 
+L 2613 3319 
+L 3131 3319 
+L 3131 450 
+Q 3131 -325 2973 -648 
+Q 2816 -972 2473 -1159 
+Q 2131 -1347 1631 -1347 
+Q 1038 -1347 672 -1080 
+Q 306 -813 319 -275 
+z
+M 784 1719 
+Q 784 1066 1043 766 
+Q 1303 466 1694 466 
+Q 2081 466 2343 764 
+Q 2606 1063 2606 1700 
+Q 2606 2309 2336 2618 
+Q 2066 2928 1684 2928 
+Q 1309 2928 1046 2623 
+Q 784 2319 784 1719 
+z
+" id="ArialMT-67" transform="scale(0.015625)"/>
+     <path d="M 581 0 
+L 581 641 
+L 1222 641 
+L 1222 0 
+L 581 0 
+z
+" id="ArialMT-2e" transform="scale(0.015625)"/>
+     <path d="M 2588 1216 
+L 3141 1144 
+Q 3050 572 2676 248 
+Q 2303 -75 1759 -75 
+Q 1078 -75 664 370 
+Q 250 816 250 1647 
+Q 250 2184 428 2587 
+Q 606 2991 970 3192 
+Q 1334 3394 1763 3394 
+Q 2303 3394 2647 3120 
+Q 2991 2847 3088 2344 
+L 2541 2259 
+Q 2463 2594 2264 2762 
+Q 2066 2931 1784 2931 
+Q 1359 2931 1093 2626 
+Q 828 2322 828 1663 
+Q 828 994 1084 691 
+Q 1341 388 1753 388 
+Q 2084 388 2306 591 
+Q 2528 794 2588 1216 
+z
+" id="ArialMT-63" transform="scale(0.015625)"/>
+     <path d="M 2588 409 
+Q 2275 144 1986 34 
+Q 1697 -75 1366 -75 
+Q 819 -75 525 192 
+Q 231 459 231 875 
+Q 231 1119 342 1320 
+Q 453 1522 633 1644 
+Q 813 1766 1038 1828 
+Q 1203 1872 1538 1913 
+Q 2219 1994 2541 2106 
+Q 2544 2222 2544 2253 
+Q 2544 2597 2384 2738 
+Q 2169 2928 1744 2928 
+Q 1347 2928 1158 2789 
+Q 969 2650 878 2297 
+L 328 2372 
+Q 403 2725 575 2942 
+Q 747 3159 1072 3276 
+Q 1397 3394 1825 3394 
+Q 2250 3394 2515 3294 
+Q 2781 3194 2906 3042 
+Q 3031 2891 3081 2659 
+Q 3109 2516 3109 2141 
+L 3109 1391 
+Q 3109 606 3145 398 
+Q 3181 191 3288 0 
+L 2700 0 
+Q 2613 175 2588 409 
+z
+M 2541 1666 
+Q 2234 1541 1622 1453 
+Q 1275 1403 1131 1340 
+Q 988 1278 909 1158 
+Q 831 1038 831 891 
+Q 831 666 1001 516 
+Q 1172 366 1500 366 
+Q 1825 366 2078 508 
+Q 2331 650 2450 897 
+Q 2541 1088 2541 1459 
+L 2541 1666 
+z
+" id="ArialMT-61" transform="scale(0.015625)"/>
+     <path d="M 397 -1278 
+L 334 -750 
+Q 519 -800 656 -800 
+Q 844 -800 956 -737 
+Q 1069 -675 1141 -563 
+Q 1194 -478 1313 -144 
+Q 1328 -97 1363 -6 
+L 103 3319 
+L 709 3319 
+L 1400 1397 
+Q 1534 1031 1641 628 
+Q 1738 1016 1872 1384 
+L 2581 3319 
+L 3144 3319 
+L 1881 -56 
+Q 1678 -603 1566 -809 
+Q 1416 -1088 1222 -1217 
+Q 1028 -1347 759 -1347 
+Q 597 -1347 397 -1278 
+z
+" id="ArialMT-79" transform="scale(0.015625)"/>
+     <path d="M 1497 -1347 
+Q 1031 -759 709 28 
+Q 388 816 388 1659 
+Q 388 2403 628 3084 
+Q 909 3875 1497 4659 
+L 1900 4659 
+Q 1522 4009 1400 3731 
+Q 1209 3300 1100 2831 
+Q 966 2247 966 1656 
+Q 966 153 1900 -1347 
+L 1497 -1347 
+z
+" id="ArialMT-28" transform="scale(0.015625)"/>
+     <path d="M 203 1375 
+L 203 1941 
+L 1931 1941 
+L 1931 1375 
+L 203 1375 
+z
+" id="ArialMT-2d" transform="scale(0.015625)"/>
+     <path d="M 791 -1347 
+L 388 -1347 
+Q 1322 153 1322 1656 
+Q 1322 2244 1188 2822 
+Q 1081 3291 891 3722 
+Q 769 4003 388 4659 
+L 791 4659 
+Q 1378 3875 1659 3084 
+Q 1900 2403 1900 1659 
+Q 1900 816 1576 28 
+Q 1253 -759 791 -1347 
+z
+" id="ArialMT-29" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#ArialMT-68"/>
+    <use x="55.615234" xlink:href="#ArialMT-74"/>
+    <use x="83.398438" xlink:href="#ArialMT-74"/>
+    <use x="111.181641" xlink:href="#ArialMT-70"/>
+    <use x="166.796875" xlink:href="#ArialMT-73"/>
+    <use x="216.796875" xlink:href="#ArialMT-3a"/>
+    <use x="244.580078" xlink:href="#ArialMT-2f"/>
+    <use x="272.363281" xlink:href="#ArialMT-2f"/>
+    <use x="300.146484" xlink:href="#ArialMT-67"/>
+    <use x="355.761719" xlink:href="#ArialMT-69"/>
+    <use x="377.978516" xlink:href="#ArialMT-74"/>
+    <use x="405.761719" xlink:href="#ArialMT-68"/>
+    <use x="461.376953" xlink:href="#ArialMT-75"/>
+    <use x="516.992188" xlink:href="#ArialMT-62"/>
+    <use x="572.607422" xlink:href="#ArialMT-2e"/>
+    <use x="600.390625" xlink:href="#ArialMT-63"/>
+    <use x="650.390625" xlink:href="#ArialMT-6f"/>
+    <use x="706.005859" xlink:href="#ArialMT-6d"/>
+    <use x="789.306641" xlink:href="#ArialMT-2f"/>
+    <use x="817.089844" xlink:href="#ArialMT-62"/>
+    <use x="872.705078" xlink:href="#ArialMT-69"/>
+    <use x="894.921875" xlink:href="#ArialMT-6f"/>
+    <use x="950.537109" xlink:href="#ArialMT-70"/>
+    <use x="1006.152344" xlink:href="#ArialMT-72"/>
+    <use x="1039.453125" xlink:href="#ArialMT-61"/>
+    <use x="1095.068359" xlink:href="#ArialMT-67"/>
+    <use x="1150.683594" xlink:href="#ArialMT-6d"/>
+    <use x="1233.984375" xlink:href="#ArialMT-61"/>
+    <use x="1289.599609" xlink:href="#ArialMT-74"/>
+    <use x="1317.382812" xlink:href="#ArialMT-69"/>
+    <use x="1339.599609" xlink:href="#ArialMT-63"/>
+    <use x="1389.599609" xlink:href="#ArialMT-73"/>
+    <use x="1439.599609" xlink:href="#ArialMT-2f"/>
+    <use x="1467.382812" xlink:href="#ArialMT-62"/>
+    <use x="1522.998047" xlink:href="#ArialMT-69"/>
+    <use x="1545.214844" xlink:href="#ArialMT-6f"/>
+    <use x="1600.830078" xlink:href="#ArialMT-72"/>
+    <use x="1634.130859" xlink:href="#ArialMT-65"/>
+    <use x="1689.746094" xlink:href="#ArialMT-67"/>
+    <use x="1745.361328" xlink:href="#ArialMT-69"/>
+    <use x="1767.578125" xlink:href="#ArialMT-73"/>
+    <use x="1817.578125" xlink:href="#ArialMT-74"/>
+    <use x="1845.361328" xlink:href="#ArialMT-72"/>
+    <use x="1878.662109" xlink:href="#ArialMT-79"/>
+    <use x="1928.662109" xlink:href="#ArialMT-20"/>
+    <use x="1956.445312" xlink:href="#ArialMT-28"/>
+    <use x="1989.746094" xlink:href="#ArialMT-32"/>
+    <use x="2045.361328" xlink:href="#ArialMT-30"/>
+    <use x="2100.976562" xlink:href="#ArialMT-32"/>
+    <use x="2156.591797" xlink:href="#ArialMT-31"/>
+    <use x="2212.207031" xlink:href="#ArialMT-2d"/>
+    <use x="2245.507812" xlink:href="#ArialMT-31"/>
+    <use x="2301.123047" xlink:href="#ArialMT-30"/>
+    <use x="2356.738281" xlink:href="#ArialMT-2d"/>
+    <use x="2390.039062" xlink:href="#ArialMT-30"/>
+    <use x="2445.654297" xlink:href="#ArialMT-31"/>
+    <use x="2501.269531" xlink:href="#ArialMT-29"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa2b7e8e69d">
+   <rect height="199.24" width="517.072592" x="48.127408" y="10.8"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/bioregistry/__init__.py
+++ b/src/bioregistry/__init__.py
@@ -73,7 +73,7 @@ from .resolve_identifier import (  # noqa:F401
     get_providers_list,
     validate,
 )
-from .schema.struct import Author, Collection, Registry, Resource  # noqa:F401
+from .schema.struct import Author, Collection, Provider, Registry, Resource  # noqa:F401
 from .uri_format import get_format, get_format_url, get_format_urls, get_prefix_map  # noqa:F401
 from .utils import (  # noqa:F401
     read_collections,

--- a/src/bioregistry/app/templates/meta/summary.html
+++ b/src/bioregistry/app/templates/meta/summary.html
@@ -162,6 +162,17 @@
         <img src="https://raw.githubusercontent.com/biopragmatics/bioregistry/main/docs/img/licenses.svg"
              alt="License Types" class="img-fluid"/>
     </p>
+    <h2>Providers</h2>
+    <p>
+        One of the original goals of using IRIs as identifiers for biomedical entities was that they could
+        be resolved in the browser. This isn't strictly enforced, and even worse it's the case that many
+        resources don't have any IRIs associated with them at all. The following chart shows roughly
+        the distribution of how many providers are available for each resource. Luckily, most have one or
+        more, but some don't have any.
+
+        <img src="https://raw.githubusercontent.com/biopragmatics/bioregistry/main/docs/img/providers.svg"
+             alt="Attributes Coverage" class="img-fluid"/>
+    </p>
     <h2>Other Attributes</h2>
     <p>
         <img src="https://raw.githubusercontent.com/biopragmatics/bioregistry/main/docs/img/has_attribute.svg"

--- a/src/bioregistry/app/templates/meta/summary.html
+++ b/src/bioregistry/app/templates/meta/summary.html
@@ -171,7 +171,7 @@
         more, but some don't have any.
 
         <img src="https://raw.githubusercontent.com/biopragmatics/bioregistry/main/docs/img/providers.svg"
-             alt="Attributes Coverage" class="img-fluid"/>
+             alt="Provider Coverage" class="img-fluid"/>
     </p>
     <h2>Other Attributes</h2>
     <p>

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -228,4 +228,35 @@
             {{ utils.render_provider_table(prefix=prefix, identifier=example, providers=providers) }}
         </div>
     {% endif %}
+    {% set extra_providers = resource.get_extra_providers() %}
+    {% if extra_providers %}
+        <div class="card" style="margin-top: 20px">
+            <a id="mappings"></a>
+            <h5 class="card-header">Extra Providers</h5>
+            <div class="card-body">
+                <p>
+                    Additional providers curated in the Bioregistry are listed here.
+                </p>
+            </div>
+            <table class="table table-hover table-striped">
+                <thead class="table-">
+                <tr>
+                    <th scope="col">Code</th>
+                    <th scope="col">Name</th>
+                    <th scope="col">URL</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for provider in extra_providers %}
+                    <tr>
+                        <td>{{ provider.code }}</td>
+                        <td>{{ provider.name }}</td>
+                        {% set url = provider.resolve(example) %}
+                        <td><a href="{{ url }}">{{ url }}</a></td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/bioregistry/compare.py
+++ b/src/bioregistry/compare.py
@@ -32,6 +32,7 @@ from bioregistry import (
 from bioregistry.constants import DOCS_IMG
 from bioregistry.external import GETTERS
 from bioregistry.resolve import _remap_license, get_external
+from bioregistry.schema import Resource
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +349,40 @@ def compare(png: bool):  # noqa:C901
         )
 
     _save(fig, name="xrefs", png=png)
+
+    ##################################################
+    # Histogram of how many providers each entry has #
+    ##################################################
+    provider_counts = [
+        _count_providers(resource)
+        for resource in read_registry().values()
+    ]
+    fig, ax = plt.subplots(figsize=SINGLE_FIG)
+    sns.barplot(data=sorted(Counter(provider_counts).items()), ci=None, color="blue", alpha=0.4, ax=ax)
+    ax.set_xlabel("Number Providers")
+    ax.set_ylabel("Count")
+    ax.set_yscale("log")
+    if watermark:
+        fig.text(
+            1.0,
+            0.5,
+            WATERMARK_TEXT,
+            fontsize=8,
+            color="gray",
+            alpha=0.5,
+            ha="right",
+            va="center",
+            rotation=90,
+        )
+    _save(fig, name="providers", png=png)
+
+
+def _count_providers(resource: Resource) -> int:
+    rv = 0
+    if resource.get_format_url():
+        rv += 1
+    rv += len(resource.get_extra_providers())
+    return rv
 
 
 def _get_license_and_conflicts():

--- a/src/bioregistry/compare.py
+++ b/src/bioregistry/compare.py
@@ -353,12 +353,11 @@ def compare(png: bool):  # noqa:C901
     ##################################################
     # Histogram of how many providers each entry has #
     ##################################################
-    provider_counts = [
-        _count_providers(resource)
-        for resource in read_registry().values()
-    ]
+    provider_counts = [_count_providers(resource) for resource in read_registry().values()]
     fig, ax = plt.subplots(figsize=SINGLE_FIG)
-    sns.barplot(data=sorted(Counter(provider_counts).items()), ci=None, color="blue", alpha=0.4, ax=ax)
+    sns.barplot(
+        data=sorted(Counter(provider_counts).items()), ci=None, color="blue", alpha=0.4, ax=ax
+    )
     ax.set_xlabel("Number Providers")
     ax.set_ylabel("Count")
     ax.set_yscale("log")

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -5272,6 +5272,15 @@
       "is_obo": true,
       "prefix": "CHEBI"
     },
+    "providers": [
+      {
+        "code": "chebi-img",
+        "description": "Image server from chebi",
+        "homepage": "https://www.ebi.ac.uk/chebi/",
+        "name": "ChEBI",
+        "url": "https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=$1"
+      }
+    ],
     "synonyms": [
       "ChEBI",
       "CHEBI",

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -81,6 +81,45 @@
         "authors"
       ]
     },
+    "Provider": {
+      "title": "Provider",
+      "description": "A provider.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "title": "Code",
+          "description": "A locally unique code within the prefix for the provider",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "Name of the provider",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "Description of the provider",
+          "type": "string"
+        },
+        "homepage": {
+          "title": "Homepage",
+          "description": "Homepage of the provider",
+          "type": "string"
+        },
+        "url": {
+          "title": "Url",
+          "description": "The URL format string, which must have at least one ``$1`` in it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "name",
+        "description",
+        "homepage",
+        "url"
+      ]
+    },
     "Resource": {
       "title": "Resource",
       "description": "Metadata about an ontology, database, or other resource.",
@@ -105,6 +144,14 @@
           "title": "Format URL",
           "description": "The URL format string, which must have at least one ``$1`` in it",
           "type": "string"
+        },
+        "providers": {
+          "title": "Providers",
+          "description": "Additional, non-default providers for the resource",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provider"
+          }
         },
         "homepage": {
           "title": "Format URL",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -27,6 +27,7 @@ from bioregistry.schema.utils import EMAIL_RE, EMAIL_RE_STR
 
 __all__ = [
     "Author",
+    "Provider",
     "Resource",
     "Collection",
     "Registry",
@@ -69,6 +70,18 @@ class Author(BaseModel):
         return node
 
 
+class Provider(BaseModel):
+    """A provider."""
+
+    code: str = Field(..., description="A locally unique code within the prefix for the provider")
+    name: str = Field(..., description="Name of the provider")
+    description: str = Field(..., description="Description of the provider")
+    homepage: str = Field(..., description="Homepage of the provider")
+    url: str = Field(
+        ..., description="The URL format string, which must have at least one ``$1`` in it"
+    )
+
+
 class Resource(BaseModel):
     """Metadata about an ontology, database, or other resource."""
 
@@ -88,6 +101,10 @@ class Resource(BaseModel):
     url: Optional[str] = Field(
         title="Format URL",
         description="The URL format string, which must have at least one ``$1`` in it",
+    )
+    #: Additional non-default providers for the given resource
+    providers: Optional[List[Provider]] = Field(
+        description="Additional, non-default providers for the resource",
     )
     #: The URL for the homepage of the resource
     homepage: Optional[str] = Field(
@@ -909,6 +926,7 @@ def get_json_schema():
             [
                 Author,
                 Collection,
+                Provider,
                 Resource,
                 Registry,
             ],

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -81,6 +81,10 @@ class Provider(BaseModel):
         ..., description="The URL format string, which must have at least one ``$1`` in it"
     )
 
+    def resolve(self, identifier: str) -> str:
+        """Resolve the identifier into a URL."""
+        return self.url.replace("$1", identifier)
+
 
 class Resource(BaseModel):
     """Metadata about an ontology, database, or other resource."""
@@ -774,6 +778,14 @@ class Resource(BaseModel):
             logging.debug("formatter does not end with $1: %s", self.name)
             return None
         return fmt[: -len("$1")]
+
+    def get_extra_providers(self) -> List[Provider]:
+        """Get a list of all extra providers."""
+        # TODO include identifiers.org import
+        rv = []
+        if self.providers is not None:
+            rv.extend(self.providers)
+        return rv
 
 
 class Registry(BaseModel):

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -781,10 +781,12 @@ class Resource(BaseModel):
 
     def get_extra_providers(self) -> List[Provider]:
         """Get a list of all extra providers."""
-        # TODO include identifiers.org import
         rv = []
         if self.providers is not None:
             rv.extend(self.providers)
+        if self.miriam:
+            for p in self.miriam.get('providers', []):
+                rv.append(Provider(**p))
         return rv
 
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -775,7 +775,7 @@ class Resource(BaseModel):
         if self.providers is not None:
             rv.extend(self.providers)
         if self.miriam:
-            for p in self.miriam.get('providers', []):
+            for p in self.miriam.get("providers", []):
                 rv.append(Provider(**p))
         return rv
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -62,6 +62,7 @@ class TestRegistry(unittest.TestCase):
             "proprietary",
             "has_canonical",
             "preferred_prefix",
+            "providers",
         }
         keys.update(bioregistry.read_metaregistry())
         for prefix, entry in self.registry.items():


### PR DESCRIPTION
Blocked by #198. Closes #196. This PR does the following:

1. Introduces a new pydantic object and schema for storing information about 3rd party providers that are not considered as resolvers (like Identifiers.org) or lookup services (like the OLS)
2. Provides an example curation from ChEBI - they have many endpoints, including one that generates images. 
3. Incorporates MIRIAM providers that were added in #198
4. Update the resource page on the web app to show extra ones (see image below)

<img width="916" alt="Screen Shot 2021-10-01 at 12 31 23" src="https://user-images.githubusercontent.com/5069736/135605872-7016763f-941b-4a2e-8732-884ac21ae3c4.png">

## Future Work

- Import providers in Identifiers.org (but deduplicate ones from OLS, BioPortal, and other resolvers/lookup services)
- Link records that "provide" like ctd.gene
- Consider tagging all providers with types on web interface to reduce confusion between first party default provider, lookup/resolvers, and third party
