### PR TITLE
Cleanup bananas

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4758,6 +4758,7 @@
       "prefix": "biomodels.kisao",
       "uri_format": "http://purl.bioontology.org/ontology/KISAO/kisao:$1"
     },
+    "namespace_in_lui": true,
     "obofoundry": {
       "contact": "jonrkarr@gmail.com",
       "contact.github": "jonrkarr",
@@ -24139,6 +24140,7 @@
       "sampleId": "GEO_000000021",
       "uri_format": "http://purl.obolibrary.org/obo/$1"
     },
+    "namespace_in_lui": true,
     "obofoundry": {
       "contact": "hoganwr@gmail.com",
       "contact.label": "Bill Hogan",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -43312,6 +43312,7 @@
       "prefix": "obi",
       "uri_format": "http://purl.obolibrary.org/obo/$1"
     },
+    "namespace_in_lui": true,
     "obofoundry": {
       "appears_in": [
         "agro",
@@ -54811,6 +54812,7 @@
       "uri_format": "http://purl.obolibrary.org/obo/$1"
     },
     "name": "Relation Ontology",
+    "namespace_in_lui": true,
     "obofoundry": {
       "appears_in": [
         "go",
@@ -58518,6 +58520,7 @@
       "uri_format": "https://www.storedb.org/?$1"
     },
     "name": "Store DB",
+    "namespace_in_lui": true,
     "pattern": "^(STUDY|FILE|DATASET)\\d+$",
     "uri_format": "https://www.storedb.org/?$1"
   },

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -25861,7 +25861,7 @@
     ]
   },
   "gramene.growthstage": {
-    "banana": "gramene.growthstage:GRO\\",
+    "banana": "GRO\\",
     "biocontext": {
       "is_identifiers": true,
       "is_obo": false,
@@ -25896,7 +25896,6 @@
       "uri_format": "http://www.gramene.org/db/ontology/search?id=GRO:$1"
     },
     "name": "Gramene Growth Stage Ontology",
-    "namespace_in_lui": false,
     "pattern": "^\\d{7}$",
     "uri_format": "http://www.gramene.org/db/ontology/search?id=GRO:$1"
   },
@@ -44454,7 +44453,6 @@
       "sampleId": "HOG:0459895",
       "uri_format": "https://omabrowser.org/oma/hog/resolve/HOG:$1/"
     },
-    "namespace_in_lui": false,
     "pattern": "^[0-9]{7}(\\.[0-9a-z.]+)?(_[0-9]+)?$",
     "uri_format": "https://omabrowser.org/oma/hog/HOG:$1"
   },

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -530,7 +530,6 @@
       "prefix": "adw",
       "uri_format": "https://animaldiversity.org/accounts/$1/"
     },
-    "namespace_in_lui": false,
     "obofoundry": {
       "contact": "adw_geeks@umich.edu",
       "contact.label": "Animal Diversity Web technical staff",
@@ -28948,7 +28947,6 @@
       "prefix": "iao",
       "uri_format": "http://purl.obolibrary.org/obo/IAO_$1"
     },
-    "namespace_in_lui": false,
     "obofoundry": {
       "appears_in": [
         "agro",
@@ -29694,7 +29692,6 @@
       "prefix": "ido",
       "uri_format": "https://www.ebi.ac.uk/ols/ontologies/ido/terms?obo_id=IDO:$1"
     },
-    "namespace_in_lui": false,
     "obofoundry": {
       "appears_in": [
         "scdo"
@@ -31330,7 +31327,6 @@
       "uri_format": "https://www.ebi.ac.uk/interpro/entry/$1"
     },
     "name": "InterPro",
-    "namespace_in_lui": false,
     "ncbi": {
       "example": "IPR002928",
       "homepage": "http://www.ebi.ac.uk/interpro/",
@@ -38590,7 +38586,6 @@
       "prefix": "mo",
       "uri_format": "http://purl.bioontology.org/ontology/MO/$1"
     },
-    "namespace_in_lui": false,
     "obofoundry": {
       "contact": "stoeckrt@pcbi.upenn.edu",
       "contact.label": "Chris Stoeckert",
@@ -44862,7 +44857,6 @@
       "uri_format": "https://www.ebi.ac.uk/ols/ontologies/omit/terms?short_form=OMIT_$1"
     },
     "name": "Ontology for MicroRNA Target",
-    "namespace_in_lui": false,
     "obofoundry": {
       "appears_in": [
         "mco"
@@ -53761,7 +53755,6 @@
       "prefix": "resid",
       "uri_format": "http://pir0.georgetown.edu/cgi-bin/resid?id=$1"
     },
-    "namespace_in_lui": false,
     "obofoundry": {
       "contact": "john.garavelli@ebi.ac.uk",
       "contact.label": "John Garavelli",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -530,6 +530,7 @@
       "prefix": "adw",
       "uri_format": "https://animaldiversity.org/accounts/$1/"
     },
+    "namespace_in_lui": false,
     "obofoundry": {
       "contact": "adw_geeks@umich.edu",
       "contact.label": "Animal Diversity Web technical staff",
@@ -28946,6 +28947,7 @@
       "prefix": "iao",
       "uri_format": "http://purl.obolibrary.org/obo/IAO_$1"
     },
+    "namespace_in_lui": false,
     "obofoundry": {
       "appears_in": [
         "agro",
@@ -29691,6 +29693,7 @@
       "prefix": "ido",
       "uri_format": "https://www.ebi.ac.uk/ols/ontologies/ido/terms?obo_id=IDO:$1"
     },
+    "namespace_in_lui": false,
     "obofoundry": {
       "appears_in": [
         "scdo"
@@ -38586,6 +38589,7 @@
       "prefix": "mo",
       "uri_format": "http://purl.bioontology.org/ontology/MO/$1"
     },
+    "namespace_in_lui": false,
     "obofoundry": {
       "contact": "stoeckrt@pcbi.upenn.edu",
       "contact.label": "Chris Stoeckert",
@@ -44857,6 +44861,7 @@
       "uri_format": "https://www.ebi.ac.uk/ols/ontologies/omit/terms?short_form=OMIT_$1"
     },
     "name": "Ontology for MicroRNA Target",
+    "namespace_in_lui": false,
     "obofoundry": {
       "appears_in": [
         "mco"
@@ -53755,6 +53760,7 @@
       "prefix": "resid",
       "uri_format": "http://pir0.georgetown.edu/cgi-bin/resid?id=$1"
     },
+    "namespace_in_lui": false,
     "obofoundry": {
       "contact": "john.garavelli@ebi.ac.uk",
       "contact.label": "John Garavelli",

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -367,7 +367,8 @@ def get_banana(prefix: str) -> Optional[str]:
     >>> assert "GO_REF" == get_banana('go.ref')
 
     Banana imported through OBO Foundry
-    >>> assert "FBbt" == get_banana('fbbt')
+    >>> assert "GO" == get_banana('go')
+    >>> assert "VariO" == get_banana('vario')
 
     Banana inferred for OBO Foundry ontology
     >>> get_banana('chebi')

--- a/src/bioregistry/resolve_identifier.py
+++ b/src/bioregistry/resolve_identifier.py
@@ -64,11 +64,16 @@ def miriam_standardize_identifier(prefix: str, identifier: str) -> str:
 
     Examples with bananas from OBO:
     >>> import bioregistry as br
-    >>> assert "FBbt" == br.get_banana('fbbt')
-    >>> miriam_standardize_identifier('fbbt', '00007294')
-    'FBbt:00007294'
-    >>> miriam_standardize_identifier('fbbt', 'FBbt:00007294')
-    'FBbt:00007294'
+    >>> assert "GO" == br.get_banana('go')
+    >>> miriam_standardize_identifier('go', '0000001')
+    'GO:0000001'
+    >>> miriam_standardize_identifier('go', 'GO:0000001')
+    'GO:0000001'
+    >>> assert "VariO" == br.get_banana('vario')
+    >>> miriam_standardize_identifier('vario', '0000001')
+    'VariO:0000001'
+    >>> miriam_standardize_identifier('vario', 'VariO:0000001')
+    'VariO:0000001'
 
     Examples from OBO Foundry:
     >>> miriam_standardize_identifier('chebi', '1234')

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -518,7 +518,7 @@ class Resource(BaseModel):
         """
         if self.banana is not None:
             return self.banana
-        if self.namespace_in_lui is False:
+        if not self.get_namespace_in_lui():
             return None  # override for a few situations
         miriam_prefix = self.get_miriam_prefix()
         obo_preferred_prefix = self.get_obo_preferred_prefix()

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -518,11 +518,11 @@ class Resource(BaseModel):
         """
         if self.banana is not None:
             return self.banana
-        if not self.get_namespace_in_lui():
-            return None  # override for a few situations
+        if self.get_namespace_in_lui() is False:
+            return None
         miriam_prefix = self.get_miriam_prefix()
         obo_preferred_prefix = self.get_obo_preferred_prefix()
-        if miriam_prefix and obo_preferred_prefix is not None:
+        if miriam_prefix is not None and obo_preferred_prefix is not None:
             return obo_preferred_prefix
         return None
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -496,8 +496,10 @@ class Resource(BaseModel):
 
         Banana imported through OBO Foundry
 
-        >>> get_resource("fbbt").get_banana()
-        'FBbt'
+        >>> get_resource("go").get_banana()
+        'GO'
+        >>> get_resource("vario").get_banana()
+        'VariO'
 
         Banana inferred for OBO Foundry ontology
 
@@ -1147,8 +1149,6 @@ class Resource(BaseModel):
 
         Examples with bananas from OBO:
         >>> get_resource("fbbt").standardize_identifier('00007294')
-        '00007294'
-        >>> get_resource("fbbt").standardize_identifier('FBbt:00007294')
         '00007294'
         >>> get_resource("chebi").standardize_identifier('1234')
         '1234'

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1190,10 +1190,10 @@ class Resource(BaseModel):
         'VariO:0376'
 
         Examples with bananas from OBO:
-        >>> get_resource("fbbt").miriam_standardize_identifier('00007294')
-        'FBbt:00007294'
-        >>> get_resource("fbbt").miriam_standardize_identifier('FBbt:00007294')
-        'FBbt:00007294'
+        >>> get_resource("go").miriam_standardize_identifier('0000001')
+        'GO:0000001'
+        >>> get_resource("go").miriam_standardize_identifier('GO:0000001')
+        'GO:0000001'
 
         Examples from OBO Foundry:
         >>> get_resource("chebi").miriam_standardize_identifier('1234')

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -520,11 +520,10 @@ class Resource(BaseModel):
             return self.banana
         if self.namespace_in_lui is False:
             return None  # override for a few situations
+        miriam_prefix = self.get_miriam_prefix()
         obo_preferred_prefix = self.get_obo_preferred_prefix()
-        if obo_preferred_prefix is not None:
+        if miriam_prefix and obo_preferred_prefix is not None:
             return obo_preferred_prefix
-        # TODO consider reinstating all preferred prefixes should
-        #  be considered as secondary bananas
         return None
 
     def get_default_format(self) -> Optional[str]:

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -62,8 +62,8 @@ class TestResolve(unittest.TestCase):
             ("go.ref", "0000041"),
             ("go.ref", "GO_REF:0000041"),
             # bananas from OBO
-            ("fbbt", "00007294"),
-            ("fbbt", "FBbt:00007294"),
+            ("go", "0000001"),
+            ("go", "GO:0000001"),
         ]
         for prefix in bioregistry.read_registry():
             if bioregistry.is_deprecated(prefix):


### PR DESCRIPTION
This PR does two things in service of better understanding the situation of namespaces embedded in LUIs and bananas as mentioned in https://syspharm.slack.com/archives/D01QC9NDUCS/p1655239400791709:

1. Does additional curation as a follow-up to to give a full overview of how bananas (both explicitly curated and inferred via OBO Foundry), namespace embedded in LUI (both from MIRIAM and overrides in the Bioregistry), and MIRIAM patterns intersect.
2. Changes automatic generation of bananas for prefixes mapped to OBO Foundry ontologies such that bananas are only automatically generated if the prefix also has a mapping to a MIRIAM/Identifiers.org prefix.
    - Adds explicit `"namespace_embedded_in_lui": false` for entries appearing in both OBO Foundry and MIRIAM, but don't have correct namespace embedded in LUI annotations (this is slightly redundant, but MIRIAM gets this wrong for several of these cases)
    - Fixes some bananas that don't match the MIRIAM pattern - a reminder that banana is mostly to serve MIRIAM backwards compatibility

<details>
<summary>
The table below shows all Bioregistry records that are mapped to MIRIAM and either 1) have a banana, 2) have namespace embedded in LUI marked as true in MIRIAM, or 3) have an explicit override of namespace embedded in LUI in the Bioregistry. Note that I stripped the `^` and `$` from the MIRIAM patterns for consistency
</summary>

| prefix                                                              | banana   | pe    | obo_prefix                                                  | miriam_prefix                                                              | miriam_pe   | correct_banana   | miriam_pattern                                                                      |
|---------------------------------------------------------------------|----------|-------|-------------------------------------------------------------|----------------------------------------------------------------------------|-------------|------------------|-------------------------------------------------------------------------------------|
| [`adw`](https://bioregistry.io/adw)                                 |          | False | [`ADW`](http://www.obofoundry.org/ontology/adw)             | [`adw`](https://bioregistry.io/miriam:adw)                                 | False       |                  | `[A-Z_a-z]+`                                                                        |
| [`ark`](https://bioregistry.io/ark)                                 | ark      |       |                                                             | [`ark`](https://bioregistry.io/miriam:ark)                                 | True        | FAILURE          | `(ark\:)/*[0-9A-Za-z]+(?:/[\w/.=*+@\$-]*)?(?:\?.*)?`                                |
| [`biomodels.kisao`](https://bioregistry.io/biomodels.kisao)         | KISAO    | True  | [`KISAO`](http://www.obofoundry.org/ontology/kisao)         | [`biomodels.kisao`](https://bioregistry.io/miriam:biomodels.kisao)         | False       |                  | `KISAO_\d+`                                                                         |
| [`bto`](https://bioregistry.io/bto)                                 | BTO      |       | [`BTO`](http://www.obofoundry.org/ontology/bto)             | [`bto`](https://bioregistry.io/miriam:bto)                                 | True        |                  | `BTO:\d{7}`                                                                         |
| [`cco`](https://bioregistry.io/cco)                                 | CCO      |       |                                                             | [`cco`](https://bioregistry.io/miriam:cco)                                 | True        |                  | `CCO\:\w+`                                                                          |
| [`chebi`](https://bioregistry.io/chebi)                             | CHEBI    |       | [`CHEBI`](http://www.obofoundry.org/ontology/chebi)         | [`chebi`](https://bioregistry.io/miriam:chebi)                             | True        |                  | `CHEBI:\d+`                                                                         |
| [`cl`](https://bioregistry.io/cl)                                   | CL       |       | [`CL`](http://www.obofoundry.org/ontology/cl)               | [`cl`](https://bioregistry.io/miriam:cl)                                   | True        |                  | `CL:\d{7}`                                                                          |
| [`did`](https://bioregistry.io/did)                                 | did      |       |                                                             | [`did`](https://bioregistry.io/miriam:did)                                 | True        |                  | `did:[a-z0-9]+:[A-Za-z0-9.\-:]+`                                                    |
| [`doid`](https://bioregistry.io/doid)                               | DOID     |       | [`DOID`](http://www.obofoundry.org/ontology/doid)           | [`doid`](https://bioregistry.io/miriam:doid)                               | True        |                  | `DOID:\d+`                                                                          |
| [`eco`](https://bioregistry.io/eco)                                 | ECO      |       | [`ECO`](http://www.obofoundry.org/ontology/eco)             | [`eco`](https://bioregistry.io/miriam:eco)                                 | True        |                  | `ECO:\d{7}`                                                                         |
| [`envo`](https://bioregistry.io/envo)                               | ENVO     |       | [`ENVO`](http://www.obofoundry.org/ontology/envo)           | [`envo`](https://bioregistry.io/miriam:envo)                               | True        |                  | `ENVO:\d{7,8}`                                                                      |
| [`eo`](https://bioregistry.io/eo)                                   | EO       |       | [`EO`](http://www.obofoundry.org/ontology/eo)               | [`eo`](https://bioregistry.io/miriam:eo)                                   | True        | FAILURE          | `(P)?EO\:\d{7}`                                                                     |
| [`fma`](https://bioregistry.io/fma)                                 | FMA      |       | [`FMA`](http://www.obofoundry.org/ontology/fma)             | [`fma`](https://bioregistry.io/miriam:fma)                                 | True        |                  | `FMA:\d+`                                                                           |
| [`foodon`](https://bioregistry.io/foodon)                           | FOODON   |       | [`FOODON`](http://www.obofoundry.org/ontology/foodon)       | [`foodon`](https://bioregistry.io/miriam:foodon)                           | True        |                  | `FOODON:[0-9]{8}`                                                                   |
| [`geogeo`](https://bioregistry.io/geogeo)                           | GEO      | True  | [`GEO`](http://www.obofoundry.org/ontology/geo)             | [`geogeo`](https://bioregistry.io/miriam:geogeo)                           | False       |                  | `GEO_[0-9]{9}`                                                                      |
| [`go`](https://bioregistry.io/go)                                   | GO       |       | [`GO`](http://www.obofoundry.org/ontology/go)               | [`go`](https://bioregistry.io/miriam:go)                                   | True        |                  | `GO:\d{7}`                                                                          |
| [`go.ref`](https://bioregistry.io/go.ref)                           | GO_REF   |       |                                                             | [`go_ref`](https://bioregistry.io/miriam:go_ref)                           | True        |                  | `GO_REF:\d{7}`                                                                      |
| [`gramene.growthstage`](https://bioregistry.io/gramene.growthstage) | GRO\     |       |                                                             | [`gramene.growthstage`](https://bioregistry.io/miriam:gramene.growthstage) | True        |                  | `GRO\:\d+`                                                                          |
| [`gsso`](https://bioregistry.io/gsso)                               | GSSO     |       | [`GSSO`](http://www.obofoundry.org/ontology/gsso)           | [`gsso`](https://bioregistry.io/miriam:gsso)                               | True        |                  | `GSSO:\d{6}`                                                                        |
| [`hp`](https://bioregistry.io/hp)                                   | HP       |       | [`HP`](http://www.obofoundry.org/ontology/hp)               | [`hp`](https://bioregistry.io/miriam:hp)                                   | True        |                  | `HP:\d{7}`                                                                          |
| [`iao`](https://bioregistry.io/iao)                                 |          | False | [`IAO`](http://www.obofoundry.org/ontology/iao)             | [`iao`](https://bioregistry.io/miriam:iao)                                 | False       |                  | `\d{7}`                                                                             |
| [`ido`](https://bioregistry.io/ido)                                 |          | False | [`IDO`](http://www.obofoundry.org/ontology/ido)             | [`ido`](https://bioregistry.io/miriam:ido)                                 | False       |                  | `[0-9]+`                                                                            |
| [`interpro`](https://bioregistry.io/interpro)                       |          | False | [`IPR`](http://www.obofoundry.org/ontology/ipr)             | [`interpro`](https://bioregistry.io/miriam:interpro)                       | False       |                  | `IPR\d{6}`                                                                          |
| [`ma`](https://bioregistry.io/ma)                                   | MA       |       | [`MA`](http://www.obofoundry.org/ontology/ma)               | [`ma`](https://bioregistry.io/miriam:ma)                                   | True        |                  | `MA:\d+`                                                                            |
| [`mamo`](https://bioregistry.io/mamo)                               | MAMO     |       | [`MAMO`](http://www.obofoundry.org/ontology/mamo)           | [`mamo`](https://bioregistry.io/miriam:mamo)                               | False       |                  | `MAMO_\d{7}`                                                                        |
| [`mge`](https://bioregistry.io/mge)                                 | mge      |       |                                                             | [`mge`](https://bioregistry.io/miriam:mge)                                 | True        |                  | `mge:\d+`                                                                           |
| [`mgi`](https://bioregistry.io/mgi)                                 | MGI      |       |                                                             | [`mgi`](https://bioregistry.io/miriam:mgi)                                 | True        |                  | `MGI:\d+`                                                                           |
| [`mi`](https://bioregistry.io/mi)                                   | MI       |       | [`MI`](http://www.obofoundry.org/ontology/mi)               | [`mi`](https://bioregistry.io/miriam:mi)                                   | True        |                  | `MI:\d{4}`                                                                          |
| [`mir`](https://bioregistry.io/mir)                                 | MIR      |       |                                                             | [`mir`](https://bioregistry.io/miriam:mir)                                 | True        |                  | `MIR:\d{8}`                                                                         |
| [`mo`](https://bioregistry.io/mo)                                   |          | False | [`MO`](http://www.obofoundry.org/ontology/mo)               | [`mo`](https://bioregistry.io/miriam:mo)                                   | False       |                  | `\w+`                                                                               |
| [`mod`](https://bioregistry.io/mod)                                 | MOD      |       | [`MOD`](http://www.obofoundry.org/ontology/mod)             | [`mod`](https://bioregistry.io/miriam:mod)                                 | True        |                  | `MOD:\d{5}`                                                                         |
| [`mp`](https://bioregistry.io/mp)                                   | MP       |       | [`MP`](http://www.obofoundry.org/ontology/mp)               | [`mp`](https://bioregistry.io/miriam:mp)                                   | True        |                  | `MP:\d{7}`                                                                          |
| [`ms`](https://bioregistry.io/ms)                                   | MS       |       | [`MS`](http://www.obofoundry.org/ontology/ms)               | [`ms`](https://bioregistry.io/miriam:ms)                                   | True        |                  | `MS:\d{7}`                                                                          |
| [`mzspec`](https://bioregistry.io/mzspec)                           | mzspec   |       |                                                             | [`mzspec`](https://bioregistry.io/miriam:mzspec)                           | True        |                  | `mzspec:.+`                                                                         |
| [`ncbitaxon`](https://bioregistry.io/ncbitaxon)                     |          | False | [`NCBITaxon`](http://www.obofoundry.org/ontology/ncbitaxon) | [`taxonomy`](https://bioregistry.io/miriam:taxonomy)                       | False       |                  | `\d+`                                                                               |
| [`ncit`](https://bioregistry.io/ncit)                               |          | False | [`NCIT`](http://www.obofoundry.org/ontology/ncit)           | [`ncit`](https://bioregistry.io/miriam:ncit)                               | False       |                  | `C\d+`                                                                              |
| [`nmr`](https://bioregistry.io/nmr)                                 | NMR      |       | [`NMR`](http://www.obofoundry.org/ontology/nmr)             | [`nmr`](https://bioregistry.io/miriam:nmr)                                 | True        |                  | `NMR:\d+`                                                                           |
| [`obi`](https://bioregistry.io/obi)                                 | OBI      | True  | [`OBI`](http://www.obofoundry.org/ontology/obi)             | [`obi`](https://bioregistry.io/miriam:obi)                                 | False       | FAILURE          | `(^OBI:\d{7}$)|(^OBI_\d{7}$)`                                                       |
| [`ocid`](https://bioregistry.io/ocid)                               | ocid     |       |                                                             | [`ocid`](https://bioregistry.io/miriam:ocid)                               | True        |                  | `ocid:[0-9]{12}`                                                                    |
| [`oma.hog`](https://bioregistry.io/oma.hog)                         | HOG      |       |                                                             | [`oma.hog`](https://bioregistry.io/miriam:oma.hog)                         | True        |                  | `HOG:[0-9]{7}(\.[0-9a-z.]+)?(_[0-9]+)?`                                             |
| [`omit`](https://bioregistry.io/omit)                               |          | False | [`OMIT`](http://www.obofoundry.org/ontology/omit)           | [`omit`](https://bioregistry.io/miriam:omit)                               | False       |                  | `\d{7}`                                                                             |
| [`pato`](https://bioregistry.io/pato)                               | PATO     |       | [`PATO`](http://www.obofoundry.org/ontology/pato)           | [`pato`](https://bioregistry.io/miriam:pato)                               | True        |                  | `PATO:\d{7}`                                                                        |
| [`po`](https://bioregistry.io/po)                                   | PO       |       | [`PO`](http://www.obofoundry.org/ontology/po)               | [`po`](https://bioregistry.io/miriam:po)                                   | True        |                  | `PO:\d+`                                                                            |
| [`pr`](https://bioregistry.io/pr)                                   | PR       |       | [`PR`](http://www.obofoundry.org/ontology/pr)               | [`pr`](https://bioregistry.io/miriam:pr)                                   | True        |                  | `PR:P?\d+`                                                                          |
| [`pw`](https://bioregistry.io/pw)                                   | PW       |       | [`PW`](http://www.obofoundry.org/ontology/pw)               | [`pw`](https://bioregistry.io/miriam:pw)                                   | True        |                  | `PW:\d{7}`                                                                          |
| [`resid`](https://bioregistry.io/resid)                             |          | False | [`RESID`](http://www.obofoundry.org/ontology/resid)         | [`resid`](https://bioregistry.io/miriam:resid)                             | False       |                  | `AA\d{4}`                                                                           |
| [`ro`](https://bioregistry.io/ro)                                   | RO       | True  | [`RO`](http://www.obofoundry.org/ontology/ro)               | [`ro`](https://bioregistry.io/miriam:ro)                                   | False       |                  | `RO_\d{7}`                                                                          |
| [`rrid`](https://bioregistry.io/rrid)                               | RRID     |       |                                                             | [`rrid`](https://bioregistry.io/miriam:rrid)                               | True        |                  | `RRID:[a-zA-Z]+.+`                                                                  |
| [`sbo`](https://bioregistry.io/sbo)                                 | SBO      |       | [`SBO`](http://www.obofoundry.org/ontology/sbo)             | [`sbo`](https://bioregistry.io/miriam:sbo)                                 | True        |                  | `SBO:\d{7}`                                                                         |
| [`so`](https://bioregistry.io/so)                                   | SO       |       | [`SO`](http://www.obofoundry.org/ontology/so)               | [`so`](https://bioregistry.io/miriam:so)                                   | True        |                  | `SO:\d{7}`                                                                          |
| [`storedb`](https://bioregistry.io/storedb)                         | STOREDB  | True  |                                                             | [`storedb`](https://bioregistry.io/miriam:storedb)                         | False       |                  | `STOREDB:(STUDY|FILE|DATASET)\d+`                                                   |
| [`swh`](https://bioregistry.io/swh)                                 | swh      |       |                                                             | [`swh`](https://bioregistry.io/miriam:swh)                                 | True        |                  | `swh:[1-9]:(cnt|dir|rel|rev|snp):[0-9a-f]+(;(origin|visit|anchor|path|lines)=\S+)*` |
| [`swisslipid`](https://bioregistry.io/swisslipid)                   | SLM      |       |                                                             | [`slm`](https://bioregistry.io/miriam:slm)                                 | True        |                  | `SLM:\d+`                                                                           |
| [`uberon`](https://bioregistry.io/uberon)                           | UBERON   |       | [`UBERON`](http://www.obofoundry.org/ontology/uberon)       | [`uberon`](https://bioregistry.io/miriam:uberon)                           | True        |                  | `UBERON:\d+`                                                                        |
| [`uo`](https://bioregistry.io/uo)                                   | UO       |       | [`UO`](http://www.obofoundry.org/ontology/uo)               | [`uo`](https://bioregistry.io/miriam:uo)                                   | True        |                  | `UO:\d{7}?`                                                                         |
| [`vario`](https://bioregistry.io/vario)                             | VariO    |       | [`VariO`](http://www.obofoundry.org/ontology/vario)         | [`vario`](https://bioregistry.io/miriam:vario)                             | True        |                  | `VariO:\d+`                                                                         |
| [`xmetdb`](https://bioregistry.io/xmetdb)                           | XMETDB   |       |                                                             |                                                                            |             |                  |                                                                                     |


</details>


<details>
<summary>Code used to generate the table</summary>

```python
import bioregistry
from tabulate import tabulate


def main():
    rows = []
    for resource in bioregistry.resources():
        miriam_prefix = resource.get_miriam_prefix()
        banana = resource.get_banana()
        bioregistry_pe = resource.namespace_in_lui
        miriam_pe = (resource.miriam or {}).get("namespaceEmbeddedInLui")
        if not banana and bioregistry_pe is None and not miriam_pe:
            continue

        miriam_pattern = (resource.miriam or {}).get("pattern", "").lstrip("^").rstrip("$")
        obo_prefix = resource.get_obofoundry_prefix()
        rows.append(
            (
                f"[`{resource.prefix}`](https://bioregistry.io/{resource.prefix})",
                banana,
                bioregistry_pe,
                f"[`{obo_prefix}`](http://www.obofoundry.org/ontology/{obo_prefix.lower()})" if obo_prefix else "",
                f"[`{miriam_prefix}`](https://bioregistry.io/miriam:{miriam_prefix})" if miriam_prefix else "",
                miriam_pe,
                "FAILURE" if miriam_prefix and banana and not miriam_pattern.startswith(banana) else "",
                f"`{miriam_pattern}`" if miriam_pattern else "",
            )
        )

    print(
        tabulate(
            rows,
            headers=["prefix", "banana", "pe", "obo_prefix", "miriam_prefix", "miriam_pe", "correct_banana",
                     "miriam_pattern"],
            tablefmt="github",
        )
    )


if __name__ == "__main__":
    main()
```

</details>