### PR TITLE
Add SPAR ontologies

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4073,9 +4073,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology that allows the description of numerical and categorical bibliometric data (e.g., journal impact factor, author h-index, categories describing research careers) in RDF.",
+    "example": "CategorialBibliometricData",
     "homepage": "http://www.sparontologies.net/ontologies/bido",
+    "mappings": {
+      "fairsharing": "FAIRsharing.d7f0a9"
+    },
     "name": "Bibliometric Data Ontology",
-    "preferred_prefix": "BiDO"
+    "preferred_prefix": "BiDO",
+    "repository": "https://github.com/sparontologies/bido"
   },
   "bigg.compartment": {
     "biocontext": {
@@ -13755,9 +13760,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology that enables the metadata properties of the DataCite Metadata Schema Specification (i.e., a list of metadata properties for the accurate and consistent identification of a resource for citation and retrieval purposes) to be described in RDF.",
+    "example": "AgentIdentifierScheme",
     "homepage": "http://www.sparontologies.net/ontologies/datacite",
+    "mappings": {
+      "fairsharing": "FAIRsharing.c06f1e"
+    },
     "name": "DataCite Ontology",
-    "preferred_prefix": "DataCite"
+    "preferred_prefix": "DataCite",
+    "repository": "https://github.com/sparontologies/datacite"
   },
   "datanator.gene": {
     "mappings": {
@@ -15674,9 +15684,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology that provides a structured vocabulary written of document components, both structural (e.g., block, inline, paragraph, section, chapter) and rhetorical (e.g., introduction, discussion, acknowledgements, reference list, figure, appendix).",
+    "example": "Paragraph",
     "homepage": "http://www.sparontologies.net/ontologies/doco",
+    "mappings": {
+      "fairsharing": "FAIRsharing.162003"
+    },
     "name": "Document Components Ontology",
-    "preferred_prefix": "DoCO"
+    "preferred_prefix": "DoCO",
+    "repository": "https://github.com/sparontologies/doco"
   },
   "doi": {
     "biocontext": {
@@ -21580,9 +21595,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology written in OWL 2 DL to enable characterization of the five attributes of an online journal article - peer review, open access, enriched content, available datasets and machine-readable metadata.",
+    "example": "hasOpenAccessRating",
     "homepage": "http://www.sparontologies.net/ontologies/fivestars",
+    "mappings": {
+      "fairsharing": "FAIRsharing.6dfe9b"
+    },
     "name": "Five Stars of Online Research Articles Ontology",
-    "preferred_prefix": "FiveStars"
+    "preferred_prefix": "FiveStars",
+    "repository": "https://github.com/sparontologies/fivestars"
   },
   "fix": {
     "aberowl": {
@@ -22545,9 +22565,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology that enables the description of reviews of scientific articles and other scholarly resources.",
+    "example": "ReviewVersion",
     "homepage": "http://www.sparontologies.net/ontologies/fr",
+    "mappings": {
+      "fairsharing": "FAIRsharing.e7e609"
+    },
     "name": "FAIR* Reviews Ontology",
-    "preferred_prefix": "FR"
+    "preferred_prefix": "FR",
+    "repository": "https://github.com/sparontologies/fr"
   },
   "frapo": {
     "contributor": {
@@ -22574,9 +22599,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "The Essential FRBR in OWL2 DL Ontology (FRBR) is an expression in OWL 2 DL of the basic concepts and relations described in the IFLA report on the Functional Requirements for Bibliographic Records (FRBR), also described in Ian Davis's RDF vocabulary. It is imported by FaBiO and BiRO.",
+    "example": "Expression",
     "homepage": "http://www.sparontologies.net/ontologies/frbr",
+    "mappings": {
+      "fairsharing": "FAIRsharing.b34b43"
+    },
     "name": "Functional Requirements for Bibliographic Records",
-    "preferred_prefix": "FRBR"
+    "preferred_prefix": "FRBR",
+    "repository": "https://github.com/sparontologies/frbr"
   },
   "fsnp": {
     "biocontext": {
@@ -53636,9 +53666,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology for describing the steps in the workflow associated with the publication of a document or other publication entity.",
+    "example": "Workflow",
     "homepage": "http://www.sparontologies.net/ontologies/pwo",
+    "mappings": {
+      "fairsharing": "FAIRsharing.c4e46c"
+    },
     "name": "Publishing Workflow Ontology",
-    "preferred_prefix": "PWO"
+    "preferred_prefix": "PWO",
+    "repository": "https://github.com/sparontologies/pwo"
   },
   "px": {
     "biocontext": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -6455,7 +6455,7 @@
     "name": "Citation Counting and Context Characterisation Ontology",
     "preferred_prefix": "C4O",
     "repository": "https://github.com/sparontologies/c4o",
-    "uri_format": "http://purl.org/spar/biro/$1"
+    "uri_format": "http://purl.org/spar/c4o/$1"
   },
   "cabri": {
     "biocontext": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4065,6 +4065,18 @@
     },
     "uri_format": "http://bgee.unil.ch/bgee/bgee?page=anatomy&action=organs&stage_children=on&stage_id=$1"
   },
+  "bido": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that allows the description of numerical and categorical bibliometric data (e.g., journal impact factor, author h-index, categories describing research careers) in RDF.",
+    "homepage": "http://www.sparontologies.net/ontologies/bido",
+    "name": "Bibliometric Data Ontology",
+    "preferred_prefix": "BiDO"
+  },
   "bigg.compartment": {
     "biocontext": {
       "is_identifiers": true,
@@ -5578,6 +5590,23 @@
     },
     "name": "Biomedical Informatics Research Network Lexicon"
   },
+  "biro": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology meant to define bibliographic records, bibliographic references, and their compilation into bibliographic collections and bibliographic lists, respectively.",
+    "example": "BibliographicRecord",
+    "homepage": "http://www.sparontologies.net/ontologies/biro",
+    "mappings": {
+      "fairsharing": "FAIRsharing.99da5f"
+    },
+    "name": "Bibliographic Reference Ontology",
+    "preferred_prefix": "BiRO",
+    "repository": "https://github.com/sparontologies/biro"
+  },
   "bitbucket": {
     "fairsharing": {
       "abbreviation": "Bitbucket",
@@ -6405,6 +6434,20 @@
       "uri_format": "http://bykdb.ibcp.fr/data/html/$1.html"
     },
     "provides": "uniprot"
+  },
+  "c4o": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that permits the number of in-text citations of a cited source to be recorded, together with their textual citation contexts, along with the number of citations a cited entity has received globally on a particular date.",
+    "example": "InTextReferencePointer",
+    "homepage": "http://www.sparontologies.net/ontologies/c4o",
+    "name": "Citation Counting and Context Characterisation Ontology",
+    "preferred_prefix": "C4O",
+    "repository": "https://github.com/sparontologies/c4o"
   },
   "cabri": {
     "biocontext": {
@@ -9340,6 +9383,23 @@
       "CTX"
     ],
     "uri_format": "https://europepmc.org/article/CTX/$1"
+  },
+  "cito": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that enables characterization of the nature or type of citations, both factually and rhetorically.",
+    "example": "sharesAuthorInstitutionWith",
+    "homepage": "http://www.sparontologies.net/ontologies/cito",
+    "mappings": {
+      "fairsharing": "FAIRsharing.b220d4"
+    },
+    "name": "Citation Typing Ontology",
+    "preferred_prefix": "CiTO",
+    "repository": "https://github.com/sparontologies/cito"
   },
   "civic.aid": {
     "mappings": {
@@ -13687,6 +13747,18 @@
       "uri_format": "https://dashr1.lisanwanglab.org/entry/hsa-mir-200a#$1#exprPerTissueTable"
     }
   },
+  "datacite": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that enables the metadata properties of the DataCite Metadata Schema Specification (i.e., a list of metadata properties for the accurate and consistent identification of a resource for citation and retrieval purposes) to be described in RDF.",
+    "homepage": "http://www.sparontologies.net/ontologies/datacite",
+    "name": "DataCite Ontology",
+    "preferred_prefix": "DataCite"
+  },
   "datanator.gene": {
     "mappings": {
       "miriam": "datanator.gene"
@@ -14661,6 +14733,18 @@
       "uri_format": "http://degradome.uniovi.es/cgi-bin/protease/$1"
     }
   },
+  "deo": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that provides a structured vocabulary for rhetorical elements within documents (e.g., Introduction, Discussion, Acknowledgements, Reference List, Figures, Appendix). It is imported by DoCO.",
+    "homepage": "http://www.sparontologies.net/ontologies/deo",
+    "name": "Discourse Elements Ontology",
+    "preferred_prefix": "DEO"
+  },
   "depmap": {
     "cellosaurus": {
       "category": "Cell line databases/resources",
@@ -15576,6 +15660,18 @@
     "name": "Developing Mouse Brain Atlas",
     "pattern": "^\\d+$",
     "preferred_prefix": "DMBA"
+  },
+  "doco": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that provides a structured vocabulary written of document components, both structural (e.g., block, inline, paragraph, section, chapter) and rhetorical (e.g., introduction, discussion, acknowledgements, reference list, figure, appendix).",
+    "homepage": "http://www.sparontologies.net/ontologies/doco",
+    "name": "Document Components Ontology",
+    "preferred_prefix": "DoCO"
   },
   "doi": {
     "biocontext": {
@@ -21471,6 +21567,18 @@
       "prefix": "P938"
     }
   },
+  "fivestars": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology written in OWL 2 DL to enable characterization of the five attributes of an online journal article - peer review, open access, enriched content, available datasets and machine-readable metadata.",
+    "homepage": "http://www.sparontologies.net/ontologies/fivestars",
+    "name": "Five Stars of Online Research Articles Ontology",
+    "preferred_prefix": "FiveStars"
+  },
   "fix": {
     "aberowl": {
       "description": "An ontology of physico-chemical methods and properties.",
@@ -22423,6 +22531,42 @@
     "wikidata": {
       "paper": "Q55505864"
     }
+  },
+  "fr": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology that enables the description of reviews of scientific articles and other scholarly resources.",
+    "homepage": "http://www.sparontologies.net/ontologies/fr",
+    "name": "FAIR* Reviews Ontology",
+    "preferred_prefix": "FR"
+  },
+  "frapo": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology for describing the administrative information of research projects, e.g., grant applications, funding bodies, project partners, etc.",
+    "homepage": "http://www.sparontologies.net/ontologies/frapo",
+    "name": "Funding, Research Administration and Projects Ontology",
+    "preferred_prefix": "FRAPO"
+  },
+  "frbr": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "The Essential FRBR in OWL2 DL Ontology (FRBR) is an expression in OWL 2 DL of the basic concepts and relations described in the IFLA report on the Functional Requirements for Bibliographic Records (FRBR), also described in Ian Davis's RDF vocabulary. It is imported by FaBiO and BiRO.",
+    "homepage": "http://www.sparontologies.net/ontologies/frbr",
+    "name": "Functional Requirements for Bibliographic Records",
+    "preferred_prefix": "FRBR"
   },
   "fsnp": {
     "biocontext": {
@@ -32768,186 +32912,6 @@
     "wikidata": {
       "prefix": "P665"
     }
-  },
-  "cito": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "CiTO",
-  "name": "Citation Typing Ontology",
-  "description": "An ontology that enables characterization of the nature or type of citations, both factually and rhetorically.",
-  "homepage":"http://www.sparontologies.net/ontologies/cito"
-  },
-  "biro": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "BiRO",
-  "name": "Bibliographic Reference Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/biro",
-  "description": "An ontology meant to define bibliographic records, bibliographic references, and their compilation into bibliographic collections and bibliographic lists, respectively."
-  },
-  "c4o": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "C4O",
-  "name": "Citation Counting and Context Characterisation Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/c4o",
-  "description": "An ontology that permits the number of in-text citations of a cited source to be recorded, together with their textual citation contexts, along with the number of citations a cited entity has received globally on a particular date."
-  },
-  "doco": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "DoCO",
-  "name": "Document Components Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/doco",
-  "description": "An ontology that provides a structured vocabulary written of document components, both structural (e.g., block, inline, paragraph, section, chapter) and rhetorical (e.g., introduction, discussion, acknowledgements, reference list, figure, appendix)."
-  },
-  "pso": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "PSO",
-  "name": "Publishing Status Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/pso",
-  "description": "An ontology designed to characterise the publication status of documents at each stage of the publishing process (draft, submitted, under review, etc.)."
-  },
-  "puro": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "PuRO",
-  "name": "Publishing Roles Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/pro",
-  "description": "An ontology for the characterisation of the roles of agents – people, corporate bodies and computational agents in the publication process. These agents can be, e.g. authors, editors, reviewers, publishers or librarians."
-  },
-  "pwo": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "PWO",
-  "name": "Publishing Workflow Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/pwo",
-  "description": "An ontology for describing the steps in the workflow associated with the publication of a document or other publication entity."
-  },
-  "frbr": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "FRBR",
-  "name": "Functional Requirements for Bibliographic Records",
-  "homepage": "http://www.sparontologies.net/ontologies/frbr",
-  "description": "The Essential FRBR in OWL2 DL Ontology (FRBR) is an expression in OWL 2 DL of the basic concepts and relations described in the IFLA report on the Functional Requirements for Bibliographic Records (FRBR), also described in Ian Davis's RDF vocabulary. It is imported by FaBiO and BiRO."
-  },
-  "deo": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "DEO",
-  "name": "Discourse Elements Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/deo",
-  "description": "An ontology that provides a structured vocabulary for rhetorical elements within documents (e.g., Introduction, Discussion, Acknowledgements, Reference List, Figures, Appendix). It is imported by DoCO."
-  },
-  "scoro": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "SCoRO",
-  "name": "Scholarly Contributions and Roles Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/scoro",
-  "description": "An ontology based on PRO for describing the contributions that may be made, and the roles that may be held by a person with respect to a journal article or other publication (e.g. the role of article guarantor or illustrator)."
-  },
-  "frapo": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "FRAPO",
-  "name": "Funding, Research Administration and Projects Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/frapo",
-  "description": "An ontology for describing the administrative information of research projects, e.g., grant applications, funding bodies, project partners, etc."
-  },
-  "datacite": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "DataCite",
-  "name": "DataCite Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/datacite",
-  "description": "An ontology that enables the metadata properties of the DataCite Metadata Schema Specification (i.e., a list of metadata properties for the accurate and consistent identification of a resource for citation and retrieval purposes) to be described in RDF."
-  },
-  "bido": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "BiDO",
-  "name": "Bibliometric Data Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/bido",
-  "description": "An ontology that allows the description of numerical and categorical bibliometric data (e.g., journal impact factor, author h-index, categories describing research careers) in RDF."
-  },
-  "fivestars": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "FiveStars",
-  "name": "Five Stars of Online Research Articles Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/fivestars",
-  "description": "An ontology written in OWL 2 DL to enable characterization of the five attributes of an online journal article - peer review, open access, enriched content, available datasets and machine-readable metadata."
-  },
-  "fr": {
-  "contributor": {
-      "email": "cthoyt@gmail.com",
-      "github": "cthoyt",
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
-  "preferred_prefix": "FR",
-  "name": "FAIR* Reviews Ontology",
-  "homepage": "http://www.sparontologies.net/ontologies/fr",
-  "description": "An ontology that enables the description of reviews of scientific articles and other scholarly resources."
   },
   "kegg.genome": {
     "biocontext": {
@@ -53495,6 +53459,18 @@
       "prefix": "P698"
     }
   },
+  "puro": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology for the characterisation of the roles of agents – people, corporate bodies and computational agents in the publication process. These agents can be, e.g. authors, editors, reviewers, publishers or librarians.",
+    "homepage": "http://www.sparontologies.net/ontologies/pro",
+    "name": "Publishing Roles Ontology",
+    "preferred_prefix": "PuRO"
+  },
   "pw": {
     "aberowl": {
       "description": "A controlled vocabulary for annotating gene products to pathways.",
@@ -53636,6 +53612,18 @@
       "database": "Q28864280",
       "prefix": "P7333"
     }
+  },
+  "pwo": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology for describing the steps in the workflow associated with the publication of a document or other publication entity.",
+    "homepage": "http://www.sparontologies.net/ontologies/pwo",
+    "name": "Publishing Workflow Ontology",
+    "preferred_prefix": "PWO"
   },
   "px": {
     "biocontext": {
@@ -56730,6 +56718,18 @@
     },
     "name": "Scopus Researcher",
     "pattern": "^\\d+$"
+  },
+  "scoro": {
+    "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "description": "An ontology based on PRO for describing the contributions that may be made, and the roles that may be held by a person with respect to a journal article or other publication (e.g. the role of article guarantor or illustrator).",
+    "homepage": "http://www.sparontologies.net/ontologies/scoro",
+    "name": "Scholarly Contributions and Roles Ontology",
+    "preferred_prefix": "SCoRO"
   },
   "scr": {
     "contributor": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -32769,6 +32769,186 @@
       "prefix": "P665"
     }
   },
+  "cito": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "CiTO",
+  "name": "Citation Typing Ontology",
+  "description": "An ontology that enables characterization of the nature or type of citations, both factually and rhetorically.",
+  "homepage":"http://www.sparontologies.net/ontologies/cito"
+  },
+  "biro": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "BiRO",
+  "name": "Bibliographic Reference Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/biro",
+  "description": "An ontology meant to define bibliographic records, bibliographic references, and their compilation into bibliographic collections and bibliographic lists, respectively."
+  },
+  "c4o": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "C4O",
+  "name": "Citation Counting and Context Characterisation Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/c4o",
+  "description": "An ontology that permits the number of in-text citations of a cited source to be recorded, together with their textual citation contexts, along with the number of citations a cited entity has received globally on a particular date."
+  },
+  "doco": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "DoCO",
+  "name": "Document Components Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/doco",
+  "description": "An ontology that provides a structured vocabulary written of document components, both structural (e.g., block, inline, paragraph, section, chapter) and rhetorical (e.g., introduction, discussion, acknowledgements, reference list, figure, appendix)."
+  },
+  "pso": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "PSO",
+  "name": "Publishing Status Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/pso",
+  "description": "An ontology designed to characterise the publication status of documents at each stage of the publishing process (draft, submitted, under review, etc.)."
+  },
+  "puro": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "PuRO",
+  "name": "Publishing Roles Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/pro",
+  "description": "An ontology for the characterisation of the roles of agents – people, corporate bodies and computational agents in the publication process. These agents can be, e.g. authors, editors, reviewers, publishers or librarians."
+  },
+  "pwo": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "PWO",
+  "name": "Publishing Workflow Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/pwo",
+  "description": "An ontology for describing the steps in the workflow associated with the publication of a document or other publication entity."
+  },
+  "frbr": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "FRBR",
+  "name": "Functional Requirements for Bibliographic Records",
+  "homepage": "http://www.sparontologies.net/ontologies/frbr",
+  "description": "The Essential FRBR in OWL2 DL Ontology (FRBR) is an expression in OWL 2 DL of the basic concepts and relations described in the IFLA report on the Functional Requirements for Bibliographic Records (FRBR), also described in Ian Davis's RDF vocabulary. It is imported by FaBiO and BiRO."
+  },
+  "deo": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "DEO",
+  "name": "Discourse Elements Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/deo",
+  "description": "An ontology that provides a structured vocabulary for rhetorical elements within documents (e.g., Introduction, Discussion, Acknowledgements, Reference List, Figures, Appendix). It is imported by DoCO."
+  },
+  "scoro": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "SCoRO",
+  "name": "Scholarly Contributions and Roles Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/scoro",
+  "description": "An ontology based on PRO for describing the contributions that may be made, and the roles that may be held by a person with respect to a journal article or other publication (e.g. the role of article guarantor or illustrator)."
+  },
+  "frapo": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "FRAPO",
+  "name": "Funding, Research Administration and Projects Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/frapo",
+  "description": "An ontology for describing the administrative information of research projects, e.g., grant applications, funding bodies, project partners, etc."
+  },
+  "datacite": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "DataCite",
+  "name": "DataCite Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/datacite",
+  "description": "An ontology that enables the metadata properties of the DataCite Metadata Schema Specification (i.e., a list of metadata properties for the accurate and consistent identification of a resource for citation and retrieval purposes) to be described in RDF."
+  },
+  "bido": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "BiDO",
+  "name": "Bibliometric Data Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/bido",
+  "description": "An ontology that allows the description of numerical and categorical bibliometric data (e.g., journal impact factor, author h-index, categories describing research careers) in RDF."
+  },
+  "fivestars": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "FiveStars",
+  "name": "Five Stars of Online Research Articles Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/fivestars",
+  "description": "An ontology written in OWL 2 DL to enable characterization of the five attributes of an online journal article - peer review, open access, enriched content, available datasets and machine-readable metadata."
+  },
+  "fr": {
+  "contributor": {
+      "email": "cthoyt@gmail.com",
+      "github": "cthoyt",
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+  "preferred_prefix": "FR",
+  "name": "FAIR* Reviews Ontology",
+  "homepage": "http://www.sparontologies.net/ontologies/fr",
+  "description": "An ontology that enables the description of reviews of scientific articles and other scholarly resources."
+  },
   "kegg.genome": {
     "biocontext": {
       "is_identifiers": true,

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -4080,7 +4080,8 @@
     },
     "name": "Bibliometric Data Ontology",
     "preferred_prefix": "BiDO",
-    "repository": "https://github.com/sparontologies/bido"
+    "repository": "https://github.com/sparontologies/bido",
+    "uri_format": "http://purl.org/spar/bido/$1"
   },
   "bigg.compartment": {
     "biocontext": {
@@ -5610,7 +5611,8 @@
     },
     "name": "Bibliographic Reference Ontology",
     "preferred_prefix": "BiRO",
-    "repository": "https://github.com/sparontologies/biro"
+    "repository": "https://github.com/sparontologies/biro",
+    "uri_format": "http://purl.org/spar/biro/$1"
   },
   "bitbucket": {
     "fairsharing": {
@@ -6452,7 +6454,8 @@
     "homepage": "http://www.sparontologies.net/ontologies/c4o",
     "name": "Citation Counting and Context Characterisation Ontology",
     "preferred_prefix": "C4O",
-    "repository": "https://github.com/sparontologies/c4o"
+    "repository": "https://github.com/sparontologies/c4o",
+    "uri_format": "http://purl.org/spar/biro/$1"
   },
   "cabri": {
     "biocontext": {
@@ -9404,7 +9407,8 @@
     },
     "name": "Citation Typing Ontology",
     "preferred_prefix": "CiTO",
-    "repository": "https://github.com/sparontologies/cito"
+    "repository": "https://github.com/sparontologies/cito",
+    "uri_format": "http://purl.org/spar/cito/$1"
   },
   "civic.aid": {
     "mappings": {
@@ -13767,7 +13771,8 @@
     },
     "name": "DataCite Ontology",
     "preferred_prefix": "DataCite",
-    "repository": "https://github.com/sparontologies/datacite"
+    "repository": "https://github.com/sparontologies/datacite",
+    "uri_format": "http://purl.org/spar/datacite/$1"
   },
   "datanator.gene": {
     "mappings": {
@@ -14758,7 +14763,8 @@
     },
     "name": "Discourse Elements Ontology",
     "preferred_prefix": "DEO",
-    "repository": "https://github.com/sparontologies/deo"
+    "repository": "https://github.com/sparontologies/deo",
+    "uri_format": "http://purl.org/spar/deo/$1"
   },
   "depmap": {
     "cellosaurus": {
@@ -15691,7 +15697,8 @@
     },
     "name": "Document Components Ontology",
     "preferred_prefix": "DoCO",
-    "repository": "https://github.com/sparontologies/doco"
+    "repository": "https://github.com/sparontologies/doco",
+    "uri_format": "http://purl.org/spar/doco/$1"
   },
   "doi": {
     "biocontext": {
@@ -20684,6 +20691,15 @@
       "fairsharing": "FAIRsharing.2f3180"
     },
     "name": "FaBiO, the FRBR-aligned Bibliographic Ontology",
+    "providers": [
+      {
+        "code": "rdf",
+        "description": "A persistent URL for FaBiO",
+        "homepage": "https://github.com/sparontologies/fabio",
+        "name": "FABIO PURL",
+        "uri_format": "http://purl.org/spar/fabio/$1"
+      }
+    ],
     "repository": "https://github.com/sparontologies/fabio",
     "uri_format": "https://sparontologies.github.io/fabio/current/fabio.html#$1"
   },
@@ -22589,7 +22605,8 @@
     },
     "name": "Funding, Research Administration and Projects Ontology",
     "preferred_prefix": "FRAPO",
-    "repository": "https://github.com/sparontologies/frapo"
+    "repository": "https://github.com/sparontologies/frapo",
+    "uri_format": "http://purl.org/cerif/frapo/$1"
   },
   "frbr": {
     "contributor": {
@@ -22606,7 +22623,8 @@
     },
     "name": "Functional Requirements for Bibliographic Records",
     "preferred_prefix": "FRBR",
-    "repository": "https://github.com/sparontologies/frbr"
+    "repository": "https://github.com/sparontologies/frbr",
+    "uri_format": "http://purl.org/vocab/frbr/core#$1"
   },
   "fsnp": {
     "biocontext": {
@@ -53514,7 +53532,8 @@
     },
     "name": "Publishing Roles Ontology",
     "preferred_prefix": "PuRO",
-    "repository": "https://github.com/sparontologies/pro"
+    "repository": "https://github.com/sparontologies/pro",
+    "uri_format": "http://purl.org/spar/pro/$1"
   },
   "pw": {
     "aberowl": {
@@ -53673,7 +53692,8 @@
     },
     "name": "Publishing Workflow Ontology",
     "preferred_prefix": "PWO",
-    "repository": "https://github.com/sparontologies/pwo"
+    "repository": "https://github.com/sparontologies/pwo",
+    "uri_format": "http://purl.org/spar/pwo/$1"
   },
   "px": {
     "biocontext": {
@@ -56784,7 +56804,8 @@
     },
     "name": "Scholarly Contributions and Roles Ontology",
     "preferred_prefix": "SCoRO",
-    "repository": "https://github.com/sparontologies/scoro"
+    "repository": "https://github.com/sparontologies/scoro",
+    "uri_format": "http://purl.org/spar/scoro/$1"
   },
   "scr": {
     "contributor": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -14741,9 +14741,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology that provides a structured vocabulary for rhetorical elements within documents (e.g., Introduction, Discussion, Acknowledgements, Reference List, Figures, Appendix). It is imported by DoCO.",
+    "example": "Reference",
     "homepage": "http://www.sparontologies.net/ontologies/deo",
+    "mappings": {
+      "fairsharing": "FAIRsharing.39fd58"
+    },
     "name": "Discourse Elements Ontology",
-    "preferred_prefix": "DEO"
+    "preferred_prefix": "DEO",
+    "repository": "https://github.com/sparontologies/deo"
   },
   "depmap": {
     "cellosaurus": {
@@ -22552,9 +22557,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology for describing the administrative information of research projects, e.g., grant applications, funding bodies, project partners, etc.",
+    "example": "Grant",
     "homepage": "http://www.sparontologies.net/ontologies/frapo",
+    "mappings": {
+      "fairsharing": "FAIRsharing.0a2576"
+    },
     "name": "Funding, Research Administration and Projects Ontology",
-    "preferred_prefix": "FRAPO"
+    "preferred_prefix": "FRAPO",
+    "repository": "https://github.com/sparontologies/frapo"
   },
   "frbr": {
     "contributor": {
@@ -53467,9 +53477,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology for the characterisation of the roles of agents – people, corporate bodies and computational agents in the publication process. These agents can be, e.g. authors, editors, reviewers, publishers or librarians.",
+    "example": "RoleInTime",
     "homepage": "http://www.sparontologies.net/ontologies/pro",
+    "mappings": {
+      "fairsharing": "FAIRsharing.3e88d6"
+    },
     "name": "Publishing Roles Ontology",
-    "preferred_prefix": "PuRO"
+    "preferred_prefix": "PuRO",
+    "repository": "https://github.com/sparontologies/pro"
   },
   "pw": {
     "aberowl": {
@@ -56727,9 +56742,14 @@
       "orcid": "0000-0003-4423-4370"
     },
     "description": "An ontology based on PRO for describing the contributions that may be made, and the roles that may be held by a person with respect to a journal article or other publication (e.g. the role of article guarantor or illustrator).",
+    "example": "IntellectualContribution",
     "homepage": "http://www.sparontologies.net/ontologies/scoro",
+    "mappings": {
+      "fairsharing": "FAIRsharing.c86b48"
+    },
     "name": "Scholarly Contributions and Roles Ontology",
-    "preferred_prefix": "SCoRO"
+    "preferred_prefix": "SCoRO",
+    "repository": "https://github.com/sparontologies/scoro"
   },
   "scr": {
     "contributor": {

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -156,7 +156,7 @@
           "orcid": "0000-0003-4423-4370"
         }
       ],
-      "description": "...",
+      "description": "The [Semantic Publishing and Referencing (SPAR) Ontologies](http://www.sparontologies.net/ontologies) are a suite of orthogonal and complementary OWL 2 ontologies that enable all aspects of the publishing process to be described in machine-readable metadata statements, encoded using RDF.",
       "identifier": "0000006",
       "name": "SPAR Ontologies",
       "resources": [

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -146,6 +146,34 @@
         "mba",
         "pba"
       ]
+    },
+    {
+      "authors": [
+        {
+          "email": "cthoyt@gmail.com",
+          "github": "cthoyt",
+          "name": "Charles Tapley Hoyt",
+          "orcid": "0000-0003-4423-4370"
+        }
+      ],
+      "description": "...",
+      "identifier": "0000006",
+      "name": "SPAR Ontologies",
+      "resources": [
+        "bido",
+        "biro",
+        "c4o",
+        "cito",
+        "datacite",
+        "deo",
+        "doco",
+        "fabio",
+        "frapo",
+        "pso",
+        "puro",
+        "pwo",
+        "scoro"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Motivated by the Trello card https://trello.com/c/xzXh2cyJ/4-adding-all-spar-ontologies-in-fairsharingorg, this PR closes #428 by adding the list of SPAR Ontologies from http://www.sparontologies.net/ontologies. Two notes:

1. `foco` and `c2w` were omitted because I couldn't find any links or information to them
2. `pro` conflicts with the Protein Ontology (PR) that has a colloquial synonym of `pro`, so it was given the prefix `puro`. This is an unfortunate inevitability of registries of short prefixes.

After this is merged and the service is re-deployed tonight, these prefixes can be viewed pages like https://bioregistry.io/fabio and this collection will be listed at https://bioregistry.io/collection/0000006.

CC @essepuntato