### PR TITLE
Improve credit to contributors

### DIFF
--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -236,10 +236,21 @@
                         </ul>
                     </dd>
                 {% endif %}
-                {% if resource.contributor %}
-                    <dt>Contributor</dt>
+                {% if resource.contributor or resource.contributor_extras %}
+                    <dt>Contributors</dt>
                     <dd>
-                        {{ utils.render_author(resource.contributor, link=url_for('ui.contributor', orcid=resource.contributor.orcid)) }}
+                        <ul>
+                            {% if resource.contributor %}
+                                <li>
+                                    <span class="badge badge-info">submitter</span> {{ utils.render_author(resource.contributor, link=url_for('ui.contributor', orcid=resource.contributor.orcid)) }}
+                                </li>
+                            {% endif %}
+                            {% for contributor in resource.contributor_extras %}
+                                <li>
+                                    <span class="badge badge-info">contributor</span> {{ utils.render_author(contributor, link=url_for('ui.contributor', orcid=contributor.orcid)) }}
+                                </li>
+                            {% endfor %}
+                        </ul>
                     </dd>
                 {% endif %}
                 {% if resource.reviewer %}

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -247,7 +247,7 @@
                                     <span class="badge badge-info">submitter</span> {{ utils.render_author(resource.contributor, link=url_for('ui.contributor', orcid=resource.contributor.orcid)) }}
                                 </li>
                             {% endif %}
-                            {% for contributor in resource.contributor_extras %}
+                            {% for contributor in resource.contributor_extras or [] %}
                                 <li>
                                     <span class="badge badge-info">contributor</span> {{ utils.render_author(contributor, link=url_for('ui.contributor', orcid=contributor.orcid)) }}
                                 </li>

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -13280,6 +13280,19 @@
       "prefix": "DOI",
       "uri_format": "https://dx.doi.org/$1"
     },
+    "contributor_extras": [
+      {
+        "email": "cjmungall@lbl.gov",
+        "github": "cmungall",
+        "name": "Chris Mungall",
+        "orcid": "0000-0002-6601-2165"
+      },
+      {
+        "github": "dhimmel",
+        "name": "Daniel Himmelstein",
+        "orcid": "0000-0002-3012-7446"
+      }
+    ],
     "fairsharing": {
       "abbreviation": "DOI",
       "description": "The digital object identifier (DOI) system originated in a joint initiative of three trade associations in the publishing industry (International Publishers Association; International Association of Scientific, Technical and Medical Publishers; Association of American Publishers). The system was announced at the Frankfurt Book Fair 1997. The International DOI® Foundation (IDF) was created to develop and manage the DOI system, also in 1997. The DOI system was adopted as International Standard ISO 26324 in 2012. The DOI system implements the Handle System and adds a number of new features. The DOI system provides an infrastructure for persistent unique identification of objects of any type. The DOI system is designed to work over the Internet. A DOI name is permanently assigned to an object to provide a resolvable persistent network link to current information about that object, including where the object, or information about it, can be found on the Internet. While information about an object can change over time, its DOI name will not change. A DOI name can be resolved within the DOI system to values of one or more types of data relating to the object identified by that DOI name, such as a URL, an e-mail address, other identifiers and descriptive metadata. The DOI system enables the construction of automated services and transactions. Applications of the DOI system include but are not limited to managing information and documentation location and access; managing metadata; facilitating electronic transactions; persistent unique identification of any form of any data; and commercial and non-commercial transactions. The content of an object associated with a DOI name is described unambiguously by DOI metadata, based on a structured extensible data model that enables the object to be associated with metadata of any desired degree of precision and granularity to support description and services. The data model supports interoperability between DOI applications. The scope of the DOI system is not defined by reference to the type of content (format, etc.) of the referent, but by reference to the functionalities it provides and the context of use. The DOI system provides, within networks of DOI applications, for unique identification, persistence, resolution, metadata and semantic interoperability.",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -101,6 +101,7 @@
   "4dn.replicate": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -239,6 +240,7 @@
   "ac": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -895,6 +897,7 @@
   "alzforum.mutation": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -2148,6 +2151,7 @@
   "asrp": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -2609,6 +2613,7 @@
   "bactibase": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -2633,6 +2638,7 @@
   "bams": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -3177,6 +3183,7 @@
     "comment": "INDRA uses bel as a catch-all for scomp/sfam",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -3862,6 +3869,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -4432,6 +4440,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -4470,6 +4479,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -5002,6 +5012,7 @@
   "bmrb.restraint": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -5077,6 +5088,7 @@
   "bpdb": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -5199,6 +5211,7 @@
     "comment": "An alernative vocabulary that has been aligned and integrated in Sequence Ontology (SO).",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -5623,6 +5636,7 @@
   "caloha": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -6144,6 +6158,7 @@
   "cba": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -6825,6 +6840,12 @@
     }
   },
   "cellosaurus.resource": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "description": "The set of prefixes used in the Cellosaurus resource",
     "example": "4DN",
     "homepage": "https://web.expasy.org/cellosaurus/",
@@ -6997,6 +7018,7 @@
   "cgnc": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -8105,6 +8127,7 @@
   "citexplore": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -9809,6 +9832,7 @@
     "pattern": "^CNP\\d{7}$",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -9864,6 +9888,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -9900,6 +9925,7 @@
     "comment": "not really sure where the source is. this also links to a system called athena. I was not able to figure out what COHD stands for.",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -10014,6 +10040,7 @@
   "come": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -10241,6 +10268,7 @@
   "conso": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -10468,6 +10496,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -10525,6 +10554,7 @@
     "comment": "Part of cell ontology but deprecated, see https://github.com/obophenotype/cell-ontology/issues/572",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -13128,6 +13158,12 @@
     "appears_in": [
       "efo"
     ],
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "deprecated": true,
     "description": "Legacy disease classes that later became MONDO",
     "download_obo": "https://github.com/obophenotype/human-disease-ontology/raw/master/src/experimental/missing-omc.obo",
@@ -14213,6 +14249,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -14335,6 +14372,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -14616,6 +14654,7 @@
   "ecmdb": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -15947,6 +15986,7 @@
   "emolecules": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -16845,6 +16885,7 @@
   "epcc": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -17292,6 +17333,7 @@
   "eurofir": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -17330,6 +17372,7 @@
   "evm": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -18115,6 +18158,7 @@
   "fbrf": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -18159,6 +18203,7 @@
   "fbtc": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -19308,6 +19353,7 @@
     "preferred_prefix": "FYECO",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     }
@@ -19315,6 +19361,7 @@
   "fyler": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -19660,6 +19707,7 @@
     "comment": "see comment here: https://github.com/obophenotype/ncbitaxon/issues/47",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -20657,6 +20705,7 @@
   "ghr": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -21626,6 +21675,12 @@
     }
   },
   "go.resource": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "description": "A database-specific registry supporting curation in the Gene Ontology",
     "example": "CHEBI",
     "homepage": "http://geneontology.org/",
@@ -21724,6 +21779,7 @@
   "goeco": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -22258,6 +22314,8 @@
   },
   "grassbase": {
     "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -22467,6 +22525,7 @@
   "gsfa": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -22593,6 +22652,7 @@
     "comment": "Identifiers appearing in MONDO don't match any of the resources apparent endpoints",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -23630,6 +23690,7 @@
   "hms.lincs.compound": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -23646,6 +23707,7 @@
   "hog": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -25782,6 +25844,7 @@
   "imdrf": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -26468,6 +26531,7 @@
     "pattern": "^(E|D|S)RR[0-9]{6,}$",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -26969,6 +27033,7 @@
   "iro": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -28424,6 +28489,7 @@
     "comment": "Website is down, now it redirects to something else that is not related",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -29186,6 +29252,7 @@
   "lncipedia": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -29340,6 +29407,7 @@
     "pattern": "^LTS\\d{7}$",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -29416,6 +29484,7 @@
   "lspci": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -29938,6 +30007,7 @@
     ],
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -31523,6 +31593,7 @@
   "mgnify.analysis": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -31688,6 +31759,7 @@
     "comment": "same as MAT",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -32053,6 +32125,7 @@
   "mim.ps": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -32421,6 +32494,7 @@
   "mirbase.family": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -34723,6 +34797,12 @@
     }
   },
   "n2t": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "description": "An ARK resolver as well as resolver built with common prefixes as in Identifiers.org",
     "example": "chebi",
     "homepage": "https://n2t.net",
@@ -34732,6 +34812,7 @@
   "namerxn": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -35087,6 +35168,7 @@
   "ncats.drug": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -35097,6 +35179,12 @@
     "uri_format": "https://drugs.ncats.io/drug/$1"
   },
   "ncbi.resource": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "description": "A database-specific registry supporting curation in the NCBI GenBank and related NCBI resources",
     "example": "ECOCYC",
     "homepage": "https://www.ncbi.nlm.nih.gov/genbank/collab/db_xref/",
@@ -35822,6 +35910,7 @@
   "ndex": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -36282,6 +36371,7 @@
   "nextprot.family": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -36467,6 +36557,7 @@
   "nist": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -36498,6 +36589,7 @@
   "nlxanat": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -36514,6 +36606,7 @@
     ],
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -36557,6 +36650,7 @@
     "pattern": "^[\\w\\-.]{3,}$",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -36868,6 +36962,7 @@
   "npass": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -38616,6 +38711,7 @@
   "omop": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -38786,6 +38882,7 @@
     ],
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -40481,6 +40578,7 @@
   "pathbank": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -40723,6 +40821,7 @@
     },
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -41464,6 +41563,7 @@
   "peff": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -41644,6 +41744,7 @@
   "pesticides": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -41758,6 +41859,7 @@
   "pfam.clan": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -41771,6 +41873,7 @@
   "pfr": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -41925,6 +42028,7 @@
   "pharmacodb.dataset": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -41937,6 +42041,7 @@
   "pharmacodb.tissue": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -42460,6 +42565,7 @@
   "pictar": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -43607,6 +43713,7 @@
   "ppdb": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -43692,6 +43799,7 @@
   "ppr": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -44803,6 +44911,7 @@
   "pspub": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -45550,6 +45659,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -45868,6 +45978,7 @@
   "receptome.family": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -46840,6 +46951,7 @@
   "rnamod": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -47609,6 +47721,7 @@
   "sael": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -47625,6 +47738,7 @@
     "comment": "spider stuff!",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -47922,6 +48036,7 @@
   "schem": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -47932,6 +48047,12 @@
     "pattern": "^A\\d{4}$"
   },
   "scholia.resource": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "description": "A frontend to Wikidata",
     "example": "doi",
     "homepage": "https://scholia.toolforge.org/",
@@ -47941,6 +48062,7 @@
   "scomp": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -48140,6 +48262,7 @@
   "sdis": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -48391,6 +48514,7 @@
   "sfam": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -48892,6 +49016,7 @@
     "pattern": "^SIGNOR-\\d+$",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     }
@@ -49203,6 +49328,7 @@
   "smid": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -49336,6 +49462,7 @@
   "snap": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -49478,6 +49605,7 @@
   "snornabase": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -49712,6 +49840,7 @@
     "comment": "see also snap. This ontology only exists in description in the paper and does not have an associated web resource",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -49980,6 +50109,7 @@
   "ssbd.project": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -50976,6 +51106,7 @@
   "syoid": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -51670,6 +51801,7 @@
   "th": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -51746,6 +51878,7 @@
     },
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -52677,6 +52810,7 @@
     "comment": "All of these are typedefs in uberon now",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -53445,6 +53579,7 @@
   "uniprot.disease": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -53557,6 +53692,12 @@
     "uri_format": "https://www.uniprot.org/locations/SL-$1"
   },
   "uniprot.resource": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
     "description": "The cross-references section of UniProtKB entries displays explicit and implicit links to databases such as nucleotide sequence databases, model organism databases and genomics and proteomics resources.",
     "example": "0174",
     "homepage": "https://www.uniprot.org/database/",
@@ -53601,6 +53742,7 @@
   "uniprot.var": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -53751,6 +53893,7 @@
     "comment": "The website is dead, there are no places to get the source information except inside https://oolonek.github.io/ISDB/.",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -54432,6 +54575,7 @@
   "vega": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -55106,6 +55250,7 @@
   "vsdb": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -55268,6 +55413,7 @@
     "comment": "The example corresponds to acetaminophen",
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -55555,6 +55701,7 @@
   "webelements": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -56164,6 +56311,7 @@
     "pattern": "^AT\\d+$",
     "reviewer": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -56598,6 +56746,7 @@
     ],
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
@@ -56748,6 +56897,7 @@
   "ymdb": {
     "contributor": {
       "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -40804,6 +40804,14 @@
       "name": "Nico Matentzoglu",
       "orcid": "0000-0002-7356-1779"
     },
+    "contributor_extras": [
+      {
+        "email": "cthoyt@gmail.com",
+        "github": "cthoyt",
+        "name": "Charles Tapley Hoyt",
+        "orcid": "0000-0003-4423-4370"
+      }
+    ],
     "description": "PAV is a lightweight ontology for tracking provenance, authorship, and versioning. It specializes the W3C provenance ontology PROV-O in order to describe authorship, curation and digital creation of online resources.",
     "example": "authoredBy",
     "fairsharing": {

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -333,6 +333,14 @@
             }
           ]
         },
+        "contributor_extras": {
+          "title": "Contributor Extras",
+          "description": "Additional contributors besides the original submitter.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Author"
+          }
+        },
         "reviewer": {
           "title": "Reviewer",
           "description": "The reviewer of the prefix to the Bioregistry, including at a minimum their name and ORCiD and optionall their email address and GitHub handle. All entries curated through the Bioregistry GitHub Workflow should contain this field pointing to the person who reviewed it on GitHub.",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -324,6 +324,9 @@ class Resource(BaseModel):
     """
         ),
     )
+    contributor_extras: Optional[List[Author]] = Field(
+        description="Additional contributors besides the original submitter.",
+    )
 
     reviewer: Optional[Author] = Field(
         description=_dedent(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -613,3 +613,29 @@ class TestRegistry(unittest.TestCase):
         for key, values in REVERSE_LICENSES.items():
             with self.subTest(key=key):
                 self.assertEqual(len(values), len(set(values)), msg=f"duplicates in {key}")
+
+    def test_contributors(self):
+        """Check contributors have minimal metadata."""
+        for prefix, resource in self.registry.items():
+            with self.subTest(prefix=prefix):
+                if not resource.contributor and not resource.contributor_extras:
+                    self.assertNotEqual(0, len(resource.get_mappings()))
+                    continue
+                if resource.contributor is not None:
+                    self.assertIsNotNone(resource.contributor.name)
+                    self.assertIsNotNone(resource.contributor.orcid)
+                    self.assertIsNotNone(resource.contributor.github)
+                for contributor in resource.contributor_extras or []:
+                    self.assertIsNotNone(contributor.name)
+                    self.assertIsNotNone(contributor.orcid)
+                    self.assertIsNotNone(contributor.github)
+
+    def test_reviewers(self):
+        """Check reviewers have minimal metadata."""
+        for prefix, resource in self.registry.items():
+            if not resource.reviewer:
+                continue
+            with self.subTest(prefix=prefix):
+                self.assertIsNotNone(resource.reviewer.name)
+                self.assertIsNotNone(resource.reviewer.orcid)
+                self.assertIsNotNone(resource.reviewer.github)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -78,6 +78,7 @@ class TestRegistry(unittest.TestCase):
             "preferred_prefix",
             "providers",
             "example_extras",
+            "contributor_extras",
         }
         keys.update(bioregistry.read_metaregistry())
         with open(BIOREGISTRY_PATH, encoding="utf-8") as file:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -639,3 +639,12 @@ class TestRegistry(unittest.TestCase):
                 self.assertIsNotNone(resource.reviewer.name)
                 self.assertIsNotNone(resource.reviewer.orcid)
                 self.assertIsNotNone(resource.reviewer.github)
+
+    def test_contacts(self):
+        """Check contacts have minimal metadata."""
+        for prefix, resource in self.registry.items():
+            if not resource.contact:
+                continue
+            with self.subTest(prefix=prefix):
+                self.assertIsNotNone(resource.contact.name)
+                self.assertIsNotNone(resource.contact.email)


### PR DESCRIPTION
Since I just finished #316, I realized that there wasn't a good way to give credit to people who make modifications after a prefix is minted. This solves that with an extra field.

This PR also adds additional tests for contact, reviewer, and contributor metadata standards.

- DOI has contributors but no submitter
- PAV has a submitter and contributor