### PR TITLE
Added flag `with_preferred_prefix` to `curie_from_iri`

### DIFF
--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -5,7 +5,7 @@
 from functools import lru_cache
 from typing import List, Mapping, Optional, Tuple, Union
 
-from .resolve import parse_curie
+from .resolve import get_preferred_prefix, parse_curie
 from .resource_manager import prepare_prefix_list
 from .uri_format import get_prefix_map
 from .utils import curie_to_str
@@ -28,12 +28,18 @@ PrefixList = List[Tuple[str, str]]
 
 
 def curie_from_iri(
-    iri: str, *, prefix_map: Union[Mapping[str, str], PrefixList, None] = None
+    iri: str,
+    *,
+    prefix_map: Union[Mapping[str, str], PrefixList, None] = None,
+    with_preferred_prefix: bool = False,
 ) -> Optional[str]:
     """Parse a compact identifier from an IRI using :func:`parse_iri` and reconstitute it.
 
     :param iri: A valid IRI
     :param prefix_map: See :func:`parse_iri`
+    :param with_preferred_prefix: A boolean indicating if the desired
+        output (CURIE) is represented using the normalized form (default) or preferred
+        form of the prefix.
     :return: A CURIE string, if the IRI can be parsed by :func:`parse_iri`.
 
     IRI from an OBO PURL:
@@ -76,6 +82,9 @@ def curie_from_iri(
     prefix, identifier = parse_iri(iri=iri, prefix_map=prefix_map)
     if prefix is None or identifier is None:
         return None
+    if with_preferred_prefix:
+        preferred_prefix = get_preferred_prefix(prefix=prefix)
+        prefix = preferred_prefix if preferred_prefix else prefix
     return curie_to_str(prefix, identifier)
 
 


### PR DESCRIPTION
This fixes #482 

Added a flag `with_preferred_prefix` to `curie_from_iri` which defaults to `False`.

What does it do?
If set to `True`, the function `curie_from_iri` returns a CURIE with the preferred prefix (if one exists). By default, it returns the normalized prefix.