### PR TITLE
Improved handling of preferred prefixes

### DIFF
--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -84,15 +84,9 @@ def resource(prefix: str):
     if _resource is None:
         raise RuntimeError
     example = _resource.get_example()
-    # TODO move into manager
-    example_curie = (
-        curie_to_str(_resource.get_preferred_prefix() or prefix, example) if example else None
-    )
+    example_curie = _resource.get_curie(example) if example else None
     example_extras = _resource.example_extras or []
-    example_curie_extras = [
-        curie_to_str(_resource.get_preferred_prefix() or prefix, example_extra)
-        for example_extra in example_extras
-    ]
+    example_curie_extras = [_resource.get_curie(example_extra) for example_extra in example_extras]
     return render_template(
         "resource.html",
         zip=zip,

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -84,7 +84,7 @@ def resource(prefix: str):
     if _resource is None:
         raise RuntimeError
     example = _resource.get_example()
-    example_curie = _resource.get_curie(example) if example else None
+    example_curie = _resource.get_example_curie()
     example_extras = _resource.example_extras or []
     example_curie_extras = [_resource.get_curie(example_extra) for example_extra in example_extras]
     return render_template(

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -5,7 +5,7 @@
 from functools import lru_cache
 from typing import List, Mapping, Optional, Tuple, Union
 
-from .resolve import parse_curie
+from .resolve import get_preferred_prefix, parse_curie
 from .resource_manager import prepare_prefix_list
 from .uri_format import get_prefix_map
 from .utils import curie_to_str
@@ -28,12 +28,17 @@ PrefixList = List[Tuple[str, str]]
 
 
 def curie_from_iri(
-    iri: str, *, prefix_map: Union[Mapping[str, str], PrefixList, None] = None
+    iri: str,
+    *,
+    prefix_map: Union[Mapping[str, str], PrefixList, None] = None,
+    use_preferred: bool = False,
 ) -> Optional[str]:
     """Parse a compact identifier from an IRI using :func:`parse_iri` and reconstitute it.
 
     :param iri: A valid IRI
     :param prefix_map: See :func:`parse_iri`
+    :param use_preferred: Should the preferred prefix be used instead
+        of the Bioregistry prefix (if it exists)?
     :return: A CURIE string, if the IRI can be parsed by :func:`parse_iri`.
 
     IRI from an OBO PURL:
@@ -72,10 +77,16 @@ def curie_from_iri(
     IRI from N2T
     >>> curie_from_iri("https://n2t.net/aop.relationships:5")
     'aop.relationships:5'
+
+    IRI from an OBO PURL (with preferred prefix)
+    >>> curie_from_iri("http://purl.obolibrary.org/obo/DRON_00023232", use_preferred=True)
+    'DRON:00023232'
     """
     prefix, identifier = parse_iri(iri=iri, prefix_map=prefix_map)
     if prefix is None or identifier is None:
         return None
+    if use_preferred:
+        prefix = get_preferred_prefix(prefix) or prefix
     return curie_to_str(prefix, identifier)
 
 

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -900,13 +900,15 @@ def get_versions() -> Mapping[str, str]:
     return manager.get_versions()
 
 
-def get_curie_pattern(prefix: str) -> Optional[str]:
+def get_curie_pattern(prefix: str, use_preferred: bool = False) -> Optional[str]:
     """Get the CURIE pattern for this resource.
 
     :param prefix: The prefix to look up
+    :param use_preferred: Should the preferred prefix be used instead
+        of the Bioregistry prefix (if it exists)?
     :return: The regular expression pattern to match CURIEs against
     """
-    return manager.get_curie_pattern(prefix)
+    return manager.get_curie_pattern(prefix, use_preferred=use_preferred)
 
 
 def get_license_conflicts():

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -386,10 +386,7 @@ class Manager:
         pattern = resource.get_pattern()
         if pattern is None:
             return None
-        if use_preferred:
-            p = resource.get_preferred_prefix() or resource.prefix
-        else:
-            p = resource.prefix
+        p = resource.get_preferred_prefix() or resource.prefix if use_preferred else resource.prefix
         p = p.replace(".", "\\.")
         return f"^{p}:{pattern.lstrip('^')}"
 

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -372,13 +372,13 @@ class Manager:
 
         >>> from bioregistry import manager
         >>> manager.get_curie_pattern("go")
-        'go:\d{7}'
+        '^go:\\d{7}$'
         >>> manager.get_curie_pattern("go", use_preferred=True)
-        'GO:\d{7}'
+        '^GO:\\d{7}$'
         >>> manager.get_curie_pattern("kegg.compound")
-        '^kegg\.compound:C\d+$'
+        '^kegg\\.compound:C\\d+$'
         >>> manager.get_curie_pattern("KEGG.COMPOUND")
-        '^kegg\.compound:C\d+$'
+        '^kegg\\.compound:C\\d+$'
         """
         resource = self.get_resource(prefix)
         if resource is None:

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -362,11 +362,23 @@ class Manager:
         #: in order to avoid conflicts of sub-URIs (thanks to Nico Matentzoglu for the idea)
         return prepare_prefix_list(self.get_prefix_map(**kwargs))
 
-    def get_curie_pattern(self, prefix: str) -> Optional[str]:
-        """Get the CURIE pattern for this resource.
+    def get_curie_pattern(self, prefix: str, use_preferred: bool = False) -> Optional[str]:
+        r"""Get the CURIE pattern for this resource.
 
         :param prefix: The prefix to look up
+        :param use_preferred: Should the preferred prefix be used instead
+            of the Bioregistry prefix (if it exists)?
         :return: The regular expression pattern to match CURIEs against
+
+        >>> from bioregistry import manager
+        >>> manager.get_curie_pattern("go")
+        'go:\d{7}'
+        >>> manager.get_curie_pattern("go", use_preferred=True)
+        'GO:\d{7}'
+        >>> manager.get_curie_pattern("kegg.compound")
+        '^kegg\.compound:C\d+$'
+        >>> manager.get_curie_pattern("KEGG.COMPOUND")
+        '^kegg\.compound:C\d+$'
         """
         resource = self.get_resource(prefix)
         if resource is None:
@@ -374,7 +386,10 @@ class Manager:
         pattern = resource.get_pattern()
         if pattern is None:
             return None
-        p = resource.get_preferred_prefix() or prefix
+        if use_preferred:
+            p = resource.get_preferred_prefix() or resource.prefix
+        else:
+            p = resource.prefix
         p = p.replace(".", "\\.")
         return f"^{p}:{pattern.lstrip('^')}"
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1214,6 +1214,13 @@ class Resource(BaseModel):
         :param identifier: A local unique identifier in this resource's semantic space
         :param use_preferred: Should preferred prefixes be used? Set this to true if you're in the OBO context.
         :returns: A CURIE for the given identifier
+
+        >>> import bioregistry
+        >>> resource = bioregistry.get_resource("go")
+        >>> resource.get_curie("0000001")
+        'go:0000001'
+        >>> resource.get_curie("0000001", use_preferred=True)
+        'GO:0000001'
         """
         _p = self.get_preferred_prefix() or self.prefix if use_preferred else self.prefix
         return curie_to_str(_p, identifier)
@@ -1222,8 +1229,8 @@ class Resource(BaseModel):
         """Normalize the identifier to not have a redundant prefix or banana.
 
         :param identifier: The identifier in the CURIE
-        :param prefix: If an optional prefix is passed, checks that this isn't also used as a caseolded banana
-            like in ``go:go:1234567``, which shouldn't techinncally be right becauase the banana for gene ontology
+        :param prefix: If an optional prefix is passed, checks that this isn't also used as a casefolded banana
+            like in ``go:go:1234567``, which shouldn't technically be right because the banana for gene ontology
             is ``GO``.
         :return: A normalized identifier, possibly with banana/redundant prefix removed
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -29,7 +29,7 @@ from bioregistry import constants as brc
 from bioregistry.constants import BIOREGISTRY_REMOTE_URL, DOCS, URI_FORMAT_KEY
 from bioregistry.license_standardizer import standardize_license
 from bioregistry.schema.utils import EMAIL_RE
-from bioregistry.utils import removeprefix, removesuffix
+from bioregistry.utils import curie_to_str, removeprefix, removesuffix
 
 try:
     from typing import Literal  # type:ignore

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -861,6 +861,18 @@ class Resource(BaseModel):
             return example
         return None
 
+    def get_example_curie(self, use_preferred: bool = False) -> Optional[str]:
+        """Get an example CURIE, if an example identifier is available.
+
+        :param use_preferred: Should the preferred prefix be used instead
+            of the Bioregistry prefix (if it exists)?
+        :return: An example CURIE for this resource
+        """
+        example = self.get_example()
+        if example is None:
+            return None
+        return self.get_curie(example, use_preferred=use_preferred)
+
     def is_deprecated(self) -> bool:
         """Return if the given prefix corresponds to a deprecated resource.
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1208,6 +1208,16 @@ class Resource(BaseModel):
                 rv.append(Provider(**p))
         return rv
 
+    def get_curie(self, identifier: str, use_preferred: bool = False) -> str:
+        """Get a CURIE for a local unique identifier in this resource's semantic space.
+
+        :param identifier: A local unique identifier in this resource's semantic space
+        :param use_preferred: Should preferred prefixes be used? Set this to true if you're in the OBO context.
+        :returns: A CURIE for the given identifier
+        """
+        _p = self.get_preferred_prefix() or self.prefix if use_preferred else self.prefix
+        return curie_to_str(_p, identifier)
+
     def standardize_identifier(self, identifier: str, prefix: Optional[str] = None) -> str:
         """Normalize the identifier to not have a redundant prefix or banana.
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -272,15 +272,11 @@ class TestRegistry(unittest.TestCase):
     def test_curie_patterns(self):
         """Test that all examples can validate against the CURIE pattern."""
         for prefix, entry in self.registry.items():
-            lui_example = entry.get_example()
-            if lui_example is None:
-                continue
-
             for use_preferred in (True, False):
+                curie_example = entry.get_example_curie(use_preferred=use_preferred)
                 curie_pattern = bioregistry.get_curie_pattern(prefix, use_preferred=use_preferred)
-                if curie_pattern is None:
+                if curie_pattern is None or curie_example is None:
                     continue
-                curie_example = curie_to_str(prefix, lui_example, use_preferred=use_preferred)
                 with self.subTest(prefix=prefix, use_preferred=use_preferred):
                     self.assertRegex(
                         curie_example,
@@ -289,7 +285,6 @@ class TestRegistry(unittest.TestCase):
                             f"""
                     prefix: {prefix}
                     preferred prefix: {entry.get_preferred_prefix()}
-                    example LUI: {lui_example}
                     example CURIE: {curie_example}
                     pattern for LUI: {bioregistry.get_pattern(prefix)}
                     pattern for CURIE: {curie_pattern}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -272,27 +272,30 @@ class TestRegistry(unittest.TestCase):
     def test_curie_patterns(self):
         """Test that all examples can validate against the CURIE pattern."""
         for prefix, entry in self.registry.items():
-            curie_pattern = bioregistry.get_curie_pattern(prefix)
             lui_example = entry.get_example()
-            if curie_pattern is None or lui_example is None:
+            if lui_example is None:
                 continue
-            pp = bioregistry.get_preferred_prefix(prefix)
-            curie_example = curie_to_str(pp or prefix, lui_example)
-            with self.subTest(prefix=prefix):
-                self.assertRegex(
-                    curie_example,
-                    curie_pattern,
-                    msg=dedent(
-                        f"""
-                prefix: {prefix}
-                preferred prefix: {pp}
-                example LUI: {lui_example}
-                example CURIE: {curie_example}
-                pattern for LUI: {bioregistry.get_pattern(prefix)}
-                pattern for CURIE: {curie_pattern}
-                """
-                    ),
-                )
+
+            for use_preferred in (True, False):
+                curie_pattern = bioregistry.get_curie_pattern(prefix, use_preferred=use_preferred)
+                if curie_pattern is None:
+                    continue
+                curie_example = curie_to_str(prefix, lui_example, use_preferred=use_preferred)
+                with self.subTest(prefix=prefix, use_preferred=use_preferred):
+                    self.assertRegex(
+                        curie_example,
+                        curie_pattern,
+                        msg=dedent(
+                            f"""
+                    prefix: {prefix}
+                    preferred prefix: {entry.get_preferred_prefix()}
+                    example LUI: {lui_example}
+                    example CURIE: {curie_example}
+                    pattern for LUI: {bioregistry.get_pattern(prefix)}
+                    pattern for CURIE: {curie_pattern}
+                    """
+                        ),
+                    )
 
     def test_pattern_with_banana(self):
         """Test getting patterns with bananas."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,7 +18,7 @@ from bioregistry.license_standardizer import REVERSE_LICENSES
 from bioregistry.schema.struct import SCHEMA_PATH, get_json_schema
 from bioregistry.schema.utils import EMAIL_RE
 from bioregistry.schema_utils import is_mismatch
-from bioregistry.utils import _norm, curie_to_str, extended_encoder
+from bioregistry.utils import _norm, extended_encoder
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -127,7 +127,8 @@ class TestResolve(unittest.TestCase):
 
         .. seealso:: https://github.com/biopragmatics/bioregistry/issues/245
         """
-        self.assertEqual("^CHEBI:\\d+$", bioregistry.get_curie_pattern("chebi"))
+        self.assertEqual("^chebi:\\d+$", bioregistry.get_curie_pattern("chebi"))
+        self.assertEqual("^CHEBI:\\d+$", bioregistry.get_curie_pattern("chebi", use_preferred=True))
         self.assertEqual(
             "^chembl\\.compound:CHEMBL\\d+$", bioregistry.get_curie_pattern("chembl.compound")
         )


### PR DESCRIPTION
Closes #482

This enables the following:

```python
>>> from bioregistry import curie_from_iri
>>> curie_from_iri("http://purl.obolibrary.org/obo/DRON_00023232", use_preferred=True)
'DRON:00023232'
```