### PR TITLE
Add ICD10WHO as synonym for ICD10

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -31782,7 +31782,8 @@
     "synonyms": [
       "ICD",
       "ICD-10",
-      "ICD10"
+      "ICD10",
+      "ICD10WHO"
     ],
     "uri_format": "https://icd.who.int/browse10/2019/en#/$1",
     "wikidata": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -31660,6 +31660,24 @@
       "name": "International Classification of Diseases, Version 10",
       "prefix": "ICD10"
     },
+    "contributor_extras": [
+      {
+        "github": "joeflack4",
+        "name": "Joe Flack",
+        "orcid": "0000-0002-2906-7319"
+      },
+      {
+        "github": "matentzn",
+        "name": "Nico Matentzoglu",
+        "orcid": "0000-0002-7356-1779"
+      },
+      {
+        "email": "cthoyt@gmail.com",
+        "github": "cthoyt",
+        "name": "Charles Tapley Hoyt",
+        "orcid": "0000-0003-4423-4370"
+      }
+    ],
     "edam": {
       "description": "An identifier of a disease from the International Classification of Diseases (ICD) database.",
       "name": "ICD",


### PR DESCRIPTION
Based on discussion with Chris Chute (https://github.com/biopragmatics/bioregistry/issues/251#issuecomment-1097994811), these are the same. Alternative to #485/#486.

@matentzn @joeflack4 thoughts?