### PR TITLE
Fix bioRxiv URI formatter, add regular expression pattern, and add extra examples

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4133,6 +4133,7 @@
   "biorxiv": {
     "description": "The bioRxiv is a preprint server for biology",
     "example": "2021.07.23.453588",
+    "pattern": "^\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6}(v\\d{1,3})?$",
     "go": {
       "homepage": "https://www.biorxiv.org/",
       "name": "bioRxiv",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4133,7 +4133,7 @@
   "biorxiv": {
     "description": "The bioRxiv is a preprint server for biology",
     "example": "2021.07.23.453588",
-    "pattern": "^\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6}(v\\d{1,3})?$",
+    "pattern": "^(\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6}(v\\d{1,3})?$",
     "go": {
       "homepage": "https://www.biorxiv.org/",
       "name": "bioRxiv",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4134,6 +4134,11 @@
     "description": "The bioRxiv is a preprint server for biology",
     "example": "2021.07.23.453588",
     "pattern": "^(\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6,8}(v\\d{1,3})?$",
+    "example_extras": [
+      "000091",
+      "000091v1",
+      "2022.01.24.477526v1"
+    ],
     "go": {
       "homepage": "https://www.biorxiv.org/",
       "name": "bioRxiv",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4140,7 +4140,7 @@
       "synonyms": [
         "BIORXIV"
       ],
-      "uri_format": "https://www.biorxiv.org/content/$1"
+      "uri_format": "https://www.biorxiv.org/content/10.1101/$1"
     },
     "homepage": "https://biorxiv.org",
     "mappings": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4133,7 +4133,7 @@
   "biorxiv": {
     "description": "The bioRxiv is a preprint server for biology",
     "example": "2021.07.23.453588",
-    "pattern": "^(\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6}(v\\d{1,3})?$",
+    "pattern": "^(\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6,8}(v\\d{1,3})?$",
     "go": {
       "homepage": "https://www.biorxiv.org/",
       "name": "bioRxiv",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4133,7 +4133,6 @@
   "biorxiv": {
     "description": "The bioRxiv is a preprint server for biology",
     "example": "2021.07.23.453588",
-    "pattern": "^(\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6,8}(v\\d{1,3})?$",
     "example_extras": [
       "000091",
       "000091v1",
@@ -4153,7 +4152,8 @@
       "go": "bioRxiv",
       "scholia": "biorxiv"
     },
-    "name": "bioRxiv"
+    "name": "bioRxiv",
+    "pattern": "^(\\d{4}\\.\\d{2}\\.\\d{2}\\.)?\\d{6,8}(v\\d{1,3})?$"
   },
   "biosample": {
     "cellosaurus": {


### PR DESCRIPTION
refs https://github.com/manubot/manubot/issues/282

The example is `2021.07.23.453588`. The following URL resolves this identifier: https://www.biorxiv.org/content/10.1101/2021.07.23.453588. The current `uri_format` results in a broken URL.