### PR TITLE
Improve generation of default URI format strings

### DIFF
--- a/exports/registry/registry.json
+++ b/exports/registry/registry.json
@@ -1423,12 +1423,12 @@
     "synonyms": [
       "kisao"
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/KISAO/kisao:$1",
+    "uri_format": "http://purl.obolibrary.org/obo/KISAO_$1",
     "version": "2.30"
   },
   "biomodels.teddy": {
     "description": "The Terminology for Description of Dynamics (TEDDY) is an ontology for dynamical behaviours, observable dynamical phenomena, and control elements of bio-models and biological systems in Systems Biology and Synthetic Biology.",
-    "example": "TEDDY_0000066",
+    "example": "0000066",
     "homepage": "http://teddyontology.sourceforge.net/",
     "mappings": {
       "bioportal": "TEDDY",
@@ -1438,12 +1438,12 @@
       "prefixcommons": "BIOMODELS.TEDDY"
     },
     "name": "Terminology for Description of Dynamics",
-    "pattern": "^TEDDY_\\d{7}$",
+    "pattern": "^\\d+$",
     "preferred_prefix": "biomodels.teddy",
     "synonyms": [
       "teddy"
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/TEDDY/$1",
+    "uri_format": "https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1",
     "version": "2014-04-24"
   },
   "biomodels.vocabulary": {
@@ -5351,7 +5351,7 @@
     "name": "Bioinformatics operations, data types, formats, identifiers and topics",
     "pattern": "^(data|topic|operation|format)\\_\\d{4}$",
     "preferred_prefix": "edam",
-    "uri_format": "http://purl.bioontology.org/ontology/EDAM/$1",
+    "uri_format": "http://identifiers.org/edam/$1",
     "version": "2019-07-17"
   },
   "efo": {
@@ -11704,7 +11704,7 @@
         "uri_format": "https://mged.sourceforge.net/ontologies/MGEDontology.php#$1"
       }
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/MO/$1"
+    "uri_format": "http://purl.obolibrary.org/obo/MO_$1"
   },
   "mobidb": {
     "description": "MobiDB is a database of protein disorder and mobility annotations.",
@@ -13747,7 +13747,7 @@
     "name": "Ontology of Physics for Biology",
     "pattern": "^OPB_\\d+$",
     "preferred_prefix": "opb",
-    "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1"
+    "uri_format": "http://identifiers.org/opb/$1"
   },
   "opl": {
     "banana": "OPL",
@@ -18382,7 +18382,7 @@
       "Uber-anatomy ontology",
       "Uberon"
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/UBERON/UBERON:$1",
+    "uri_format": "http://purl.obolibrary.org/obo/UBERON_$1",
     "version": "2021-10-01"
   },
   "ubio.namebank": {
@@ -19017,7 +19017,7 @@
         "uri_format": "http://www.ontobee.org/search?ontology=VariO&keywords=VariO_$1&submit=Search+terms"
       }
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/VARIO/VariO:$1",
+    "uri_format": "http://purl.obolibrary.org/obo/VARIO_$1",
     "version": "2018-11-09"
   },
   "vbase2": {

--- a/exports/registry/registry.json
+++ b/exports/registry/registry.json
@@ -1428,7 +1428,7 @@
   },
   "biomodels.teddy": {
     "description": "The Terminology for Description of Dynamics (TEDDY) is an ontology for dynamical behaviours, observable dynamical phenomena, and control elements of bio-models and biological systems in Systems Biology and Synthetic Biology.",
-    "example": "TEDDY_0000066",
+    "example": "0000066",
     "homepage": "http://teddyontology.sourceforge.net/",
     "mappings": {
       "bioportal": "TEDDY",
@@ -1438,7 +1438,7 @@
       "prefixcommons": "BIOMODELS.TEDDY"
     },
     "name": "Terminology for Description of Dynamics",
-    "pattern": "^TEDDY_\\d{7}$",
+    "pattern": "^\\d+$",
     "preferred_prefix": "biomodels.teddy",
     "synonyms": [
       "teddy"

--- a/exports/registry/registry.json
+++ b/exports/registry/registry.json
@@ -1423,7 +1423,7 @@
     "synonyms": [
       "kisao"
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/KISAO/kisao:$1",
+    "uri_format": "http://purl.obolibrary.org/obo/KISAO_$1",
     "version": "2.30"
   },
   "biomodels.teddy": {
@@ -1443,7 +1443,7 @@
     "synonyms": [
       "teddy"
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/TEDDY/$1",
+    "uri_format": "https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1",
     "version": "2014-04-24"
   },
   "biomodels.vocabulary": {
@@ -5351,7 +5351,7 @@
     "name": "Bioinformatics operations, data types, formats, identifiers and topics",
     "pattern": "^(data|topic|operation|format)\\_\\d{4}$",
     "preferred_prefix": "edam",
-    "uri_format": "http://purl.bioontology.org/ontology/EDAM/$1",
+    "uri_format": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http://edamontology.org/$1",
     "version": "2019-07-17"
   },
   "efo": {
@@ -8758,7 +8758,7 @@
     "name": "Identifiers.org namespace",
     "pattern": "^[a-z_\\.]+$",
     "preferred_prefix": "identifiers.namespace",
-    "uri_format": "https://identifiers.org/identifiers.namespace:$1"
+    "uri_format": "https://registry.identifiers.org/registry/$1"
   },
   "ido": {
     "banana": "IDO",
@@ -8840,7 +8840,7 @@
     "name": "Identifiers.org Ontology",
     "pattern": "^[0-9a-zA-Z]+$",
     "preferred_prefix": "idoo",
-    "uri_format": "https://identifiers.org/idoo:$1"
+    "uri_format": "http://registry.api.hq.identifiers.org/semanticApi/getRegistryOntology#$1"
   },
   "idot": {
     "description": "Identifiers.org Terms (idot) is an RDF vocabulary providing useful terms for describing datasets.",
@@ -10428,7 +10428,7 @@
     "banana": "MAMO",
     "contact": "n.lenovere@gmail.com",
     "description": "The Mathematical Modelling Ontology (MAMO) is a classification of the types of mathematical models used mostly in the life sciences, their variables, relationships and other relevant features.",
-    "example": "MAMO_0000026",
+    "example": "0000026",
     "homepage": "http://sourceforge.net/p/mamo-ontology/wiki/Home/",
     "license": "Artistic License 2.0",
     "mappings": {
@@ -10441,9 +10441,9 @@
       "prefixcommons": "MAMO"
     },
     "name": "Mathematical modeling ontology",
-    "pattern": "^MAMO_\\d{7}$",
+    "pattern": "^\\d{7}$",
     "preferred_prefix": "MAMO",
-    "uri_format": "http://purl.obolibrary.org/obo/MAMO_$1",
+    "uri_format": "http://bioportal.bioontology.org/ontologies/MAMO/?p=classes&conceptid=http://identifiers.org/mamo/MAMO_$1",
     "version": "2020-08-24"
   },
   "mao": {
@@ -11335,7 +11335,7 @@
     "namespace_in_lui": true,
     "pattern": "^\\d{8}$",
     "preferred_prefix": "mir",
-    "uri_format": "http://identifiers.org/mir/$1"
+    "uri_format": "https://registry.identifiers.org/registry?query=\"MIR:$1\""
   },
   "mirbase": {
     "description": "The miRBase Sequence Database is a searchable database of published miRNA sequences and annotation. The data were previously provided by the miRNA Registry. Each entry in the miRBase Sequence database represents a predicted hairpin portion of a miRNA transcript (termed mir in the database), with information on the location and sequence of the mature miRNA sequence (termed miR).",
@@ -11704,7 +11704,7 @@
         "uri_format": "https://mged.sourceforge.net/ontologies/MGEDontology.php#$1"
       }
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/MO/$1"
+    "uri_format": "http://purl.obolibrary.org/obo/MO_$1"
   },
   "mobidb": {
     "description": "MobiDB is a database of protein disorder and mobility annotations.",
@@ -13736,7 +13736,7 @@
   },
   "opb": {
     "description": "The OPB is a reference ontology of classical physics as applied to the dynamics of biological systems. It is designed to encompass the multiple structural scales (multiscale atoms to organisms) and multiple physical domains (multidomain fluid dynamics, chemical kinetics, particle diffusion, etc.) that are encountered in the study and analysis of biological organisms.",
-    "example": "OPB_00573",
+    "example": "00573",
     "homepage": "http://bioportal.bioontology.org/ontologies/OPB",
     "mappings": {
       "bioportal": "OPB",
@@ -13745,9 +13745,9 @@
       "prefixcommons": "OPB"
     },
     "name": "Ontology of Physics for Biology",
-    "pattern": "^OPB_\\d+$",
+    "pattern": "^\\d+$",
     "preferred_prefix": "opb",
-    "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1"
+    "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23OPB_$1"
   },
   "opl": {
     "banana": "OPL",
@@ -18382,7 +18382,7 @@
       "Uber-anatomy ontology",
       "Uberon"
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/UBERON/UBERON:$1",
+    "uri_format": "http://purl.obolibrary.org/obo/UBERON_$1",
     "version": "2021-10-01"
   },
   "ubio.namebank": {
@@ -19017,7 +19017,7 @@
         "uri_format": "http://www.ontobee.org/search?ontology=VariO&keywords=VariO_$1&submit=Search+terms"
       }
     ],
-    "uri_format": "http://purl.bioontology.org/ontology/VARIO/VariO:$1",
+    "uri_format": "http://purl.obolibrary.org/obo/VARIO_$1",
     "version": "2018-11-09"
   },
   "vbase2": {

--- a/exports/registry/registry.json
+++ b/exports/registry/registry.json
@@ -1423,12 +1423,12 @@
     "synonyms": [
       "kisao"
     ],
-    "uri_format": "http://purl.obolibrary.org/obo/KISAO_$1",
+    "uri_format": "http://purl.bioontology.org/ontology/KISAO/kisao:$1",
     "version": "2.30"
   },
   "biomodels.teddy": {
     "description": "The Terminology for Description of Dynamics (TEDDY) is an ontology for dynamical behaviours, observable dynamical phenomena, and control elements of bio-models and biological systems in Systems Biology and Synthetic Biology.",
-    "example": "0000066",
+    "example": "TEDDY_0000066",
     "homepage": "http://teddyontology.sourceforge.net/",
     "mappings": {
       "bioportal": "TEDDY",
@@ -1438,12 +1438,12 @@
       "prefixcommons": "BIOMODELS.TEDDY"
     },
     "name": "Terminology for Description of Dynamics",
-    "pattern": "^\\d+$",
+    "pattern": "^TEDDY_\\d{7}$",
     "preferred_prefix": "biomodels.teddy",
     "synonyms": [
       "teddy"
     ],
-    "uri_format": "https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1",
+    "uri_format": "http://purl.bioontology.org/ontology/TEDDY/$1",
     "version": "2014-04-24"
   },
   "biomodels.vocabulary": {
@@ -5351,7 +5351,7 @@
     "name": "Bioinformatics operations, data types, formats, identifiers and topics",
     "pattern": "^(data|topic|operation|format)\\_\\d{4}$",
     "preferred_prefix": "edam",
-    "uri_format": "http://identifiers.org/edam/$1",
+    "uri_format": "http://purl.bioontology.org/ontology/EDAM/$1",
     "version": "2019-07-17"
   },
   "efo": {
@@ -11704,7 +11704,7 @@
         "uri_format": "https://mged.sourceforge.net/ontologies/MGEDontology.php#$1"
       }
     ],
-    "uri_format": "http://purl.obolibrary.org/obo/MO_$1"
+    "uri_format": "http://purl.bioontology.org/ontology/MO/$1"
   },
   "mobidb": {
     "description": "MobiDB is a database of protein disorder and mobility annotations.",
@@ -13747,7 +13747,7 @@
     "name": "Ontology of Physics for Biology",
     "pattern": "^OPB_\\d+$",
     "preferred_prefix": "opb",
-    "uri_format": "http://identifiers.org/opb/$1"
+    "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1"
   },
   "opl": {
     "banana": "OPL",
@@ -18382,7 +18382,7 @@
       "Uber-anatomy ontology",
       "Uberon"
     ],
-    "uri_format": "http://purl.obolibrary.org/obo/UBERON_$1",
+    "uri_format": "http://purl.bioontology.org/ontology/UBERON/UBERON:$1",
     "version": "2021-10-01"
   },
   "ubio.namebank": {
@@ -19017,7 +19017,7 @@
         "uri_format": "http://www.ontobee.org/search?ontology=VariO&keywords=VariO_$1&submit=Search+terms"
       }
     ],
-    "uri_format": "http://purl.obolibrary.org/obo/VARIO_$1",
+    "uri_format": "http://purl.bioontology.org/ontology/VARIO/VariO:$1",
     "version": "2018-11-09"
   },
   "vbase2": {

--- a/exports/registry/registry.yml
+++ b/exports/registry/registry.yml
@@ -1447,13 +1447,13 @@ biomodels.kisao:
   preferred_prefix: biomodels.kisao
   synonyms:
   - kisao
-  uri_format: http://purl.bioontology.org/ontology/KISAO/kisao:$1
+  uri_format: http://purl.obolibrary.org/obo/KISAO_$1
   version: '2.30'
 biomodels.teddy:
   description: The Terminology for Description of Dynamics (TEDDY) is an ontology
     for dynamical behaviours, observable dynamical phenomena, and control elements
     of bio-models and biological systems in Systems Biology and Synthetic Biology.
-  example: TEDDY_0000066
+  example: '0000066'
   homepage: http://teddyontology.sourceforge.net/
   mappings:
     bioportal: TEDDY
@@ -1462,11 +1462,11 @@ biomodels.teddy:
     ols: teddy
     prefixcommons: BIOMODELS.TEDDY
   name: Terminology for Description of Dynamics
-  pattern: ^TEDDY_\d{7}$
+  pattern: ^\d+$
   preferred_prefix: biomodels.teddy
   synonyms:
   - teddy
-  uri_format: http://purl.bioontology.org/ontology/TEDDY/$1
+  uri_format: https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1
   version: '2014-04-24'
 biomodels.vocabulary:
   description: Vocabulary used in the RDF representation of SBML models.
@@ -5473,7 +5473,7 @@ edam:
   name: Bioinformatics operations, data types, formats, identifiers and topics
   pattern: ^(data|topic|operation|format)\_\d{4}$
   preferred_prefix: edam
-  uri_format: http://purl.bioontology.org/ontology/EDAM/$1
+  uri_format: http://identifiers.org/edam/$1
   version: '2019-07-17'
 efo:
   contact: efo-users@lists.sourceforge.net
@@ -11931,7 +11931,7 @@ mo:
     homepage: https://mged.sourceforge.net/ontologies/MGEDontology.php
     name: MGED Ontology at SourceForge
     uri_format: https://mged.sourceforge.net/ontologies/MGEDontology.php#$1
-  uri_format: http://purl.bioontology.org/ontology/MO/$1
+  uri_format: http://purl.obolibrary.org/obo/MO_$1
 mobidb:
   description: MobiDB is a database of protein disorder and mobility annotations.
   example: P10636
@@ -14040,7 +14040,7 @@ opb:
   name: Ontology of Physics for Biology
   pattern: ^OPB_\d+$
   preferred_prefix: opb
-  uri_format: http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1
+  uri_format: http://identifiers.org/opb/$1
 opl:
   banana: OPL
   contact: preets79@gmail.com
@@ -18855,7 +18855,7 @@ uberon:
   - UBERON
   - Uber-anatomy ontology
   - Uberon
-  uri_format: http://purl.bioontology.org/ontology/UBERON/UBERON:$1
+  uri_format: http://purl.obolibrary.org/obo/UBERON_$1
   version: '2021-10-01'
 ubio.namebank:
   description: NameBank is a "biological name server" focused on storing names and
@@ -19494,7 +19494,7 @@ vario:
     homepage: http://www.variationontology.org/
     name: VariO at Lund University
     uri_format: http://www.ontobee.org/search?ontology=VariO&keywords=VariO_$1&submit=Search+terms
-  uri_format: http://purl.bioontology.org/ontology/VARIO/VariO:$1
+  uri_format: http://purl.obolibrary.org/obo/VARIO_$1
   version: '2018-11-09'
 vbase2:
   description: The database VBASE2 provides germ-line sequences of human and mouse

--- a/exports/registry/registry.yml
+++ b/exports/registry/registry.yml
@@ -1453,7 +1453,7 @@ biomodels.teddy:
   description: The Terminology for Description of Dynamics (TEDDY) is an ontology
     for dynamical behaviours, observable dynamical phenomena, and control elements
     of bio-models and biological systems in Systems Biology and Synthetic Biology.
-  example: TEDDY_0000066
+  example: '0000066'
   homepage: http://teddyontology.sourceforge.net/
   mappings:
     bioportal: TEDDY
@@ -1462,7 +1462,7 @@ biomodels.teddy:
     ols: teddy
     prefixcommons: BIOMODELS.TEDDY
   name: Terminology for Description of Dynamics
-  pattern: ^TEDDY_\d{7}$
+  pattern: ^\d+$
   preferred_prefix: biomodels.teddy
   synonyms:
   - teddy

--- a/exports/registry/registry.yml
+++ b/exports/registry/registry.yml
@@ -1447,13 +1447,13 @@ biomodels.kisao:
   preferred_prefix: biomodels.kisao
   synonyms:
   - kisao
-  uri_format: http://purl.obolibrary.org/obo/KISAO_$1
+  uri_format: http://purl.bioontology.org/ontology/KISAO/kisao:$1
   version: '2.30'
 biomodels.teddy:
   description: The Terminology for Description of Dynamics (TEDDY) is an ontology
     for dynamical behaviours, observable dynamical phenomena, and control elements
     of bio-models and biological systems in Systems Biology and Synthetic Biology.
-  example: '0000066'
+  example: TEDDY_0000066
   homepage: http://teddyontology.sourceforge.net/
   mappings:
     bioportal: TEDDY
@@ -1462,11 +1462,11 @@ biomodels.teddy:
     ols: teddy
     prefixcommons: BIOMODELS.TEDDY
   name: Terminology for Description of Dynamics
-  pattern: ^\d+$
+  pattern: ^TEDDY_\d{7}$
   preferred_prefix: biomodels.teddy
   synonyms:
   - teddy
-  uri_format: https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1
+  uri_format: http://purl.bioontology.org/ontology/TEDDY/$1
   version: '2014-04-24'
 biomodels.vocabulary:
   description: Vocabulary used in the RDF representation of SBML models.
@@ -5473,7 +5473,7 @@ edam:
   name: Bioinformatics operations, data types, formats, identifiers and topics
   pattern: ^(data|topic|operation|format)\_\d{4}$
   preferred_prefix: edam
-  uri_format: http://identifiers.org/edam/$1
+  uri_format: http://purl.bioontology.org/ontology/EDAM/$1
   version: '2019-07-17'
 efo:
   contact: efo-users@lists.sourceforge.net
@@ -11931,7 +11931,7 @@ mo:
     homepage: https://mged.sourceforge.net/ontologies/MGEDontology.php
     name: MGED Ontology at SourceForge
     uri_format: https://mged.sourceforge.net/ontologies/MGEDontology.php#$1
-  uri_format: http://purl.obolibrary.org/obo/MO_$1
+  uri_format: http://purl.bioontology.org/ontology/MO/$1
 mobidb:
   description: MobiDB is a database of protein disorder and mobility annotations.
   example: P10636
@@ -14040,7 +14040,7 @@ opb:
   name: Ontology of Physics for Biology
   pattern: ^OPB_\d+$
   preferred_prefix: opb
-  uri_format: http://identifiers.org/opb/$1
+  uri_format: http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1
 opl:
   banana: OPL
   contact: preets79@gmail.com
@@ -18855,7 +18855,7 @@ uberon:
   - UBERON
   - Uber-anatomy ontology
   - Uberon
-  uri_format: http://purl.obolibrary.org/obo/UBERON_$1
+  uri_format: http://purl.bioontology.org/ontology/UBERON/UBERON:$1
   version: '2021-10-01'
 ubio.namebank:
   description: NameBank is a "biological name server" focused on storing names and
@@ -19494,7 +19494,7 @@ vario:
     homepage: http://www.variationontology.org/
     name: VariO at Lund University
     uri_format: http://www.ontobee.org/search?ontology=VariO&keywords=VariO_$1&submit=Search+terms
-  uri_format: http://purl.obolibrary.org/obo/VARIO_$1
+  uri_format: http://purl.bioontology.org/ontology/VARIO/VariO:$1
   version: '2018-11-09'
 vbase2:
   description: The database VBASE2 provides germ-line sequences of human and mouse

--- a/exports/registry/registry.yml
+++ b/exports/registry/registry.yml
@@ -1447,7 +1447,7 @@ biomodels.kisao:
   preferred_prefix: biomodels.kisao
   synonyms:
   - kisao
-  uri_format: http://purl.bioontology.org/ontology/KISAO/kisao:$1
+  uri_format: http://purl.obolibrary.org/obo/KISAO_$1
   version: '2.30'
 biomodels.teddy:
   description: The Terminology for Description of Dynamics (TEDDY) is an ontology
@@ -1466,7 +1466,7 @@ biomodels.teddy:
   preferred_prefix: biomodels.teddy
   synonyms:
   - teddy
-  uri_format: http://purl.bioontology.org/ontology/TEDDY/$1
+  uri_format: https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1
   version: '2014-04-24'
 biomodels.vocabulary:
   description: Vocabulary used in the RDF representation of SBML models.
@@ -5473,7 +5473,7 @@ edam:
   name: Bioinformatics operations, data types, formats, identifiers and topics
   pattern: ^(data|topic|operation|format)\_\d{4}$
   preferred_prefix: edam
-  uri_format: http://purl.bioontology.org/ontology/EDAM/$1
+  uri_format: https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http://edamontology.org/$1
   version: '2019-07-17'
 efo:
   contact: efo-users@lists.sourceforge.net
@@ -8994,7 +8994,7 @@ identifiers.namespace:
   name: Identifiers.org namespace
   pattern: ^[a-z_\.]+$
   preferred_prefix: identifiers.namespace
-  uri_format: https://identifiers.org/identifiers.namespace:$1
+  uri_format: https://registry.identifiers.org/registry/$1
 ido:
   banana: IDO
   contact: Lindsay.Cowell@utsouthwestern.edu
@@ -9072,7 +9072,7 @@ idoo:
   name: Identifiers.org Ontology
   pattern: ^[0-9a-zA-Z]+$
   preferred_prefix: idoo
-  uri_format: https://identifiers.org/idoo:$1
+  uri_format: http://registry.api.hq.identifiers.org/semanticApi/getRegistryOntology#$1
 idot:
   description: Identifiers.org Terms (idot) is an RDF vocabulary providing useful
     terms for describing datasets.
@@ -10646,7 +10646,7 @@ mamo:
   description: The Mathematical Modelling Ontology (MAMO) is a classification of the
     types of mathematical models used mostly in the life sciences, their variables,
     relationships and other relevant features.
-  example: MAMO_0000026
+  example: '0000026'
   homepage: http://sourceforge.net/p/mamo-ontology/wiki/Home/
   license: Artistic License 2.0
   mappings:
@@ -10658,9 +10658,9 @@ mamo:
     ontobee: MAMO
     prefixcommons: MAMO
   name: Mathematical modeling ontology
-  pattern: ^MAMO_\d{7}$
+  pattern: ^\d{7}$
   preferred_prefix: MAMO
-  uri_format: http://purl.obolibrary.org/obo/MAMO_$1
+  uri_format: http://bioportal.bioontology.org/ontologies/MAMO/?p=classes&conceptid=http://identifiers.org/mamo/MAMO_$1
   version: '2020-08-24'
 mao:
   banana: MAO
@@ -11567,7 +11567,7 @@ mir:
   namespace_in_lui: true
   pattern: ^\d{8}$
   preferred_prefix: mir
-  uri_format: http://identifiers.org/mir/$1
+  uri_format: https://registry.identifiers.org/registry?query="MIR:$1"
 mirbase:
   description: The miRBase Sequence Database is a searchable database of published
     miRNA sequences and annotation. The data were previously provided by the miRNA
@@ -11931,7 +11931,7 @@ mo:
     homepage: https://mged.sourceforge.net/ontologies/MGEDontology.php
     name: MGED Ontology at SourceForge
     uri_format: https://mged.sourceforge.net/ontologies/MGEDontology.php#$1
-  uri_format: http://purl.bioontology.org/ontology/MO/$1
+  uri_format: http://purl.obolibrary.org/obo/MO_$1
 mobidb:
   description: MobiDB is a database of protein disorder and mobility annotations.
   example: P10636
@@ -14030,7 +14030,7 @@ opb:
     scales (multiscale atoms to organisms) and multiple physical domains (multidomain
     fluid dynamics, chemical kinetics, particle diffusion, etc.) that are encountered
     in the study and analysis of biological organisms.
-  example: OPB_00573
+  example: '00573'
   homepage: http://bioportal.bioontology.org/ontologies/OPB
   mappings:
     bioportal: OPB
@@ -14038,9 +14038,9 @@ opb:
     n2t: opb
     prefixcommons: OPB
   name: Ontology of Physics for Biology
-  pattern: ^OPB_\d+$
+  pattern: ^\d+$
   preferred_prefix: opb
-  uri_format: http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1
+  uri_format: http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23OPB_$1
 opl:
   banana: OPL
   contact: preets79@gmail.com
@@ -18855,7 +18855,7 @@ uberon:
   - UBERON
   - Uber-anatomy ontology
   - Uberon
-  uri_format: http://purl.bioontology.org/ontology/UBERON/UBERON:$1
+  uri_format: http://purl.obolibrary.org/obo/UBERON_$1
   version: '2021-10-01'
 ubio.namebank:
   description: NameBank is a "biological name server" focused on storing names and
@@ -19494,7 +19494,7 @@ vario:
     homepage: http://www.variationontology.org/
     name: VariO at Lund University
     uri_format: http://www.ontobee.org/search?ontology=VariO&keywords=VariO_$1&submit=Search+terms
-  uri_format: http://purl.bioontology.org/ontology/VARIO/VariO:$1
+  uri_format: http://purl.obolibrary.org/obo/VARIO_$1
   version: '2018-11-09'
 vbase2:
   description: The database VBASE2 provides germ-line sequences of human and mouse

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -23039,6 +23039,7 @@
       "name": "Mathematical Modelling Ontology",
       "prefix": "MAMO"
     },
+    "example": "0000026",
     "mappings": {
       "bioportal": "MAMO",
       "miriam": "mamo",
@@ -23098,12 +23099,14 @@
       "prefix": "MAMO",
       "url": "http://www.ontobee.org/ontology/MAMO"
     },
+    "pattern": "^\\d{7}$",
     "prefixcommons": {
       "is_identifiers": false,
       "is_obo": true,
       "prefix": "MAMO",
       "uri_format": "http://purl.obolibrary.org/obo/MAMO_$1"
-    }
+    },
+    "uri_format": "http://bioportal.bioontology.org/ontologies/MAMO/?p=classes&conceptid=http://identifiers.org/mamo/MAMO_$1"
   },
   "mao": {
     "mappings": {
@@ -30716,6 +30719,7 @@
       "name": "Ontology of Physics for Biology",
       "prefix": "OPB"
     },
+    "example": "00573",
     "mappings": {
       "bioportal": "OPB",
       "miriam": "opb",
@@ -30744,12 +30748,14 @@
       "prefix": "opb",
       "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1"
     },
+    "pattern": "^\\d+$",
     "prefixcommons": {
       "is_identifiers": true,
       "is_obo": false,
       "prefix": "OPB",
       "uri_format": "http://identifiers.org/opb/$1"
-    }
+    },
+    "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23OPB_$1"
   },
   "opl": {
     "bioportal": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -11627,7 +11627,8 @@
       "is_obo": false,
       "prefix": "EDAM",
       "uri_format": "http://identifiers.org/edam/$1"
-    }
+    },
+    "uri_format": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http://edamontology.org/$1"
   },
   "efo": {
     "biolink": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -1320,7 +1320,8 @@
       "is_obo": false,
       "prefix": "ARK",
       "uri_format": "http://identifiers.org/ark/$1"
-    }
+    },
+    "uri_format": "http://n2t.net/ark:$1"
   },
   "aro": {
     "bioportal": {
@@ -3302,6 +3303,7 @@
       "name": "Terminology for the Description of Dynamics",
       "prefix": "TEDDY"
     },
+    "example": "0000066",
     "mappings": {
       "bioportal": "TEDDY",
       "miriam": "biomodels.teddy",
@@ -3339,6 +3341,7 @@
       "version": "2014-04-24",
       "version.iri": "http://identifiers.org/combine.specifications/teddy.rel-2014-04-24"
     },
+    "pattern": "^\\d+$",
     "prefixcommons": {
       "is_identifiers": true,
       "is_obo": false,
@@ -3347,7 +3350,8 @@
     },
     "synonyms": [
       "teddy"
-    ]
+    ],
+    "uri_format": "https://www.ebi.ac.uk/ols/ontologies/teddy/terms?iri=http://identifiers.org/teddy/TEDDY_$1"
   },
   "biomodels.vocabulary": {
     "mappings": {

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1179,7 +1179,12 @@ def clean_pattern(rv: str) -> str:
 
 def _allowed_uri_format(rv: str) -> bool:
     """Check that a URI format doesn't have another resolver in it."""
-    return "identifiers.org" not in rv and "purl.bioontology.org" not in rv and "n2t.net" not in rv
+    return (
+        not rv.startswith("https://identifiers.org")
+        and not rv.startswith("http://identifiers.org")
+        and "n2t.net" not in rv
+        and "purl.bioontology.org" not in rv
+    )
 
 
 @lru_cache(maxsize=1)

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -413,7 +413,7 @@ class Resource(BaseModel):
             ("cellosaurus", URI_FORMAT_KEY),
         ]:
             rv = self.get_external(metaprefix).get(key)
-            if rv is not None and "identifiers.org" not in rv:
+            if rv is not None and _allowed_uri_format(rv):
                 return rv
         return None
 
@@ -1175,6 +1175,11 @@ def clean_pattern(rv: str) -> str:
     if not rv.endswith("$"):
         rv = f"{rv}$"
     return rv
+
+
+def _allowed_uri_format(rv: str) -> bool:
+    """Check that a URI format doesn't have another resolver in it."""
+    return "identifiers.org" not in rv and "purl.bioontology.org" not in rv and "n2t.net" not in rv
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -474,7 +474,8 @@ class TestRegistry(unittest.TestCase):
                 # allow identifiers.org namespaces since this actually should be here
                 continue
             with self.subTest(prefix=prefix):
-                self.assertNotIn("identifiers.org", uri_prefix, msg=uri_prefix)
+                self.assertFalse(uri_prefix.startswith("https://identifiers.org"), msg=uri_prefix)
+                self.assertFalse(uri_prefix.startswith("http://identifiers.org"), msg=uri_prefix)
 
     def test_preferred_prefix(self):
         """Test the preferred prefix matches the normalized prefix."""


### PR DESCRIPTION
Some of prefix commons, identifiers.org, etc. refer to other resolvers rather than curating their own stuff. This is a particular problem right now because the UBERON resolution via identifiers.org has broken due to BioPortal changing. The fact that this is 3 levels deep is just not a good look for the Bioregistry. This PR does a few things:

1. Makes sure that the "default URI" is not considered from external resources if they are from a different resolver.
2. Does a few curations to use higher quality resources for resolution
3. Random curations

This PR should supercede #248 