### PR TITLE
Use preferred DOI uri_format

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -11915,6 +11915,7 @@
       "prefix": "DOI",
       "uri_format": "https://dx.doi.org/$1"
     },
+    "comment": "The [DOI resolution factsheet](https://www.doi.org/factsheets/DOIProxy.html) specifies that `https://doi.org/DOI` is the preferred format:\n\n> Users may resolve DOI names that are structured to use the DOI system Proxy Server (https://doi.org (preferred)). The resolution of the DOI name in this case depends on the use of URL syntax: the example DOI name doi:10.10.123/456 would be resolved from the address: \"https://doi.org/10.123/456\". Any standard browser encountering a DOI name in this form will be able to resolve it. The proxy service (both doi.org and the **earlier but no longer preferred** dx.doi.org) is accessible over IPv6, and supports DNSSEC. The proxy servers respond to HTTPS (**preferred**) as well as HTTP requests.",
     "fairsharing": {
       "abbreviation": "DOI",
       "description": "The digital object identifier (DOI) system originated in a joint initiative of three trade associations in the publishing industry (International Publishers Association; International Association of Scientific, Technical and Medical Publishers; Association of American Publishers). The system was announced at the Frankfurt Book Fair 1997. The International DOI® Foundation (IDF) was created to develop and manage the DOI system, also in 1997. The DOI system was adopted as International Standard ISO 26324 in 2012. The DOI system implements the Handle System and adds a number of new features. The DOI system provides an infrastructure for persistent unique identification of objects of any type. The DOI system is designed to work over the Internet. A DOI name is permanently assigned to an object to provide a resolvable persistent network link to current information about that object, including where the object, or information about it, can be found on the Internet. While information about an object can change over time, its DOI name will not change. A DOI name can be resolved within the DOI system to values of one or more types of data relating to the object identified by that DOI name, such as a URL, an e-mail address, other identifiers and descriptive metadata. The DOI system enables the construction of automated services and transactions. Applications of the DOI system include but are not limited to managing information and documentation location and access; managing metadata; facilitating electronic transactions; persistent unique identification of any form of any data; and commercial and non-commercial transactions. The content of an object associated with a DOI name is described unambiguously by DOI metadata, based on a structured extensible data model that enables the object to be associated with metadata of any desired degree of precision and granularity to support description and services. The data model supports interoperability between DOI applications. The scope of the DOI system is not defined by reference to the type of content (format, etc.) of the referent, but by reference to the functionalities it provides and the context of use. The DOI system provides, within networks of DOI applications, for unique identification, persistence, resolution, metadata and semantic interoperability.",
@@ -11977,6 +11978,13 @@
     },
     "providers": [
       {
+        "code": "dx_doi_http",
+        "description": "An alternate provider from the DOI website using HTTP",
+        "homepage": "https://www.doi.org",
+        "name": "Digital Object Identifier",
+        "uri_format": "http://dx.doi.org/$1"
+      },
+      {
         "code": "dx_doi_https",
         "description": "An alternate provider from the DOI website using HTTPS",
         "homepage": "https://www.doi.org",
@@ -11984,19 +11992,16 @@
         "uri_format": "https://dx.doi.org/$1"
       },
       {
-        "code": "doi_https",
-        "description": "An alternate provider from the DOI website",
-        "homepage": "https://www.doi.org",
-        "name": "Digital Object Identifier",
-        "uri_format": "https://doi.org/$1"
-      },
-      {
         "code": "doi_http",
-        "description": "An alternate provider from the DOI website",
+        "description": "An alternate provider from the DOI website using HTTP",
         "homepage": "https://www.doi.org",
         "name": "Digital Object Identifier",
         "uri_format": "http://doi.org/$1"
       }
+    ],
+    "references": [
+      "https://github.com/biopragmatics/bioregistry/issues/287",
+      "https://github.com/biopragmatics/bioregistry/pull/316"
     ],
     "uri_format": "https://doi.org/$1"
   },

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -11998,7 +11998,7 @@
         "uri_format": "http://doi.org/$1"
       }
     ],
-    "uri_format": "http://dx.doi.org/$1"
+    "uri_format": "https://doi.org/$1"
   },
   "doid": {
     "bioportal": {


### PR DESCRIPTION
refs https://github.com/biopragmatics/bioregistry/issues/287
reverts part of https://github.com/biopragmatics/bioregistry/pull/288

The [DOI resolution factsheet](https://www.doi.org/factsheets/DOIProxy.html) specifies that `https://doi.org/DOI` is the preferred format:

> Users may resolve DOI names that are structured to use the DOI system Proxy Server (https://doi.org (preferred)). The resolution of the DOI name in this case depends on the use of URL syntax: the example DOI name doi:10.10.123/456 would be resolved from the address: "https://doi.org/10.123/456". Any standard browser encountering a DOI name in this form will be able to resolve it. The proxy service (both doi.org and the **earlier but no longer preferred** dx.doi.org) is accessible over IPv6, and supports DNSSEC. The proxy servers respond to HTTPS (**preferred**) as well as HTTP requests.

