### PR TITLE
Add metaresolver

### DIFF
--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -261,7 +261,13 @@ def resolve(prefix: str, identifier: Optional[str] = None):
 @ui_blueprint.route("/metaregistry/<metaprefix>/<metaidentifier>")
 @ui_blueprint.route("/metaregistry/<metaprefix>/<metaidentifier>:<path:identifier>")
 def metaresolve(metaprefix: str, metaidentifier: str, identifier: Optional[str] = None):
-    """Redirect to a prefix page or meta-resolve the CURIE."""
+    """Redirect to a prefix page or meta-resolve the CURIE.
+
+    Test this function locally with:
+
+    - http://localhost:5000/metaregistry/obofoundry/GO
+    - http://localhost:5000/metaregistry/obofoundry/GO:0032571
+    """  # noqa:DAR101,DAR201
     if metaprefix not in manager.metaregistry:
         return abort(404, f"invalid metaprefix: {metaprefix}")
     prefix = manager.lookup_from(metaprefix, metaidentifier, normalize=True)
@@ -272,10 +278,7 @@ def metaresolve(metaprefix: str, metaidentifier: str, identifier: Optional[str] 
             f" The Bioregistry contains mappings for the following:"
             f" {list(manager.get_registry_invmap(metaprefix))}",
         )
-    if identifier is None:
-        return redirect(url_for(f".{resource.__name__}", prefix=prefix))
-    else:
-        return redirect(url_for(f".{resolve.__name__}", prefix=prefix, identifier=identifier))
+    return redirect(url_for(f".{resolve.__name__}", prefix=prefix, identifier=identifier))
 
 
 @ui_blueprint.route("/contributors/")

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1242,6 +1242,8 @@ class Registry(BaseModel):
     def get_provider_uri_prefix(self) -> str:
         """Get provider URI prefix.
 
+        :returns: The URI prefix for the provider for prefixes in this registry.
+
         >>> from bioregistry import get_registry
         >>> get_registry("fairsharing").get_provider_uri_prefix()
         'https://fairsharing.org/'

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1252,10 +1252,9 @@ class Registry(BaseModel):
         >>> get_registry("n2t").get_provider_uri_prefix()
         'https://bioregistry.io/metaregistry/n2t/'
         """
-        provider_url = self.provider_uri_format
         if self.provider_uri_format is None or not self.provider_uri_format.endswith("$1"):
             return f"{BIOREGISTRY_REMOTE_URL}/metaregistry/{self.prefix}/"
-        return provider_url.replace("$1", "")
+        return self.provider_uri_format.replace("$1", "")
 
     def get_provider_uri_format(self, prefix: str) -> Optional[str]:
         """Get the provider string.


### PR DESCRIPTION
This pull request adds a metaresolver to the Bioregistry. This does the following:

1. Creates a URI for resolving prefixes inside any registry, as in https://bioregistry.io/metaregistry/obofoundry/GO. This solves two cases:
   1. even if it doesn't have prefix-specific pages like cellosaurus, scholia, and NCBI
   2. This URI is also appropriate for poorly-behaved resources like N2T whose prefix pages end with a semicolon
2. Creates a URI that's a resolver for CURIEs that use prefixes from each registry, as in https://bioregistry.io/metaregistry/obofoundry/GO:0032571

Under the hood, this maps the registry-specific prefix back to a bioregistry canonical prefix then forwards resolution to the standard resolution endpoint.