### PR TITLE
CI: skip scheduled builds on forks

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -7,6 +7,7 @@ jobs:
   homepage:
     name: Homepage Check
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' || github.repository == 'biopragmatics/bioregistry' }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -20,6 +21,7 @@ jobs:
   providers:
     name: Provider Check
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' || github.repository == 'biopragmatics/bioregistry' }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' || github.repository == 'biopragmatics/bioregistry' }}
     steps:
       - uses: actions/checkout@master
         with:


### PR DESCRIPTION
refs https://github.com/biopragmatics/bioregistry/issues/320

I was getting a bunch of emails from scheduled workflows failing on my fork. I don't think the scheduled workflows are relevant to forks. Workflow dispatch of these workflows on forks should still be possible.