### PR TITLE
Clean up EPIO/EPSO entries

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -14688,12 +14688,12 @@
       "name": "EpilepsyOntology",
       "prefix": "EPIO"
     },
+    "example": "0000011",
     "mappings": {
       "bioportal": "EPIO",
       "obofoundry": "epio",
       "ontobee": "EPIO"
     },
-    "example": "0000011",
     "obofoundry": {
       "contact": "alpha.tom.kodamullil@scai.fraunhofer.de",
       "contact.github": "akodamullil",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -14766,31 +14766,13 @@
     "mappings": {
       "bioportal": "EPSO",
       "fairsharing": "FAIRsharing.ttprgy",
-      "obofoundry": "epso",
       "ontobee": "EPSO"
-    },
-    "obofoundry": {
-      "contact": "alpha.tom.kodamullil@scai.fraunhofer.de",
-      "contact.github": "akodamullil",
-      "contact.label": "Alpha Tom Kodamullil",
-      "deprecated": false,
-      "description": "A application driven Epilepsy Ontology sith official terms from the ILAE.",
-      "download.owl": "http://purl.obolibrary.org/obo/epso.owl",
-      "homepage": "https://github.com/phwegner/Epilepsyontology",
-      "inactive": false,
-      "license": "CC BY 4.0",
-      "license.url": "http://creativecommons.org/licenses/by/4.0/",
-      "name": "Epilepsy Ontology",
-      "preferredPrefix": "EPSO",
-      "prefix": "epso",
-      "repository": "https://github.com/phwegner/Epilepsyontology"
     },
     "ontobee": {
       "library": "Library",
       "name": "Epilepsy Ontology",
       "prefix": "EPSO"
-    },
-    "uri_format": "https://bio.scai.fraunhofer.de/ontology/$1"
+    }
   },
   "erm": {
     "mappings": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -14693,6 +14693,7 @@
       "obofoundry": "epio",
       "ontobee": "EPIO"
     },
+    "example": "0000011",
     "obofoundry": {
       "contact": "alpha.tom.kodamullil@scai.fraunhofer.de",
       "contact.github": "akodamullil",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -14762,7 +14762,7 @@
       "name": "Epilepsy and Seizure Ontology",
       "prefix": "FAIRsharing.ttprgy"
     },
-    "homepage": "https://github.com/phwegner/Epilepsyontology",
+    "homepage": "http://prism.case.edu/prism/index.php/EpilepsyOntology",
     "mappings": {
       "bioportal": "EPSO",
       "fairsharing": "FAIRsharing.ttprgy",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -515,7 +515,9 @@ class Resource(BaseModel):
 
     def get_description(self) -> Optional[str]:
         """Get the description for the given prefix, if available."""
-        rv = self.get_prefix_key("description", ("miriam", "ols", "obofoundry", "wikidata", "fairsharing"))
+        rv = self.get_prefix_key(
+            "description", ("miriam", "ols", "obofoundry", "wikidata", "fairsharing")
+        )
         if rv is not None:
             return rv
         if self.cellosaurus and "category" in self.cellosaurus:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -515,7 +515,7 @@ class Resource(BaseModel):
 
     def get_description(self) -> Optional[str]:
         """Get the description for the given prefix, if available."""
-        rv = self.get_prefix_key("description", ("miriam", "ols", "obofoundry", "wikidata"))
+        rv = self.get_prefix_key("description", ("miriam", "ols", "obofoundry", "wikidata", "fairsharing"))
         if rv is not None:
             return rv
         if self.cellosaurus and "category" in self.cellosaurus:


### PR DESCRIPTION
The group responsible for EPIO in the OBO Foundry made a huge mess - they changed the prefix after being listed in the OBO Foundry, and it overlapped with a pre-existing ontology that was not the same (but was in fact also about the same topic, epilepsy). Since the Bioregistry considers OBO Foundry to be pretty high quality and immutable, this required going back and fixing the mappings manually. Unfortunately there is no really good way to guard against this kind of stuff other than petitioning the OBO Foundry to increase its stringency and provide more automated checks for collisions in the future.

Related, I blogged a bit about my frustrations in this regard here https://cthoyt.com/2021/12/17/unique-prefix-picking.html 