### PR TITLE
Implement getting pattern with namespace embedded

### DIFF
--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -32,9 +32,9 @@ from bioregistry.schema.utils import EMAIL_RE
 from bioregistry.utils import removeprefix, removesuffix
 
 try:
-    from typing import Literal, Match  # type:ignore
+    from typing import Literal, Pattern  # type:ignore
 except ImportError:
-    from typing_extensions import Literal, Match  # type:ignore
+    from typing_extensions import Literal, Pattern  # type:ignore
 
 __all__ = [
     "Attributable",
@@ -669,7 +669,7 @@ class Resource(BaseModel):
             return None
         return re.compile(pattern)
 
-    def get_pattern_re_with_banana(self, strict: bool = True) -> Optional[Match]:
+    def get_pattern_re_with_banana(self, strict: bool = True) -> Optional[Pattern]:
         """Get the compiled pattern for the prefix including a banana if available.
 
         :param strict: If True (default), and a banana exists for the prefix,

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -701,11 +701,10 @@ class Resource(BaseModel):
             return re.compile(pattern)
 
         banana_peel = self.get_banana_peel()
-        if strict:
-            head = f"^({banana}{banana_peel})?"
-        else:
-            head = f"^{banana}{banana_peel}"
-        return re.compile(pattern + pattern.lstrip("^"))
+        prepattern = f"{banana}{banana_peel}"
+        if not strict:
+            prepattern = f"({prepattern})?"
+        return re.compile("^" + prepattern + pattern.lstrip("^"))
 
     def get_namespace_in_lui(self) -> Optional[bool]:
         """Check if the namespace should appear in the LUI."""

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -693,7 +693,7 @@ class Resource(BaseModel):
 
         Non-strict match allows the banana to be optionally present
         >>> resource.get_pattern_with_banana(strict=False)
-         '^(CHEBI:)?\\d+$'
+        '^(CHEBI:)?\\d+$'
         """
         pattern = self.get_pattern()
         if pattern is None:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -669,6 +669,43 @@ class Resource(BaseModel):
             return None
         return re.compile(pattern)
 
+    def get_pattern_with_banana(self, strict: bool = True) -> Optional[str]:
+        """Get the pattern for the prefix including a banana if available.
+
+        .. warning::
+
+            This function is meant to mediate backwards compatibility with legacy
+            MIRIAM/Identifiers.org standards. New projects should **not** use redundant
+            prefixes in their local unique identifiers.
+
+        :param strict: If True (default), and a banana exists for the prefix,
+            the banana is required in the pattern. If False, the pattern
+            will match the banana if present but will also match the identifier
+            without the banana.
+        :returns: A pattern for the prefix if available
+
+        >>> import bioregistry as br
+        >>> resource = br.get_resource("chebi")
+
+        Strict match requires banana
+        >>> resource.get_pattern_with_banana()
+        '^CHEBI:\\d+$'
+        >>> resource.get_pattern_with_banana(strict=False)
+         '^(CHEBI:)?\\d+$'
+        """
+        pattern = self.get_pattern()
+        if pattern is None:
+            return None
+        banana = self.get_banana()
+        if not banana:
+            return pattern
+
+        banana_peel = self.get_banana_peel()
+        prepattern = f"{banana}{banana_peel}"
+        if not strict:
+            prepattern = f"({prepattern})?"
+        return "^" + prepattern + pattern.lstrip("^")
+
     def get_pattern_re_with_banana(self, strict: bool = True):
         """Get the compiled pattern for the prefix including a banana if available.
 
@@ -688,9 +725,9 @@ class Resource(BaseModel):
         >>> resource = br.get_resource("chebi")
 
         Strict match requires banana
-        >>> pattern = resource.get_pattern_re_with_banana().match("1234")
+        >>> resource.get_pattern_re_with_banana().match("1234")
 
-        >>> pattern = resource.get_pattern_re_with_banana().match("CHEBI:1234")
+        >>> resource.get_pattern_re_with_banana().match("CHEBI:1234")
         <re.Match object; span=(0, 10), match='CHEBI:1234'>
 
         Loose match does not require banana
@@ -699,18 +736,10 @@ class Resource(BaseModel):
         >>> resource.get_pattern_re_with_banana(strict=False).match('CHEBI:1234')
         <re.Match object; span=(0, 10), match='CHEBI:1234'>
         """
-        pattern = self.get_pattern()
-        if pattern is None:
+        p = self.get_pattern_with_banana(strict=strict)
+        if p is None:
             return None
-        banana = self.get_banana()
-        if not banana:
-            return re.compile(pattern)
-
-        banana_peel = self.get_banana_peel()
-        prepattern = f"{banana}{banana_peel}"
-        if not strict:
-            prepattern = f"({prepattern})?"
-        return re.compile("^" + prepattern + pattern.lstrip("^"))
+        return re.compile(p)
 
     def get_namespace_in_lui(self) -> Optional[bool]:
         """Check if the namespace should appear in the LUI."""

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -669,6 +669,24 @@ class Resource(BaseModel):
             return None
         return re.compile(pattern)
 
+    def get_pattern_re_with_banana(self, strict: bool = True):
+        """Get the compiled pattern for the prefix including a banana if available.
+
+        :param strict: If True (default), and a banana exists for the prefix,
+            the banana is required in the pattern. If False, the pattern
+            will match the banana if present but will also match the identifier
+            without the banana.
+        """
+        pattern = self.get_pattern()
+        if pattern is None:
+            return None
+        banana = self.get_banana()
+        banana_peel = self.get_banana_peel() or ':'
+        optional = '' if strict else '?'
+        if banana:
+            pattern = f'^({banana}{banana_peel}){optional}' + pattern[1:]
+        return re.compile(pattern)
+
     def get_namespace_in_lui(self) -> Optional[bool]:
         """Check if the namespace should appear in the LUI."""
         if self.namespace_in_lui is not None:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -670,7 +670,7 @@ class Resource(BaseModel):
         return re.compile(pattern)
 
     def get_pattern_with_banana(self, strict: bool = True) -> Optional[str]:
-        """Get the pattern for the prefix including a banana if available.
+        r"""Get the pattern for the prefix including a banana if available.
 
         .. warning::
 
@@ -687,9 +687,11 @@ class Resource(BaseModel):
         >>> import bioregistry as br
         >>> resource = br.get_resource("chebi")
 
-        Strict match requires banana
+        Strict match requires the banana to be present
         >>> resource.get_pattern_with_banana()
         '^CHEBI:\\d+$'
+
+        Non-strict match allows the banana to be optionally present
         >>> resource.get_pattern_with_banana(strict=False)
          '^(CHEBI:)?\\d+$'
         """

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -32,9 +32,9 @@ from bioregistry.schema.utils import EMAIL_RE
 from bioregistry.utils import removeprefix, removesuffix
 
 try:
-    from typing import Literal, Pattern  # type:ignore
+    from typing import Literal  # type:ignore
 except ImportError:
-    from typing_extensions import Literal, Pattern  # type:ignore
+    from typing_extensions import Literal  # type:ignore
 
 __all__ = [
     "Attributable",
@@ -669,8 +669,14 @@ class Resource(BaseModel):
             return None
         return re.compile(pattern)
 
-    def get_pattern_re_with_banana(self, strict: bool = True) -> Optional[Pattern]:
+    def get_pattern_re_with_banana(self, strict: bool = True):
         """Get the compiled pattern for the prefix including a banana if available.
+
+        .. warning::
+
+            This function is meant to mediate backwards compatibility with legacy
+            MIRIAM/Identifiers.org standards. New projects should **not** use redundant
+            prefixes in their local unique identifiers.
 
         :param strict: If True (default), and a banana exists for the prefix,
             the banana is required in the pattern. If False, the pattern
@@ -683,7 +689,7 @@ class Resource(BaseModel):
 
         Strict match requires banana
         >>> pattern = resource.get_pattern_re_with_banana().match("1234")
-        None
+
         >>> pattern = resource.get_pattern_re_with_banana().match("CHEBI:1234")
         <re.Match object; span=(0, 10), match='CHEBI:1234'>
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -669,23 +669,28 @@ class Resource(BaseModel):
             return None
         return re.compile(pattern)
 
-    def get_pattern_re_with_banana(self, strict: bool = True):
+    def get_pattern_re_with_banana(self, strict: bool = True) -> Optional[str]:
         """Get the compiled pattern for the prefix including a banana if available.
 
         :param strict: If True (default), and a banana exists for the prefix,
             the banana is required in the pattern. If False, the pattern
             will match the banana if present but will also match the identifier
             without the banana.
+        :returns: A compiled pattern for the prefix if available
         """
         pattern = self.get_pattern()
         if pattern is None:
             return None
         banana = self.get_banana()
-        banana_peel = self.get_banana_peel() or ':'
-        optional = '' if strict else '?'
-        if banana:
-            pattern = f'^({banana}{banana_peel}){optional}' + pattern[1:]
-        return re.compile(pattern)
+        if not banana:
+            return re.compile(pattern)
+
+        banana_peel = self.get_banana_peel()
+        if optional:
+            head = f"^({banana}{banana_peel})?"
+        else:
+            head = f"^{banana}{banana_peel}"
+        return re.compile(pattern + pattern.lstrip("^"))
 
     def get_namespace_in_lui(self) -> Optional[bool]:
         """Check if the namespace should appear in the LUI."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -294,6 +294,15 @@ class TestRegistry(unittest.TestCase):
                     ),
                 )
 
+    def test_pattern_with_banana(self):
+        """Test getting patterns with bananas."""
+        resource = self.registry["chebi"]
+        self.assertEqual(
+            "^CHEBI:\\d+$",
+            resource.get_pattern_with_banana(),
+        )
+        self.assertEqual("^(CHEBI:)?\\d+$", resource.get_pattern_with_banana(strict=False))
+
     def test_examples(self):
         """Test examples for the required conditions.
 


### PR DESCRIPTION
This PR adds a method for the `Resource` class called `get_pattern_re_with_banana` which returns a version of the identifier pattern that matches the embedded namespace (aka banana) in the identifier.

Some example usages:
```python
In [1]: import bioregistry
In [2]: ch = bioregistry.get_resource('chebi')

In [3]: ch.get_pattern_re_with_banana()
Out[3]: re.compile(r'^(CHEBI:)\d+$', re.UNICODE)

In [4]: ch.get_pattern_re_with_banana().match('1234')

In [5]: ch.get_pattern_re_with_banana().match('CHEBI:1234')
Out[5]: <re.Match object; span=(0, 10), match='CHEBI:1234'>

In [6]: ch.get_pattern_re_with_banana(strict=False).match('1234')
Out[6]: <re.Match object; span=(0, 4), match='1234'>

In [7]: ch.get_pattern_re_with_banana(strict=False).match('CHEBI:1234')
Out[7]: <re.Match object; span=(0, 10), match='CHEBI:1234'>
```