### PR TITLE
Add resolution URL override for Uberon

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -41456,6 +41456,7 @@
       "Uberon",
       "Uber-anatomy ontology"
     ],
+    "uri_format": "https://bioportal.bioontology.org/ontologies/UBERON/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_$1",
     "wikidata": {
       "prefix": "P1554"
     }


### PR DESCRIPTION
The current resolution URL for Uberon (imported via Miriam, redirects to a URL of the form https://bioportal.bioontology.org/ontologies/UBERON?p=classes&conceptid=UBERON%3A2005080) is not working. This PR adds an override to link to e.g., https://bioportal.bioontology.org/ontologies/UBERON/?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_2005080 which resolves correctly.