### PR TITLE
Add first table exports for paper

### DIFF
--- a/exports/tables/comparison_goveranance.tex
+++ b/exports/tables/comparison_goveranance.tex
@@ -1,34 +1,34 @@
 \begin{table}
 \centering
-\caption{Caption of this table, nice}
+\caption{A survey of registries' governance and maintenance models. The scope column describes the kinds of prefixes contained within the registry. The status column is active if the registry is currently being maintained and is responsive to public external feedback, unresponsive if the registry is currently being maintained but is not responsive to public external feedback, and inactive otherwise. The imports external prefixes column denotes if the registry reuses and harmonizes content from external registries. The curates novel prefixes column denotes whether novel curation of prefixes and their associated metadata is done for the registry. The accepts external contributions column denotes whether the registry has both the governance model and technical infrastructure for accepting external contributions in the form of the suggestion of new prefixes, improvement to metadata associated with existing prefixes, etc. The uses public version control column denotes whether the data underlying the registry and/or its associated code are stored in a publicly accessible version-controlled system (e.g., git via GitHub). The has public review team column denotes whether there is a publicly accessible list of the reviewers. Asterisks in this column denote that rather than an explicit list, the reviewers can be inferred through the registry's version control system.}
 \label{registry-comparison-governance}
-\begin{tabular}{llllll}
+\begin{tabular}{llllllll}
 \toprule
-           Name & Accepts External Contributions & Public Version Control & Review Team &           Scope &       Status \\
+           Name &           Scope &       Status & Imports External Prefixes & Curates Novel Prefixes & Accepts External Contributions & Uses Public Version Control & Has Public Review Team \\
 \midrule
-        AberOWL &                                &                        &         N/A &  Bio-Ontologies &       Active \\
-     AgroPortal &                              ✓ &                        &     Private & Agro-Ontologies &       Active \\
-     BioContext &                              ✓ &                      ✓ &  Inferrable &        Internal &       Active \\
-        Biolink &                              ✓ &                      ✓ &  Inferrable &        Internal &       Active \\
-      BioPortal &                              ✓ &                        &     Private &  Bio-Ontologies &       Active \\
-    Bioregistry &                              ✓ &                      ✓ &      Public &   Life Sciences &       Active \\
-    Cellosaurus &                                &                        &         N/A &        Internal &       Active \\
-        CHEMINF &                              ✓ &                      ✓ &  Inferrable &       Chemistry & Unresponsive \\
-       Crop OCT &                              ✓ &                        &      Public & Agro-Ontologies &       Active \\
-      EcoPortal &                              ✓ &                        &     Private &  Eco-Ontologies &       Active \\
-    FAIRSharing &                              ✓ &                        &     Private &   Life Sciences &       Active \\
-             GO &                              ✓ &                      ✓ &  Inferrable &        Internal &     Inactive \\
-Identifiers.org &                              ✓ &                        &     Private &   Life Sciences & Unresponsive \\
-  Name-to-Thing &                                &                        &         N/A &   Life Sciences &       Active \\
-           NCBI &                                &                        &         N/A &        Internal &     Inactive \\
-    OBO Foundry &                              ✓ &                      ✓ &      Public &  Bio-Ontologies &       Active \\
-            OLS &                              ✓ &                        &  Inferrable &  Bio-Ontologies &       Active \\
-        OntoBee &                                &                        &         N/A &  Bio-Ontologies &       Active \\
-      Prefix.cc &                              ✓ &                      ✓ &         N/A &         General &       Active \\
- Prefix Commons &                              ✓ &                        &      Public &   Life Sciences &       Active \\
-        Scholia &                              ✓ &                      ✓ &  Inferrable &   Life Sciences &       Active \\
-        UniProt &                                &                        &         N/A &        Internal &       Active \\
-       Wikidata &                              ✓ &                        &  Inferrable &         General &       Active \\
+        AberOWL &  Bio-Ontologies &       Active &                           &                        &                                &                             &                        \\
+     AgroPortal & Agro-Ontologies &       Active &                           &                      ✓ &                              ✓ &                             &                      ✗ \\
+     BioContext &        Internal &       Active &                           &                      ✓ &                              ✓ &                           ✓ &                     ✓* \\
+        Biolink &        Internal &       Active &                           &                      ✓ &                              ✓ &                           ✓ &                     ✓* \\
+      BioPortal &  Bio-Ontologies &       Active &                           &                      ✓ &                              ✓ &                             &                      ✗ \\
+    Bioregistry &   Life Sciences &       Active &                         ✓ &                      ✓ &                              ✓ &                           ✓ &                      ✓ \\
+    Cellosaurus &        Internal &       Active &                           &                      ✓ &                                &                             &                        \\
+        CHEMINF &       Chemistry & Unresponsive &                           &                      ✓ &                              ✓ &                           ✓ &                     ✓* \\
+       Crop OCT & Agro-Ontologies &       Active &                           &                      ✓ &                              ✓ &                             &                      ✓ \\
+      EcoPortal &  Eco-Ontologies &       Active &                           &                      ✓ &                              ✓ &                             &                      ✗ \\
+    FAIRSharing &   Life Sciences &       Active &                           &                      ✓ &                              ✓ &                             &                      ✗ \\
+             GO &        Internal &     Inactive &                           &                      ✓ &                              ✓ &                           ✓ &                     ✓* \\
+Identifiers.org &   Life Sciences & Unresponsive &                           &                      ✓ &                              ✓ &                             &                      ✗ \\
+  Name-to-Thing &   Life Sciences &       Active &                         ✓ &                        &                                &                             &                        \\
+           NCBI &        Internal &     Inactive &                           &                      ✓ &                                &                             &                        \\
+    OBO Foundry &  Bio-Ontologies &       Active &                           &                      ✓ &                              ✓ &                           ✓ &                      ✓ \\
+            OLS &  Bio-Ontologies &       Active &                           &                        &                              ✓ &                             &                     ✓* \\
+        OntoBee &  Bio-Ontologies &       Active &                           &                        &                                &                             &                        \\
+      Prefix.cc &         General &       Active &                           &                      ✓ &                              ✓ &                           ✓ &                        \\
+ Prefix Commons &   Life Sciences &       Active &                           &                      ✓ &                              ✓ &                             &                      ✓ \\
+        Scholia &   Life Sciences &       Active &                           &                      ✓ &                              ✓ &                           ✓ &                     ✓* \\
+        UniProt &        Internal &       Active &                           &                      ✓ &                                &                             &                        \\
+       Wikidata &         General &       Active &                           &                      ✓ &                              ✓ &                             &                     ✓* \\
 \bottomrule
 \end{tabular}
 \end{table}

--- a/exports/tables/comparison_goveranance.tex
+++ b/exports/tables/comparison_goveranance.tex
@@ -1,0 +1,34 @@
+\begin{table}
+\centering
+\caption{Caption of this table, nice}
+\label{registry-comparison-governance}
+\begin{tabular}{llllll}
+\toprule
+           Name & Accepts External Contributions & Public Version Control & Review Team &           Scope &       Status \\
+\midrule
+        AberOWL &                                &                        &         N/A &  Bio-Ontologies &       Active \\
+     AgroPortal &                              ✓ &                        &     Private & Agro-Ontologies &       Active \\
+     BioContext &                              ✓ &                      ✓ &  Inferrable &        Internal &       Active \\
+        Biolink &                              ✓ &                      ✓ &  Inferrable &        Internal &       Active \\
+      BioPortal &                              ✓ &                        &     Private &  Bio-Ontologies &       Active \\
+    Bioregistry &                              ✓ &                      ✓ &      Public &   Life Sciences &       Active \\
+    Cellosaurus &                                &                        &         N/A &        Internal &       Active \\
+        CHEMINF &                              ✓ &                      ✓ &  Inferrable &       Chemistry & Unresponsive \\
+       Crop OCT &                              ✓ &                        &      Public & Agro-Ontologies &       Active \\
+      EcoPortal &                              ✓ &                        &     Private &  Eco-Ontologies &       Active \\
+    FAIRSharing &                              ✓ &                        &     Private &   Life Sciences &       Active \\
+             GO &                              ✓ &                      ✓ &  Inferrable &        Internal &     Inactive \\
+Identifiers.org &                              ✓ &                        &     Private &   Life Sciences & Unresponsive \\
+  Name-to-Thing &                                &                        &         N/A &   Life Sciences &       Active \\
+           NCBI &                                &                        &         N/A &        Internal &     Inactive \\
+    OBO Foundry &                              ✓ &                      ✓ &      Public &  Bio-Ontologies &       Active \\
+            OLS &                              ✓ &                        &  Inferrable &  Bio-Ontologies &       Active \\
+        OntoBee &                                &                        &         N/A &  Bio-Ontologies &       Active \\
+      Prefix.cc &                              ✓ &                      ✓ &         N/A &         General &       Active \\
+ Prefix Commons &                              ✓ &                        &      Public &   Life Sciences &       Active \\
+        Scholia &                              ✓ &                      ✓ &  Inferrable &   Life Sciences &       Active \\
+        UniProt &                                &                        &         N/A &        Internal &       Active \\
+       Wikidata &                              ✓ &                        &  Inferrable &         General &       Active \\
+\bottomrule
+\end{tabular}
+\end{table}

--- a/exports/tables/comparison_goveranance.tsv
+++ b/exports/tables/comparison_goveranance.tsv
@@ -1,24 +1,24 @@
-Name	Accepts External Contributions	Public Version Control	Review Team	Scope	Status
-AberOWL			N/A	Bio-Ontologies	Active
-AgroPortal	✓		Private	Agro-Ontologies	Active
-BioContext	✓	✓	Inferrable	Internal	Active
-Biolink	✓	✓	Inferrable	Internal	Active
-BioPortal	✓		Private	Bio-Ontologies	Active
-Bioregistry	✓	✓	Public	Life Sciences	Active
-Cellosaurus			N/A	Internal	Active
-CHEMINF	✓	✓	Inferrable	Chemistry	Unresponsive
-Crop OCT	✓		Public	Agro-Ontologies	Active
-EcoPortal	✓		Private	Eco-Ontologies	Active
-FAIRSharing	✓		Private	Life Sciences	Active
-GO	✓	✓	Inferrable	Internal	Inactive
-Identifiers.org	✓		Private	Life Sciences	Unresponsive
-Name-to-Thing			N/A	Life Sciences	Active
-NCBI			N/A	Internal	Inactive
-OBO Foundry	✓	✓	Public	Bio-Ontologies	Active
-OLS	✓		Inferrable	Bio-Ontologies	Active
-OntoBee			N/A	Bio-Ontologies	Active
-Prefix.cc	✓	✓	N/A	General	Active
-Prefix Commons	✓		Public	Life Sciences	Active
-Scholia	✓	✓	Inferrable	Life Sciences	Active
-UniProt			N/A	Internal	Active
-Wikidata	✓		Inferrable	General	Active
+Name	Scope	Status	Imports External Prefixes	Curates Novel Prefixes	Accepts External Contributions	Uses Public Version Control	Has Public Review Team
+AberOWL	Bio-Ontologies	Active					
+AgroPortal	Agro-Ontologies	Active		✓	✓		✗
+BioContext	Internal	Active		✓	✓	✓	✓*
+Biolink	Internal	Active		✓	✓	✓	✓*
+BioPortal	Bio-Ontologies	Active		✓	✓		✗
+Bioregistry	Life Sciences	Active	✓	✓	✓	✓	✓
+Cellosaurus	Internal	Active		✓			
+CHEMINF	Chemistry	Unresponsive		✓	✓	✓	✓*
+Crop OCT	Agro-Ontologies	Active		✓	✓		✓
+EcoPortal	Eco-Ontologies	Active		✓	✓		✗
+FAIRSharing	Life Sciences	Active		✓	✓		✗
+GO	Internal	Inactive		✓	✓	✓	✓*
+Identifiers.org	Life Sciences	Unresponsive		✓	✓		✗
+Name-to-Thing	Life Sciences	Active	✓				
+NCBI	Internal	Inactive		✓			
+OBO Foundry	Bio-Ontologies	Active		✓	✓	✓	✓
+OLS	Bio-Ontologies	Active			✓		✓*
+OntoBee	Bio-Ontologies	Active					
+Prefix.cc	General	Active		✓	✓	✓	
+Prefix Commons	Life Sciences	Active		✓	✓		✓
+Scholia	Life Sciences	Active		✓	✓	✓	✓*
+UniProt	Internal	Active		✓			
+Wikidata	General	Active		✓	✓		✓*

--- a/exports/tables/comparison_goveranance.tsv
+++ b/exports/tables/comparison_goveranance.tsv
@@ -1,0 +1,24 @@
+Name	Accepts External Contributions	Public Version Control	Review Team	Scope	Status
+AberOWL			N/A	Bio-Ontologies	Active
+AgroPortal	✓		Private	Agro-Ontologies	Active
+BioContext	✓	✓	Inferrable	Internal	Active
+Biolink	✓	✓	Inferrable	Internal	Active
+BioPortal	✓		Private	Bio-Ontologies	Active
+Bioregistry	✓	✓	Public	Life Sciences	Active
+Cellosaurus			N/A	Internal	Active
+CHEMINF	✓	✓	Inferrable	Chemistry	Unresponsive
+Crop OCT	✓		Public	Agro-Ontologies	Active
+EcoPortal	✓		Private	Eco-Ontologies	Active
+FAIRSharing	✓		Private	Life Sciences	Active
+GO	✓	✓	Inferrable	Internal	Inactive
+Identifiers.org	✓		Private	Life Sciences	Unresponsive
+Name-to-Thing			N/A	Life Sciences	Active
+NCBI			N/A	Internal	Inactive
+OBO Foundry	✓	✓	Public	Bio-Ontologies	Active
+OLS	✓		Inferrable	Bio-Ontologies	Active
+OntoBee			N/A	Bio-Ontologies	Active
+Prefix.cc	✓	✓	N/A	General	Active
+Prefix Commons	✓		Public	Life Sciences	Active
+Scholia	✓	✓	Inferrable	Life Sciences	Active
+UniProt			N/A	Internal	Active
+Wikidata	✓		Inferrable	General	Active

--- a/src/bioregistry/compare.py
+++ b/src/bioregistry/compare.py
@@ -82,7 +82,13 @@ def _save(fig, name: str, *, svg: bool = True, png: bool = False, eps: bool = Fa
     plt.close(fig)
 
 
-def _plot_attribute_pies(*, measurements, watermark, ncols: int = 4, keep_ontology: bool = True):
+def _plot_attribute_pies(
+    *,
+    measurements: Collection[Tuple[str, typing.Counter]],
+    watermark,
+    ncols: int = 4,
+    keep_ontology: bool = True,
+):
     import matplotlib.pyplot as plt
 
     if not keep_ontology:
@@ -95,16 +101,17 @@ def _plot_attribute_pies(*, measurements, watermark, ncols: int = 4, keep_ontolo
     nrows = int(math.ceil(len(measurements) / ncols))
     figsize = (2.75 * ncols, 2.0 * nrows)
     fig, axes = plt.subplots(ncols=ncols, nrows=nrows, figsize=figsize)
-    for (label, counter), ax in itt.zip_longest(measurements, axes.ravel(), fillvalue=(None, None)):
-        if label is None:
+    for label_counter, ax in itt.zip_longest(measurements, axes.ravel()):
+        if label_counter is None:
             ax.axis("off")
             continue
+        label, counter = label_counter
         if label == "License Type":
             labels, sizes = zip(*counter.most_common())
             explode = None
         else:
             labels = ("Yes", "No")
-            n_yes = counter.get("Yes")
+            n_yes = counter.get("Yes", 0)
             sizes = (n_yes, len(read_registry()) - n_yes)
             explode = [0.1, 0]
         ax.pie(

--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -71,6 +71,10 @@ EXPORT_COLLECTIONS = EXPORT_DIRECTORY.joinpath("collections")
 COLLECTIONS_YAML_PATH = EXPORT_COLLECTIONS / "collections.yml"
 COLLECTIONS_TSV_PATH = EXPORT_COLLECTIONS / "collections.tsv"
 
+EXPORT_TABLES = EXPORT_DIRECTORY.joinpath("tables")
+TABLES_GOVERNANCE_TSV_PATH = EXPORT_TABLES.joinpath("comparison_goveranance.tsv")
+TABLES_GOVERNANCE_LATEX_PATH = EXPORT_TABLES.joinpath("comparison_goveranance.tex")
+
 #: The URL of the remote Bioregistry site
 BIOREGISTRY_REMOTE_URL = pystow.get_config("bioregistry", "url") or "https://bioregistry.io"
 

--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -27,7 +27,9 @@
       "example": "CHEBI",
       "governance": {
         "accepts_external_contributions": false,
+        "curates": false,
         "curation": "import",
+        "imports": false,
         "public_version_control": false,
         "review_team": "n/a",
         "scope": "bio-ontologies",
@@ -68,7 +70,9 @@
       "example": "ENVO",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "opaque-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "private",
         "scope": "agro-ontologies",
@@ -107,7 +111,9 @@
       "example": "CHEBI",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": true,
         "review_team": "inferrable",
         "scope": "internal",
@@ -147,7 +153,9 @@
       "example": "doi",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": true,
         "review_team": "inferrable",
         "scope": "internal",
@@ -187,7 +195,9 @@
       "example": "CHEBI",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "opaque-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "private",
         "scope": "bio-ontologies",
@@ -228,7 +238,9 @@
       "example": "chebi",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": true,
         "public_version_control": true,
         "review_team": "public",
         "scope": "life sciences",
@@ -270,7 +282,9 @@
       "example": "4DN",
       "governance": {
         "accepts_external_contributions": false,
+        "curates": true,
         "curation": "private",
+        "imports": false,
         "public_version_control": false,
         "review_team": "n/a",
         "scope": "internal",
@@ -310,7 +324,9 @@
       "example": "000140",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": true,
         "review_team": "inferrable",
         "scope": "chemistry",
@@ -350,7 +366,9 @@
       "example": "CO_010",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "opaque-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "public",
         "scope": "agro-ontologies",
@@ -390,7 +408,9 @@
       "example": "ALIENSPECIES",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "opaque-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "private",
         "scope": "eco-ontologies",
@@ -430,7 +450,9 @@
       "example": "FAIRsharing.62qk8w",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "opaque-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "private",
         "scope": "life sciences",
@@ -471,7 +493,9 @@
       "example": "CHEBI",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": true,
         "review_team": "inferrable",
         "scope": "internal",
@@ -511,7 +535,9 @@
       "example": "chebi",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "opaque-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "private",
         "scope": "life sciences",
@@ -554,7 +580,9 @@
       "example": "chebi",
       "governance": {
         "accepts_external_contributions": false,
+        "curates": false,
         "curation": "import",
+        "imports": true,
         "public_version_control": false,
         "review_team": "n/a",
         "scope": "life sciences",
@@ -595,7 +623,9 @@
       "example": "ECOCYC",
       "governance": {
         "accepts_external_contributions": false,
+        "curates": true,
         "curation": "private",
+        "imports": false,
         "public_version_control": false,
         "review_team": "n/a",
         "scope": "internal",
@@ -634,7 +664,9 @@
       "example": "chebi",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": true,
         "review_team": "public",
         "scope": "bio-ontologies",
@@ -676,7 +708,9 @@
       "governance": {
         "accepts_external_contributions": true,
         "comments": "Accepts suggestions through the OLS issue tracker at https://github.com/EBISPOT/OLS/issues",
+        "curates": false,
         "curation": "import",
+        "imports": false,
         "public_version_control": false,
         "review_team": "inferrable",
         "scope": "bio-ontologies",
@@ -717,7 +751,9 @@
       "example": "AGRO",
       "governance": {
         "accepts_external_contributions": false,
+        "curates": false,
         "curation": "import",
+        "imports": false,
         "public_version_control": false,
         "review_team": "n/a",
         "scope": "bio-ontologies",
@@ -758,7 +794,9 @@
       "example": "foaf",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "community",
+        "imports": false,
         "public_version_control": true,
         "review_team": "n/a",
         "scope": "general",
@@ -798,7 +836,9 @@
       "example": "CHEBI",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "community",
+        "imports": false,
         "public_version_control": false,
         "review_team": "public",
         "scope": "life sciences",
@@ -838,7 +878,9 @@
       "example": "doi",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": true,
         "review_team": "inferrable",
         "scope": "life sciences",
@@ -879,7 +921,9 @@
       "example": "0174",
       "governance": {
         "accepts_external_contributions": false,
+        "curates": true,
         "curation": "private",
+        "imports": false,
         "public_version_control": false,
         "review_team": "n/a",
         "scope": "internal",
@@ -917,7 +961,9 @@
       "example": "P683",
       "governance": {
         "accepts_external_contributions": true,
+        "curates": true,
         "curation": "open-review",
+        "imports": false,
         "public_version_control": false,
         "review_team": "inferrable",
         "scope": "general",

--- a/src/bioregistry/export/cli.py
+++ b/src/bioregistry/export/cli.py
@@ -12,10 +12,10 @@ def export(ctx: click.Context):
     from .prefix_maps import generate_contexts
     from .rdf_export import export_rdf
     from .sssom_export import export_sssom
+    from .tables_export import export_tables
     from .tsv_export import export_tsv
     from .warnings_export import export_warnings
     from .yaml_export import export_yaml
-    from .tables_export import export_tables
 
     ctx.invoke(export_warnings)
     ctx.invoke(export_rdf)

--- a/src/bioregistry/export/cli.py
+++ b/src/bioregistry/export/cli.py
@@ -15,12 +15,14 @@ def export(ctx: click.Context):
     from .tsv_export import export_tsv
     from .warnings_export import export_warnings
     from .yaml_export import export_yaml
+    from .tables_export import export_tables
 
     ctx.invoke(export_warnings)
     ctx.invoke(export_rdf)
     ctx.invoke(export_tsv)
     ctx.invoke(export_yaml)
     ctx.invoke(export_sssom)
+    ctx.invoke(export_tables)
     ctx.invoke(generate_contexts)
 
 

--- a/src/bioregistry/export/tables_export.py
+++ b/src/bioregistry/export/tables_export.py
@@ -71,7 +71,7 @@ def export_tables():
             index=False,
             label="registry-comparison-governance",
             caption=dedent(
-                f"""\
+                """\
                A survey of registries' governance and maintenance models. The scope column describes the
                kinds of prefixes contained within the registry. The status column is active if the registry
                is currently being maintained and is responsive to public external feedback, unresponsive if
@@ -88,7 +88,9 @@ def export_tables():
                list of the reviewers. Asterisks in this column denote that rather than an explicit list, the
                reviewers can be inferred through the registry's version control system.
             """
-            ).strip().replace("\n", " "),
+            )
+            .strip()
+            .replace("\n", " "),
         ),
         encoding="utf-8",
     )

--- a/src/bioregistry/export/tables_export.py
+++ b/src/bioregistry/export/tables_export.py
@@ -2,11 +2,16 @@
 
 """Make tables exports."""
 
+from textwrap import dedent
+
 import click
 import pandas as pd
 
 import bioregistry
-from bioregistry.constants import TABLES_GOVERNANCE_LATEX_PATH, TABLES_GOVERNANCE_TSV_PATH
+from bioregistry.constants import (
+    TABLES_GOVERNANCE_LATEX_PATH,
+    TABLES_GOVERNANCE_TSV_PATH,
+)
 
 __all__ = [
     "export_tables",
@@ -14,29 +19,41 @@ __all__ = [
 
 GOVERNANCE_COLUMNS = [
     "Name",
-    "Accepts External Contributions",
-    "Public Version Control",
-    "Review Team",
     "Scope",
     "Status",
+    "Imports External Prefixes",
+    "Curates Novel Prefixes",
+    "Accepts External Contributions",
+    "Uses Public Version Control",
+    "Has Public Review Team",
 ]
 
 
-def _render_bool(x: bool) -> str:
-    return "✓" if x else ""
+def _render_bool(x: bool, true_value: str = "✓", false_value: str = "") -> str:
+    return true_value if x else false_value
+
+
+def _replace_na(s: str) -> str:
+    if s.lower() == "n/a":
+        return ""
+    return s
 
 
 def _governance_df() -> pd.DataFrame:
     rows = []
     for registry in bioregistry.read_metaregistry().values():
-        rows.append((
-            registry.get_short_name(),
-            _render_bool(registry.governance.accepts_external_contributions),
-            _render_bool(registry.governance.public_version_control),
-            registry.governance.review_team.title(),
-            registry.governance.scope.title(),
-            registry.governance.status.title(),
-        ))
+        rows.append(
+            (
+                registry.get_short_name(),
+                registry.governance.scope.title(),
+                registry.governance.status.title(),
+                _render_bool(registry.governance.imports),
+                _render_bool(registry.governance.curates),
+                _render_bool(registry.governance.accepts_external_contributions),
+                _render_bool(registry.governance.public_version_control),
+                registry.governance.review_team_icon,
+            )
+        )
     return pd.DataFrame(rows, columns=GOVERNANCE_COLUMNS)
 
 
@@ -48,16 +65,34 @@ def export_tables():
     2. Export governance comparison, see also https://bioregistry.io/related#governance
     """
     df = _governance_df()
-    df.to_csv(TABLES_GOVERNANCE_TSV_PATH, sep='\t', index=False)
+    df.to_csv(TABLES_GOVERNANCE_TSV_PATH, sep="\t", index=False)
     TABLES_GOVERNANCE_LATEX_PATH.write_text(
         df.to_latex(
             index=False,
             label="registry-comparison-governance",
-            caption="Caption of this table, nice",
+            caption=dedent(
+                f"""\
+               A survey of registries' governance and maintenance models. The scope column describes the
+               kinds of prefixes contained within the registry. The status column is active if the registry
+               is currently being maintained and is responsive to public external feedback, unresponsive if
+               the registry is currently being maintained but is not responsive to public external feedback,
+               and inactive otherwise. The imports external prefixes column denotes if the registry reuses
+               and harmonizes content from external registries. The curates novel prefixes column denotes
+               whether novel curation of prefixes and their associated metadata is done for the registry.
+               The accepts external contributions column denotes whether the registry has both the governance
+               model and technical infrastructure for accepting external contributions in the form of the
+               suggestion of new prefixes, improvement to metadata associated with existing prefixes, etc.
+               The uses public version control column denotes whether the data underlying the registry and/or
+               its associated code are stored in a publicly accessible version-controlled system (e.g., git
+               via GitHub). The has public review team column denotes whether there is a publicly accessible
+               list of the reviewers. Asterisks in this column denote that rather than an explicit list, the
+               reviewers can be inferred through the registry's version control system.
+            """
+            ).strip().replace("\n", " "),
         ),
-        encoding='utf-8',
+        encoding="utf-8",
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     export_tables()

--- a/src/bioregistry/export/tables_export.py
+++ b/src/bioregistry/export/tables_export.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+"""Make tables exports."""
+
+import click
+import pandas as pd
+
+import bioregistry
+from bioregistry.constants import TABLES_GOVERNANCE_LATEX_PATH, TABLES_GOVERNANCE_TSV_PATH
+
+__all__ = [
+    "export_tables",
+]
+
+GOVERNANCE_COLUMNS = [
+    "Name",
+    "Accepts External Contributions",
+    "Public Version Control",
+    "Review Team",
+    "Scope",
+    "Status",
+]
+
+
+def _render_bool(x: bool) -> str:
+    return "✓" if x else ""
+
+
+def _governance_df() -> pd.DataFrame:
+    rows = []
+    for registry in bioregistry.read_metaregistry().values():
+        rows.append((
+            registry.get_short_name(),
+            _render_bool(registry.governance.accepts_external_contributions),
+            _render_bool(registry.governance.public_version_control),
+            registry.governance.review_team.title(),
+            registry.governance.scope.title(),
+            registry.governance.status.title(),
+        ))
+    return pd.DataFrame(rows, columns=GOVERNANCE_COLUMNS)
+
+
+@click.command()
+def export_tables():
+    """Export tables.
+
+    1. TODO: Export data model comparison, see also https://bioregistry.io/related#data-models
+    2. Export governance comparison, see also https://bioregistry.io/related#governance
+    """
+    df = _governance_df()
+    df.to_csv(TABLES_GOVERNANCE_TSV_PATH, sep='\t', index=False)
+    TABLES_GOVERNANCE_LATEX_PATH.write_text(
+        df.to_latex(
+            index=False,
+            label="registry-comparison-governance",
+            caption="Caption of this table, nice",
+        ),
+        encoding='utf-8',
+    )
+
+
+if __name__ == '__main__':
+    export_tables()

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -653,6 +653,16 @@
           ],
           "type": "string"
         },
+        "curates": {
+          "title": "Curates",
+          "description": "Does the registry curate novel prefixes?",
+          "type": "boolean"
+        },
+        "imports": {
+          "title": "Imports",
+          "description": "Does the registry import and align prefixes from other registries?",
+          "type": "boolean"
+        },
         "scope": {
           "title": "Scope",
           "description": "What is the scope of prefixes which the registry covers? For example, some registries are limited to ontologies, some have a full scope over the life sciences, and some are general purpose.",
@@ -696,6 +706,8 @@
       },
       "required": [
         "curation",
+        "curates",
+        "imports",
         "scope",
         "accepts_external_contributions",
         "public_version_control",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1288,6 +1288,10 @@ class RegistryGovernance(BaseModel):
     """Metadata about a registry's governance."""
 
     curation: Literal["private", "import", "community", "opaque-review", "open-review"]
+    curates: bool = Field(description="Does the registry curate novel prefixes?")
+    imports: bool = Field(
+        description="Does the registry import and align prefixes from other registries?"
+    )
     scope: str = Field(
         description="What is the scope of prefixes which the registry covers? For example,"
         " some registries are limited to ontologies, some have a full scope over the life sciences,"
@@ -1319,6 +1323,18 @@ class RegistryGovernance(BaseModel):
         " in some capacity but is not responsive to external requests for improvement. An inactive repository is"
         " no longer being proactively maintained (though may receive occasional patches)."
     )
+
+    @property
+    def review_team_icon(self) -> str:
+        """Get an icon for the review team."""
+        if self.review_team == "public":
+            return "✓"
+        elif self.review_team == "inferrable":
+            return "✓*"
+        elif self.review_team == "private":
+            return "✗"
+        else:
+            return ""
 
 
 class RegistrySchema(BaseModel):


### PR DESCRIPTION
This PR improves the survey on governance for external registries and creates an automatically generated TSV file as well as LaTeX table for use in the paper.