### PR TITLE
Update DOI pattern

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -17480,6 +17480,7 @@
     "uri_format": "http://purl.org/spar/doco/$1"
   },
   "doi": {
+    "banana": "doi",
     "biocontext": {
       "is_identifiers": false,
       "is_obo": false,
@@ -17520,6 +17521,9 @@
       "prefix": "1188"
     },
     "example": "10.1101/2022.07.08.499378",
+    "example_extras": [
+      "10.21/FQSQT4T3"
+    ],
     "fairsharing": {
       "abbreviation": "DOI",
       "description": "The digital object identifier (DOI) system originated in a joint initiative of three trade associations in the publishing industry (International Publishers Association; International Association of Scientific, Technical and Medical Publishers; Association of American Publishers). The system was announced at the Frankfurt Book Fair 1997. The International DOI® Foundation (IDF) was created to develop and manage the DOI system, also in 1997. The DOI system was adopted as International Standard ISO 26324 in 2012. The DOI system implements the Handle System and adds a number of new features. The DOI system provides an infrastructure for persistent unique identification of objects of any type. The DOI system is designed to work over the Internet. A DOI name is permanently assigned to an object to provide a resolvable persistent network link to current information about that object, including where the object, or information about it, can be found on the Internet. While information about an object can change over time, its DOI name will not change. A DOI name can be resolved within the DOI system to values of one or more types of data relating to the object identified by that DOI name, such as a URL, an e-mail address, other identifiers and descriptive metadata. The DOI system enables the construction of automated services and transactions. Applications of the DOI system include but are not limited to managing information and documentation location and access; managing metadata; facilitating electronic transactions; persistent unique identification of any form of any data; and commercial and non-commercial transactions. The content of an object associated with a DOI name is described unambiguously by DOI metadata, based on a structured extensible data model that enables the object to be associated with metadata of any desired degree of precision and granularity to support description and services. The data model supports interoperability between DOI applications. The scope of the DOI system is not defined by reference to the type of content (format, etc.) of the referent, but by reference to the functionalities it provides and the context of use. The DOI system provides, within networks of DOI applications, for unique identification, persistence, resolution, metadata and semantic interoperability.",
@@ -17578,6 +17582,7 @@
       "prefix": "doi",
       "uri_format": "https://doi.org/$1"
     },
+    "pattern": "^\\d{2}\\.\\d{2,4}.*$",
     "prefixcommons": {
       "description": "The Digital Object Identifier System is for identifying content objects in the digital environment.",
       "example": "10.1038/nbt1156",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -17582,7 +17582,7 @@
       "prefix": "doi",
       "uri_format": "https://doi.org/$1"
     },
-    "pattern": "^\\d{2}\\.\\d{2,4}.*$",
+    "pattern": "^10.\\d{2,9}/[-._;()/:A-Z0-9]+$",
     "prefixcommons": {
       "description": "The Digital Object Identifier System is for identifying content objects in the digital environment.",
       "example": "10.1038/nbt1156",


### PR DESCRIPTION
Motivated by https://github.com/identifiers-org/identifiers-org.github.io/issues/207, this PR adds an additional example `10.21/FQSQT4T3` that has a registrant code that's of length 2 instead of 4. It updates the regular expression to better reflect this as well as annotate the banana for MIRIAM backwards compatibility.

I checked out https://www.crossref.org/blog/dois-and-matching-regular-expressions/ to find a better regular expression, but it appears that there's some edge cases that I think it's reasonable to not handle for now.