### PR TITLE
Update DOI entry

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -11931,7 +11931,31 @@
       "is_obo": false,
       "prefix": "DOI",
       "uri_format": "http://dx.doi.org/$1"
-    }
+    },
+    "providers": [
+      {
+        "code": "dx_doi_https",
+        "description": "An alternate provider from the DOI website using HTTPS",
+        "homepage": "https://www.doi.org",
+        "name": "Digital Object Identifier",
+        "uri_format": "https://dx.doi.org/$1"
+      },
+      {
+        "code": "doi_https",
+        "description": "An alternate provider from the DOI website",
+        "homepage": "https://www.doi.org",
+        "name": "Digital Object Identifier",
+        "uri_format": "https://doi.org/$1"
+      },
+      {
+        "code": "doi_http",
+        "description": "An alternate provider from the DOI website",
+        "homepage": "https://www.doi.org",
+        "name": "Digital Object Identifier",
+        "uri_format": "http://doi.org/$1"
+      }
+    ],
+    "uri_format": "http://dx.doi.org/$1"
   },
   "doid": {
     "bioportal": {


### PR DESCRIPTION
Closes #287 CC @cmungall 

This PR does several things:

1. Uses the HTTP / dx.doi.org URI format string for the [`doi`](https://bioregistry.io/registry/doi) prefix
2. Adds three alternate providers into the DOI entry corresponding the the HTTPS / dx.doi.org URI format string and both variants of the doi.org URI format string.