### PR TITLE
Update pattern for google.patent

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -23375,6 +23375,9 @@
         "orcid": "0000-0001-9439-5346"
       }
     ],
+    "example_extras": [
+      "USRE38117E1"
+    ],
     "mappings": {
       "biocontext": "GOOGLE.PATENT",
       "cellosaurus": "Patent",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -23367,6 +23367,14 @@
       "prefix": "Patent",
       "uri_format": "https://patents.google.com/patent/$1"
     },
+    "contributor_extras": [
+      {
+        "email": "benjamin_gyori@hms.harvard.edu",
+        "github": "bgyori",
+        "name": "Benjamin Gyori",
+        "orcid": "0000-0001-9439-5346"
+      }
+    ],
     "mappings": {
       "biocontext": "GOOGLE.PATENT",
       "cellosaurus": "Patent",
@@ -23395,6 +23403,7 @@
       "prefix": "google.patent",
       "uri_format": "https://www.google.com/patents/$1"
     },
+    "pattern": "^[A-Z]{2,4}\\d+([A-Z])?([0-9])?$",
     "synonyms": [
       "patent"
     ]


### PR DESCRIPTION
Closes #408 

@bgyori ideally, before merging, we can add a few more examples that failed under the old regular expression from Identifiers.org (`^[A-Z]{2}\\d+([A-Z])?$`) in the `"example_extras"` list field in this record in addition to [USRE38117E1](https://patents.google.com/patent/USRE38117E1). Did you happen to take notes on some that failed?