### PR TITLE
Add INDRA resolution

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -17253,6 +17253,7 @@
       "bioportal": "HGNC",
       "cellosaurus": "HGNC",
       "go": "HGNC",
+      "indra": "HGNC",
       "miriam": "hgnc",
       "n2t": "hgnc",
       "ncbi": "HGNC",
@@ -40618,6 +40619,7 @@
     "mappings": {
       "cellosaurus": "UniProtKB",
       "go": "UniProtKB",
+      "indra": "UP",
       "miriam": "uniprot",
       "n2t": "uniprot",
       "ncbi": "UniProt",

--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -88,6 +88,14 @@
       "prefix": "go"
     },
     {
+      "description": "A large scale database of biomedical statements.",
+      "example": "HGNC",
+      "homepage": "https://db.indra.bio",
+      "name": "INDRA Database",
+      "prefix": "indra",
+      "resolver_url": "https://db.indra.bio/statements/from_agents?&format=html&agent0=$2@$1"
+    },
+    {
       "contact": "hhe@ebi.ac.uk",
       "description": "The Identifiers.org Resolution Service provides consistent access to life science data using Compact Identifiers. Compact Identifiers consist of an assigned unique prefix and a local provider designated accession number (prefix:accession).",
       "download": "https://registry.api.identifiers.org/resolutionApi/getResolverDataset",

--- a/src/bioregistry/resolve_identifier.py
+++ b/src/bioregistry/resolve_identifier.py
@@ -313,6 +313,11 @@ def get_bioregistry_iri(prefix: str, identifier: str) -> Optional[str]:
     return f"{BIOREGISTRY_REMOTE_URL.rstrip()}/{norm_prefix}:{norm_identifier}"
 
 
+def get_indra_iri(prefix: str, identifier: str) -> Optional[str]:
+    """Get an INDRA IRI, if possible."""
+    return get_formatted_iri("indra", prefix, identifier)
+
+
 PROVIDER_FUNCTIONS: Mapping[str, Callable[[str, str], Optional[str]]] = {
     "default": get_default_iri,
     "miriam": get_identifiers_org_iri,
@@ -321,6 +326,7 @@ PROVIDER_FUNCTIONS: Mapping[str, Callable[[str, str], Optional[str]]] = {
     "n2t": get_n2t_iri,
     "bioportal": get_bioportal_iri,
     "scholia": get_scholia_iri,
+    "indra": get_indra_iri,
 }
 
 LINK_PRIORITY = [
@@ -333,6 +339,7 @@ LINK_PRIORITY = [
     "n2t",
     "bioportal",
     "scholia",
+    "indra",
 ]
 
 


### PR DESCRIPTION
This PR adds the programmatically generated INDRA database URLs for mappable prefixes. Currently it's got manually mapped prefixes, but there's a mapping living somewhere that we can consume to keep this up to date (hopefully without having to install/import INDRA).

see `from indra.databases.identifiers import identifiers_mappings`

<img width="1006" alt="Screen Shot 2021-10-03 at 18 41 39" src="https://user-images.githubusercontent.com/5069736/135763341-177a8dab-f4b3-4e87-9b5e-841d1d0f5a5e.png">

