### PR TITLE
Update GlycoNAVI pattern

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -20743,6 +20743,9 @@
     }
   },
   "glyconavi": {
+    "example_extras": [
+      "GN_GlyTouCan_G03681DA"
+    ],
     "fairsharing": {
       "abbreviation": "GlycoNAVI",
       "description": "GlycoNAVI is a repository of data relevant to carbohydrate research. It contains a free suite of carbohydrate research tools organized by domain, including glycans, proteins, lipids, genes, diseases and samples.",
@@ -20771,7 +20774,8 @@
       "prefix": "glyconavi",
       "sampleId": "GN_G03681DA",
       "uri_format": "https://glyconavi.org/hub/?id=$1"
-    }
+    },
+    "pattern": "^GN_[A-Za-z0-9_:]+$"
   },
   "glycopost": {
     "fairsharing": {


### PR DESCRIPTION
The Bioregistry pulls from many external registries and reuses their content when possible, but sometimes the data becomes out of date or needs to be fixed in the upstream external registries, and their curation teams are slow to respond.

This pull request demonstrates that the Bioregistry can be used to override incorrect/outdated content from those registries.

See also request to Identifiers.org in https://github.com/identifiers-org/identifiers-org.github.io/issues/180