### PR TITLE
fix typos in AEON entry

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -869,7 +869,7 @@
       "name": "Philip Strömert",
       "orcid": "0000-0002-1595-3213"
     },
-    "description": "The academic event ontology, currently still in development and thus unstable, is as an OBO compliant reference ontology for describing the academic events such as conferences, workshops or seminars and their series. it is being developed as part of the [ConfIDent project](https://projects.tib.eu/confident/) to allow and RDF of the academic events and series stored and curated in the [ConfIDent platform](https://www.confident-conference.org/index.php/main_page).",
+    "description": "The academic event ontology, currently still in development and thus unstable, is an OBO compliant reference ontology for describing academic events such as conferences, workshops or seminars and their series. It is being developed as part of the [ConfIDent project](https://projects.tib.eu/confident/) to allow RDF representations of the academic events and series stored and curated in the [ConfIDent platform](https://www.confident-conference.org/index.php/main_page).",
     "download_owl": "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl",
     "example": "0000001",
     "github_request_issue": 617,


### PR DESCRIPTION
This PR fixes some typos in the description of the AEON (Academic Event Ontology) entry. 
@cthoyt do you want me to make corresponding issue for that?