### PR TITLE
Automated getting OBO Foundry examples

### DIFF
--- a/src/bioregistry/align/obofoundry.py
+++ b/src/bioregistry/align/obofoundry.py
@@ -5,7 +5,7 @@
 from typing import Mapping, Sequence
 
 from bioregistry.align.utils import Aligner
-from bioregistry.external.obofoundry import get_obofoundry
+from bioregistry.external.obofoundry import get_obofoundry, get_obofoundry_example
 
 __all__ = [
     "OBOFoundryAligner",
@@ -34,6 +34,14 @@ class OBOFoundryAligner(Aligner):
             external_entry["name"].strip(),
             external_entry.get("description", "").strip(),
         ]
+
+    def _align_action(self, bioregistry_id, external_id, external_entry):
+        super()._align_action(bioregistry_id, external_id, external_entry)
+        if self.manager.get_example(bioregistry_id) or self.manager.has_no_terms(bioregistry_id):
+            return
+        example = get_obofoundry_example(external_id)
+        if example:
+            self.internal_registry[bioregistry_id]["example"] = example
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/external/obofoundry.py
+++ b/src/bioregistry/external/obofoundry.py
@@ -4,8 +4,10 @@
 
 import json
 import logging
+from typing import Optional
 
 import click
+import requests
 import yaml
 from pystow.utils import download
 
@@ -13,6 +15,7 @@ from bioregistry.data import EXTERNAL
 
 __all__ = [
     "get_obofoundry",
+    "get_obofoundry_example",
 ]
 
 logger = logging.getLogger(__name__)
@@ -93,6 +96,16 @@ def _parse_activity_status(record) -> bool:
         return True
     else:
         raise ValueError(f"unexpected activity value: {status}")
+
+
+def get_obofoundry_example(prefix: str) -> Optional[str]:
+    """Get an example identifier from the OBO Library PURL configuration."""
+    url = f"https://raw.githubusercontent.com/OBOFoundry/purl.obolibrary.org/master/config/{prefix}.yml"
+    data = yaml.safe_load(requests.get(url).content)
+    examples = data.get("example_terms")
+    if not examples:
+        return None
+    return examples[0].rsplit("_")[-1]
 
 
 @click.command()

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -529,10 +529,7 @@ def get_example(prefix: str) -> Optional[str]:
 
 def has_no_terms(prefix: str) -> bool:
     """Check if the prefix is specifically noted to not have terms."""
-    entry = get_resource(prefix)
-    if entry is None or entry.no_own_terms is None:
-        return False
-    return entry.no_own_terms
+    return manager.has_no_terms(prefix)
 
 
 def is_deprecated(prefix: str) -> bool:

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -266,6 +266,13 @@ class Manager:
             return None
         return entry.get_example()
 
+    def has_no_terms(self, prefix: str) -> bool:
+        """Get if the entry has been annotated to not have own terms."""
+        entry = self.get_resource(prefix)
+        if entry is None or entry.no_own_terms is None:
+            return False
+        return entry.no_own_terms
+
     def is_deprecated(self, prefix: str) -> bool:
         """Return if the given prefix corresponds to a deprecated resource."""
         entry = self.get_resource(prefix)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,11 @@
+import unittest
+
+from bioregistry.external.obofoundry import get_obofoundry_example
+
+
+class TestUtils(unittest.TestCase):
+    """Test utilities."""
+
+    def test_obolibrary_example(self):
+        """Test looking up an example from the OBO Foundry PURL service configuration."""
+        self.assertEqual("0011124", get_obofoundry_example("pcl"))

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for downloading external data."""
+
 import unittest
 
 from bioregistry.external.obofoundry import get_obofoundry_example


### PR DESCRIPTION
Closes #300

While https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1622 received relatively little interest, this PR automates grabbing information on the OBO Foundry's PURL service configuration repository, which is also on GitHub