### PR TITLE
Update UniProt PTM

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -77232,9 +77232,17 @@
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
+    "contributor_extras": [
+      {
+        "email": "benjamin_gyori@hms.harvard.edu",
+        "github": "bgyori",
+        "name": "Benjamin M. Gyori",
+        "orcid": "0000-0001-9439-5346"
+      }
+    ],
     "description": "The post-translational modifications used in the UniProt knowledgebase (Swiss-Prot and TrEMBL). The definition of the post-translational modifications usage as well as other information is provided in the following format",
     "example": "PTM-0450",
-    "homepage": "https://www.uniprot.org/docs/ptmlist",
+    "homepage": "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/docs/ptmlist",
     "name": "UniProt Post-Translational Modification",
     "part_of": "uniprot",
     "pattern": "^PTM-\\d{4}$",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -77235,33 +77235,9 @@
     "description": "The post-translational modifications used in the UniProt knowledgebase (Swiss-Prot and TrEMBL). The definition of the post-translational modifications usage as well as other information is provided in the following format",
     "example": "PTM-0450",
     "homepage": "https://www.uniprot.org/docs/ptmlist",
-    "mappings": {
-      "prefixcommons": "ptmswitchboard"
-    },
     "name": "UniProt Post-Translational Modification",
     "part_of": "uniprot",
     "pattern": "^PTM-\\d{4}$",
-    "prefixcommons": {
-      "description": "PTM-Switchboard is designed to catalog known cases of TF-PTMs affecting gene transcriptions.. PTM-Switchboard differs from existing molecular pathway databases in that, instead of using pairwise interactions as a primary data type, it stores triplets of genes such that the ability of one gene (the TF) to regulate a target gene is dependent on a third gene (the modifying enzyme).",
-      "example": "128",
-      "homepage": "http://cagr.pcbi.upenn.edu/PTMswitchboard/",
-      "keywords": [
-        "gene",
-        "regulation",
-        "DNA",
-        "pathway",
-        "small molecule",
-        "interaction",
-        "enzyme"
-      ],
-      "name": "PTM-Switchboard",
-      "pattern": "^\\d+$",
-      "prefix": "ptmswitchboard",
-      "synonyms": [
-        "ptm"
-      ],
-      "uri_format": "http://cagr.pcbi.upenn.edu/PTMswitchboard/jsp/detail.jsp?ID=$1"
-    },
     "references": [
       "https://twitter.com/cthoyt/status/1510570256619778053",
       "https://www.uniprot.org/docs/ptmlist.txt"

--- a/src/bioregistry/data/mismatch.json
+++ b/src/bioregistry/data/mismatch.json
@@ -74,5 +74,8 @@
   },
   "eol": {
     "fairsharing": "FAIRsharing.3J6NYn"
+  },
+  "uniprot.ptm": {
+     "prefixcommons": "ptmswitchboard"
   }
 }

--- a/src/bioregistry/data/mismatch.json
+++ b/src/bioregistry/data/mismatch.json
@@ -72,5 +72,8 @@
   },
   "ro": {
     "bioportal": "OBOREL"
+  },
+  "uniprot.ptm": {
+    "prefixcommons": "ptmswitchboard"
   }
 }


### PR DESCRIPTION
Closes #603

This PR does two things:

1. Removes an erroneous mapping to prefixcommons `ptmswitchboard` (I made a companion video explaining how I did this part https://www.youtube.com/watch?v=m-6kYq_8tjQ)
2. Updates the home page
