### PR TITLE
Update MIRIAM standardization

### DIFF
--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1176,7 +1176,7 @@ class Resource(BaseModel):
         >>> get_resource("pdb").miriam_standardize_identifier('00000020')
         '00000020'
         """
-        if not self.get_miriam_uri_prefix():
+        if not self.get_identifiers_org_prefix():
             # No need to normalize for MIRIAM if it's not listed there
             return identifier
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1176,6 +1176,10 @@ class Resource(BaseModel):
         >>> get_resource("pdb").miriam_standardize_identifier('00000020')
         '00000020'
         """
+        if not self.get_miriam_uri_prefix():
+            # No need to normalize for MIRIAM if it's not listed there
+            return identifier
+
         # A "banana" is an embedded prefix that isn't actually part of the identifier.
         # Usually this corresponds to the prefix itself, with some specific stylization
         # such as in the case of FBbt. The banana does NOT include a colon ":" at the end


### PR DESCRIPTION
This PR makes sure that bananas aren't added for MIRIAM-flavored standardization if the prefix isn't itself mapped to a MIRIAM prefix