### PR TITLE
Add OMA provider to UniProt

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -63292,6 +63292,13 @@
         "homepage": "https://scholia.toolforge.org/",
         "name": "Scholia",
         "uri_format": "https://scholia.toolforge.org/uniprot/$1"
+      },
+      {
+        "code": "oma",
+        "description": "The OMA project is a method and database for the inference of orthologs among complete genomes.",
+        "homepage": "https://omabrowser.org/oma/home/",
+        "name": "Orthologous Matrix Browser",
+        "uri_format": "http://omabrowser.org/cgi-bin/gateway.pl?f=DisplayEntry&p2=orthologs&p1=$1"
       }
     ],
     "synonyms": [


### PR DESCRIPTION
OMA provides information about UniProt proteins. I realized this exists when reading through the ontology quality assessment page on https://cthoyt.com/oquat/unknowns/prefix/oma. 

PR pages that shadow UniProt identifiers like https://proconsortium.org/app/entry/PR:Q01112 have links to OMA as if they're xrefs.