### PR TITLE
Fix resolution lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ assert ('chebi', '1234') == parse_curie('chebi:1234')
 assert ('pubchem.compound', '1234') == parse_curie('pubchem:1234')
 
 # Normalize mixed case prefixes
-assert ('fbbt', '1234') == parse_curie('FBbt:1234')
+assert ('fbbt', '00007294') == parse_curie('FBbt:00007294')
 
 # Remove the redundant prefix and normalize
 assert ('go', '1234') == parse_curie('GO:GO:1234')

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -16811,6 +16811,7 @@
   },
   "hgnc.genefamily": {
     "example": "2029",
+    "has_canonical": "hgnc.genegroup",
     "homepage": "http://www.genenames.org",
     "mappings": {
       "miriam": "hgnc.family",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -39848,6 +39848,7 @@
       "name": "Unipathway",
       "prefix": "UPA"
     },
+    "deprecated": true,
     "download_obo": "https://raw.githubusercontent.com/geneontology/unipathway/master/upa.obo",
     "example": "UCR00513",
     "go": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -41086,6 +41086,7 @@
       "prefix": "WBLS",
       "url": "http://www.ontobee.org/ontology/WBLS"
     },
+    "part_of": "wormbase",
     "pattern": "^\\d{7}$",
     "prefixcommons": {
       "formatter": "http://purl.obolibrary.org/obo/WBLS_$1",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -23971,31 +23971,10 @@
       "is_identifiers": true,
       "is_obo": false,
       "prefix": "MMMP:BIOMAPS"
-    }
-  },
-  "mmmp:biomaps": {
-    "mappings": {
-      "miriam": "mmmp:biomaps",
-      "prefixcommons": "MMMP:BIOMAPS"
     },
-    "miriam": {
-      "deprecated": false,
-      "description": "A collection of molecular interaction maps and pathways involved in cancer development and progression with a focus on melanoma.",
-      "homepage": "http://www.mmmp.org/MMMP/public/biomap/listBiomap.mmmp",
-      "id": "00000075",
-      "name": "Melanoma Molecular Map Project Biomaps",
-      "namespaceEmbeddedInLui": false,
-      "pattern": "^\\d+$",
-      "prefix": "mmmp:biomaps",
-      "provider_url": "http://www.mmmp.org/MMMP/public/biomap/viewBiomap.mmmp?id=$1",
-      "sampleId": "37"
-    },
-    "prefixcommons": {
-      "formatter": "http://identifiers.org/mmmp:biomaps/$1",
-      "is_identifiers": true,
-      "is_obo": false,
-      "prefix": "MMMP:BIOMAPS"
-    }
+    "synonyms": [
+      "mmmp:biomaps"
+    ]
   },
   "mmo": {
     "bioportal": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -12626,6 +12626,7 @@
       "is_obo": true,
       "prefix": "FBbt"
     },
+    "url": "https://flybase.org/cgi-bin/cvreport.pl?id=FBbt:$1",
     "synonyms": [
       "FBbt_root",
       "FBbt"

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -31938,7 +31938,8 @@
       "is_identifiers": true,
       "is_obo": false,
       "prefix": "PMP"
-    }
+    },
+    "provides": "uniprot"
   },
   "po": {
     "bioportal": {
@@ -41150,6 +41151,7 @@
       "prefix": "WBPhenotype",
       "url": "http://www.ontobee.org/ontology/WBPhenotype"
     },
+    "part_of": "wormbase",
     "pattern": "^\\d{7}$",
     "prefixcommons": {
       "formatter": "http://purl.obolibrary.org/obo/WBPhenotype_$1",

--- a/src/bioregistry/resolve_identifier.py
+++ b/src/bioregistry/resolve_identifier.py
@@ -308,12 +308,12 @@ def get_bioregistry_iri(prefix: str, identifier: str) -> Optional[str]:
 
     Redundant prefix (banana; OBO)
 
-    >>> get_bioregistry_iri('fbbt', 'FBbt:1234')
-    'https://bioregistry.io/fbbt:1234'
-    >>> get_bioregistry_iri('fbbt', 'fbbt:1234')
-    'https://bioregistry.io/fbbt:1234'
-    >>> get_bioregistry_iri('fbbt', '1234')
-    'https://bioregistry.io/fbbt:1234'
+    >>> get_bioregistry_iri('fbbt', 'fbbt:00007294')
+    'https://bioregistry.io/fbbt:00007294'
+    >>> get_bioregistry_iri('fbbt', 'fbbt:00007294')
+    'https://bioregistry.io/fbbt:00007294'
+    >>> get_bioregistry_iri('fbbt', '00007294')
+    'https://bioregistry.io/fbbt:00007294'
 
     Redundant prefix (banana; explicit)
     >>> get_bioregistry_iri('go.ref', 'GO_REF:1234')
@@ -396,8 +396,8 @@ def get_iri(
     >>> prefix_map = {"chebi": "https://example.org/chebi/"}
     >>> get_iri("chebi:24867", prefix_map=prefix_map)
     'https://example.org/chebi/24867'
-    >>> get_iri("fbbt:1234")
-    'http://purl.obolibrary.org/obo/FBbt_1234'
+    >>> get_iri("fbbt:00007294")
+    'https://flybase.org/cgi-bin/cvreport.pl?id=FBbt:00007294'
 
     A custom prefix map can be supplied in combination with a priority list
     >>> prefix_map = {"lipidmaps": "https://example.org/lipidmaps/"}

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -293,9 +293,6 @@ class Resource(BaseModel):
                 return rv
         return None
 
-    def _default_provider_url(self) -> Optional[str]:
-        return self.get_default_format()
-
     def get_default_url(self, identifier: str) -> Optional[str]:
         """Return the default URL for the identifier.
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,8 +5,10 @@
 import logging
 import unittest
 from collections import defaultdict
+from typing import Mapping
 
 import bioregistry
+from bioregistry.export.prefix_maps import get_obofoundry_prefix_map
 from bioregistry.export.rdf_export import resource_to_rdf_str
 from bioregistry.resolve import get_external
 from bioregistry.schema.utils import EMAIL_RE
@@ -369,6 +371,26 @@ class TestRegistry(unittest.TestCase):
 
             x[iri] = parts, unmapped, canonical_target, all_targets
         self.assertEqual({}, x)
+
+    def test_default_prefix_map_no_miriam(self):
+        """Test no identifiers.org URI prefixes get put in the prefix map."""
+        self.assert_no_idot(bioregistry.get_prefix_map())
+        # self.assert_no_idot(bioregistry.get_prefix_map(include_synonyms=True))
+
+    def test_obo_prefix_map_no_miriam(self):
+        """Test no identifiers.org URI prefixes get put in the OBO prefix map."""
+        self.assert_no_idot(get_obofoundry_prefix_map())
+        # self.assert_no_idot(get_obofoundry_prefix_map(include_synonyms=True))
+
+    def assert_no_idot(self, prefix_map: Mapping[str, str]) -> None:
+        """Assert none of the URI prefixes have identifiers.org in them."""
+        for prefix, uri_prefix in prefix_map.items():
+            if prefix in {"idoo", "miriam.collection", "mir"}:
+                continue
+            with self.subTest(prefix=prefix):
+                # self.assertFalse(uri_prefix.startswith("https://identifiers.org/"), msg=uri_prefix)
+                # self.assertFalse(uri_prefix.startswith("http://identifiers.org/"), msg=uri_prefix)
+                self.assertNotIn("identifiers.org", uri_prefix, msg=uri_prefix)
 
     def test_preferred_prefix(self):
         """Test the preferred prefix matches the normalized prefix."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -386,10 +386,9 @@ class TestRegistry(unittest.TestCase):
         """Assert none of the URI prefixes have identifiers.org in them."""
         for prefix, uri_prefix in prefix_map.items():
             if prefix in {"idoo", "miriam.collection", "mir"}:
+                # allow identifiers.org namespaces since this actually should be here
                 continue
             with self.subTest(prefix=prefix):
-                # self.assertFalse(uri_prefix.startswith("https://identifiers.org/"), msg=uri_prefix)
-                # self.assertFalse(uri_prefix.startswith("http://identifiers.org/"), msg=uri_prefix)
                 self.assertNotIn("identifiers.org", uri_prefix, msg=uri_prefix)
 
     def test_preferred_prefix(self):


### PR DESCRIPTION
There were two redundant functions that were getting out of sync, so I deleted one and made improvements on the other. Further, it tries to avoid using identifiers.org lookups (since those snuck in to prefixcommons and GO quite a bit)