### PR TITLE
Add GitHub issue reference to resource schema

### DIFF
--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -133,6 +133,11 @@
                             OBO JSON <i class="fas fa-download"></i>
                         </a>
                     {% endif %}
+                    {% if resource.github_request_issue %}
+                        <a class="badge badge-pill badge-light" href="https://github.com/biopragmatics/bioregistry/issues/{{ resource.github_request_issue }}">
+                            <i class="fas fa-info-circle"></i> Request Discussion
+                        </a>
+                    {% endif %}
                     {% if twitter %}
                         <a class="badge badge-pill badge-light" href="https://twitter.com/{{ twitter }}">
                             <i class="fa-brands fa-twitter"></i> @{{ twitter }}

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -11368,6 +11368,7 @@
     },
     "description": "COCONUT (COlleCtion of Open Natural ProdUcTs) Online is an open source project for Natural Products (NPs) storage, search and analysis. It gathers data from over 50 open NP resources and is available free of charge and without any restriction. Each entry corresponds to a \"flat\" NP structure, and is associated, when available, to their known stereochemical forms, literature, organisms that produce them, natural geographical presence and diverse pre-computed molecular properties.",
     "example": "CNP0171505",
+    "github_request_issue": 221,
     "homepage": "https://coconut.naturalproducts.net",
     "name": "COlleCtion of Open Natural ProdUcTs",
     "pattern": "^CNP\\d{7}$",
@@ -22135,6 +22136,7 @@
     },
     "description": "PomBase manages gene and phenotype data related to Fission Yeast. FYECO contains experimental conditions relevant to fission yeast biology. The FYECO namespace shows up in data ingests from PomBase.",
     "example": "0000003",
+    "github_request_issue": 268,
     "homepage": "https://github.com/pombase/fypo",
     "mappings": {
       "biolink": "FYECO"
@@ -25414,6 +25416,7 @@
     },
     "description": "GrassBase provides an interactive guide to nomenclature for the whole grass family. It provides lists of over 60,000 names for any given genus, geographical region or genus within a geographical region, helps find the accepted name, synonyms and distribution for any given name, and gives a desription for each species.",
     "example": "imp10873",
+    "github_request_issue": 218,
     "homepage": "https://www.kew.org/data/grasses-syn/index.htm",
     "name": "GrassBase",
     "pattern": "^(imp|gen)\\d{5}$",
@@ -33481,6 +33484,7 @@
     },
     "description": "LOTUS, actually, represents the most exhaustive resource of documented structure-organism pairs. Within the frame of current computational approaches in Natural Produts’s research and related fields, these documented structure-organism pairs should allow a more complete understanding of organisms and their chemistry.",
     "example": "LTS0004651",
+    "github_request_issue": 222,
     "homepage": "https://lotus.naturalproducts.net",
     "name": "LOTUS Initiative for Open Natural Products Research",
     "pattern": "^LTS\\d{7}$",
@@ -44549,6 +44553,7 @@
     },
     "description": "OpenAlex is a fully open catalog of the global research system that describes scholarly entities and how those entities are connected to each other.",
     "example": "W2741809807",
+    "github_request_issue": 280,
     "homepage": "https://openalex.org/",
     "name": "OpenAlex",
     "pattern": "^[WAICV]\\d{2,}$",
@@ -45000,6 +45005,7 @@
         "Ontology and Terminology"
       ]
     },
+    "github_request_issue": 187,
     "mappings": {
       "biocontext": "Orphanet",
       "fairsharing": "FAIRsharing.6bd5k6",
@@ -46309,6 +46315,7 @@
         "Subject Agnostic"
       ]
     },
+    "github_request_issue": 186,
     "homepage": "https://pav-ontology.github.io/pav/",
     "mappings": {
       "aberowl": "PAV",
@@ -55591,6 +55598,7 @@
     },
     "description": "Sigma Aldrich is a life sciences supply vendor.",
     "example": "HPA000698",
+    "github_request_issue": 216,
     "homepage": "https://www.sigmaaldrich.com",
     "name": "Sigma Aldrich",
     "uri_format": "https://www.sigmaaldrich.com/US/en/product/sigma/$1"
@@ -63982,6 +63990,7 @@
     },
     "description": "WWF ecoregions are large unit of land or water containing a geographically distinct assemblage of species, natural communities, and environmental conditions.",
     "example": "AT1402",
+    "github_request_issue": 153,
     "homepage": "https://www.worldwildlife.org/biomes",
     "name": "World Wildlife Fund Ecoregion",
     "pattern": "^AT\\d+$",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -5587,6 +5587,7 @@
     },
     "name": "SBGN Bricks data and ontology",
     "pattern": "^\\d+$",
+    "request_issue": "283",
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -12307,6 +12308,7 @@
       "https://github.com/biopragmatics/bioregistry/pull/358",
       "https://github.com/biolink/biolink-model/pull/993"
     ],
+    "request_issue": "357",
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -41366,6 +41368,7 @@
     "homepage": "https://reporter.nih.gov/",
     "name": "NIH RePORTER",
     "pattern": "^\\d+$",
+    "request_issue": "400",
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -5587,7 +5587,7 @@
     },
     "name": "SBGN Bricks data and ontology",
     "pattern": "^\\d+$",
-    "request_issue": "283",
+    "github_request_issue": 283,
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -12304,11 +12304,10 @@
     "name": "Current Procedural Terminology",
     "pattern": "^\\d+$",
     "references": [
-      "https://github.com/biopragmatics/bioregistry/issues/357",
       "https://github.com/biopragmatics/bioregistry/pull/358",
       "https://github.com/biolink/biolink-model/pull/993"
     ],
-    "request_issue": "357",
+    "github_request_issue": 357,
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -41368,7 +41367,7 @@
     "homepage": "https://reporter.nih.gov/",
     "name": "NIH RePORTER",
     "pattern": "^\\d+$",
-    "request_issue": "400",
+    "github_request_issue": 400,
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -30272,6 +30272,7 @@
     },
     "description": "An experimental run, served thrugh the ENA",
     "example": "ERR436051",
+    "github_request_issue": 131,
     "has_canonical": "ena.embl",
     "homepage": "https://www.insdc.org/",
     "name": "International Nucleotide Sequence Database Collaboration (INSDC) Run",
@@ -55588,7 +55589,7 @@
     "provides": "umls",
     "uri_format": "http://sideeffects.embl.de/se/$1"
   },
-  "sigmaaldirch": {
+  "sigmaaldrich": {
     "contributor": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -45005,7 +45005,6 @@
         "Ontology and Terminology"
       ]
     },
-    "github_request_issue": 187,
     "mappings": {
       "biocontext": "Orphanet",
       "fairsharing": "FAIRsharing.6bd5k6",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -5580,6 +5580,7 @@
     },
     "description": "SBGN bricks represent biomolecular or biological concepts. BKO formally associates bricks with the concepts they represent. BKO includes terms that describe concepts, the template bricks representing these concepts, and categories that gather bricks in a broader way.",
     "example": "0000204",
+    "github_request_issue": 283,
     "homepage": "http://www.sbgnbricks.org/",
     "mappings": {
       "aberowl": "BKO",
@@ -5587,7 +5588,6 @@
     },
     "name": "SBGN Bricks data and ontology",
     "pattern": "^\\d+$",
-    "github_request_issue": 283,
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -12294,6 +12294,7 @@
         "Biomedical Science"
       ]
     },
+    "github_request_issue": 357,
     "homepage": "https://www.aapc.com",
     "mappings": {
       "aberowl": "CPT",
@@ -12307,7 +12308,6 @@
       "https://github.com/biopragmatics/bioregistry/pull/358",
       "https://github.com/biolink/biolink-model/pull/993"
     ],
-    "github_request_issue": 357,
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -41364,10 +41364,10 @@
     },
     "description": "RePORTER is an electronic tool that allows users to search a repository of both intramural and extramural NIH-funded research projects and access publications and patents resulting from NIH funding.",
     "example": "10343835",
+    "github_request_issue": 400,
     "homepage": "https://reporter.nih.gov/",
     "name": "NIH RePORTER",
     "pattern": "^\\d+$",
-    "github_request_issue": 400,
     "reviewer": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",

--- a/src/bioregistry/gh/new_prefix.py
+++ b/src/bioregistry/gh/new_prefix.py
@@ -81,7 +81,9 @@ def get_new_prefix_issues(token: Optional[str] = None) -> Mapping[int, Resource]
                 issue_id,
             )
             continue
-        rv[issue_id] = Resource(prefix=prefix, contributor=contributor, **resource_data)
+        rv[issue_id] = Resource(
+            prefix=prefix, contributor=contributor, request_issue=issue_id, **resource_data
+        )
     return rv
 
 

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -388,6 +388,11 @@
           "description": "The twitter handle for the project",
           "type": "string"
         },
+        "github_request_issue": {
+          "title": "Github Request Issue",
+          "description": "The GitHub issue for the new prefix request",
+          "type": "integer"
+        },
         "miriam": {
           "title": "Miriam",
           "type": "object"
@@ -422,6 +427,10 @@
         },
         "agroportal": {
           "title": "Agroportal",
+          "type": "object"
+        },
+        "cropoct": {
+          "title": "Cropoct",
           "type": "object"
         },
         "ols": {

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -384,6 +384,7 @@ class Resource(BaseModel):
         ),
     )
     twitter: Optional[str] = Field(description="The twitter handle for the project")
+    request_issue: Optional[str] = Field(description="The GitHub issue for the new prefix request")
     #: External data from Identifiers.org's MIRIAM Database
     miriam: Optional[Mapping[str, Any]]
     #: External data from the Name-to-Thing service

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -384,7 +384,7 @@ class Resource(BaseModel):
         ),
     )
     twitter: Optional[str] = Field(description="The twitter handle for the project")
-    request_issue: Optional[str] = Field(description="The GitHub issue for the new prefix request")
+    github_request_issue: Optional[int] = Field(description="The GitHub issue for the new prefix request")
     #: External data from Identifiers.org's MIRIAM Database
     miriam: Optional[Mapping[str, Any]]
     #: External data from the Name-to-Thing service
@@ -1828,6 +1828,7 @@ def write_bulk_prefix_request_template():
             "reviewer",
             "contact",
             "contributor",
+            "github_request_issue",
         }:
             continue
         if name in metaprefixes:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -384,7 +384,9 @@ class Resource(BaseModel):
         ),
     )
     twitter: Optional[str] = Field(description="The twitter handle for the project")
-    github_request_issue: Optional[int] = Field(description="The GitHub issue for the new prefix request")
+    github_request_issue: Optional[int] = Field(
+        description="The GitHub issue for the new prefix request"
+    )
     #: External data from Identifiers.org's MIRIAM Database
     miriam: Optional[Mapping[str, Any]]
     #: External data from the Name-to-Thing service

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -755,7 +755,12 @@ class TestRegistry(unittest.TestCase):
     def test_request_issue(self):
         """Check all prefixes with a request issue have a reviewer."""
         for prefix, resource in self.registry.items():
-            if resource.request_issue is None:
+            if resource.github_request_issue is None:
                 continue
             with self.subTest(prefix=prefix):
                 self.assertIsNotNone(resource.reviewer)
+                self.assertNotIn(
+                    f"https://github.com/biopragmatics/bioregistry/issues/{resource.github_request_issue}",
+                    resource.references or [],
+                    msg="Reference to GitHub request issue should be in its dedicated field.",
+                )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -750,3 +750,11 @@ class TestRegistry(unittest.TestCase):
                     prefix in set(self.registry),
                     msg=f"mismatches.json has invalid prefix: {prefix}",
                 )
+
+    def test_request_issue(self):
+        """Check all prefixes with a request issue have a reviewer."""
+        for prefix, resource in self.registry.items():
+            if resource.request_issue is None:
+                continue
+            with self.subTest(prefix=prefix):
+                self.assertIsNotNone(resource.reviewer)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -758,7 +758,9 @@ class TestRegistry(unittest.TestCase):
             if resource.github_request_issue is None:
                 continue
             with self.subTest(prefix=prefix):
-                self.assertIsNotNone(resource.reviewer)
+                if resource.contributor.github != "cthoyt":
+                    # needed to bootstrap records before there was more governance in place
+                    self.assertIsNotNone(resource.reviewer)
                 self.assertNotIn(
                     f"https://github.com/biopragmatics/bioregistry/issues/{resource.github_request_issue}",
                     resource.references or [],


### PR DESCRIPTION
This PR does the following:

1. Adds element to resource schema to link to a github issue where it was requested
2. Adds annotations to all requested prefixes via github 
3. Adds badge to web pages
4. Updates the new prefix request pipeline to automatically add future annotations