### PR TITLE
External registry mapping

### DIFF
--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -455,8 +455,8 @@ def mapping(source: str, target: str):
     if target not in manager.metaregistry:
         return {"bad target prefix": target}, 400
     rv = {}
-    source_only = 0
-    target_only = 0
+    source_only = set()
+    target_only = set()
     for resource in manager.registry.values():
         mappings = resource.get_mappings()
         mp1_prefix = mappings.get(source)
@@ -464,17 +464,19 @@ def mapping(source: str, target: str):
         if mp1_prefix and mp2_prefix:
             rv[mp1_prefix] = mp2_prefix
         elif mp1_prefix and not mp2_prefix:
-            source_only += 1
+            source_only.add(mp1_prefix)
         elif not mp1_prefix and mp2_prefix:
-            target_only += 1
+            target_only.add(mp2_prefix)
 
     return jsonify(
         meta=dict(
-            overlap=len(rv),
+            len_overlap=len(rv),
             source=source,
             target=target,
-            source_only=source_only,
-            target_only=target_only,
+            len_source_only=len(source_only),
+            len_target_only=len(target_only),
+            source_only=sorted(source_only),
+            target_only=sorted(target_only),
         ),
         mappings=rv,
     )

--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -86,7 +86,34 @@ def resource(prefix: str):
 
 @api_blueprint.route("/metaregistry/<metaprefix>/<metaidentifier>")
 def resource_from_metaregistry(metaprefix: str, metaidentifier: str):
-    """Get a resource by an external prefix."""
+    """Get a resource by an external prefix.
+
+    ---
+    tags:
+    - resource
+    parameters:
+    - name: metaprefix
+      in: path
+      description: The meteprefix for a registry
+      required: true
+      type: string
+      example: obofoundry
+    - name: metaidentifier
+      in: path
+      description: The prefix instide for a registry
+      required: true
+      type: string
+      example: GO
+    - name: format
+      description: The file type
+      in: query
+      required: false
+      default: json
+      schema:
+        type: string
+        enum: [json, yaml, turtle, jsonld]
+
+    """  # noqa:DAR101,DAR201
     if metaprefix not in manager.metaregistry:
         return abort(404, f"invalid metaprefix: {metaprefix}")
     prefix = manager.lookup_from(metaprefix, metaidentifier, normalize=True)
@@ -470,7 +497,7 @@ def mapping(source: str, target: str):
       description: The target metaprefix (e.g., bioportal)
       required: true
       type: string
-    """
+    """  # noqa:DAR101,DAR201
     if source not in manager.metaregistry:
         return {"bad source prefix": source}, 400
     if target not in manager.metaregistry:

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -595,11 +595,12 @@ class Manager:
 
     def _rasterized_registry(self) -> Mapping[str, Resource]:
         return {
-            prefix: self._rasterized_resource(prefix, resource)
+            prefix: self.rasterized_resource(prefix, resource)
             for prefix, resource in self.registry.items()
         }
 
-    def _rasterized_resource(self, prefix: str, resource: Resource) -> Resource:
+    def rasterized_resource(self, prefix: str, resource: Resource) -> Resource:
+        """Rasterize a resource."""
         return Resource(
             prefix=resource.prefix,
             preferred_prefix=resource.get_preferred_prefix() or prefix,


### PR DESCRIPTION
This PR adds an API endpoint for generating mappings between external registries' prefixes, with the caveat that it can only handle stuff that's already mapped to bioregistry prefixes.

For example, http://localhost:5000/api/external/mapping/obofoundry/bioportal (later will be https://bioregistry.io/api/external/mapping/obofoundry/bioportal) gives the following summary of OBO Foundry to BioPortal mappings (plus a summary of 27 prefixes only appearing in OBO Foundry and 94 only appearing in BioPortal, of the prefixes from each source that have been mapped to Bioregistry)

<details>
<summary>Click to see JSON</summary>

```json
{
  "mappings": {
    "ado": "ADO",
    "adw": "ADW",
    "aeo": "AEO",
    "aero": "AERO",
    "agro": "AGRO",
    "aism": "AISM",
    "amphx": "AMPHX",
    "apo": "APO",
    "apollo_sv": "APOLLO-SV",
    "aro": "ARO",
    "ato": "ATO",
    "bcgo": "BCGO",
    "bco": "BCO",
    "bfo": "BFO",
    "bspo": "BSPO",
    "bto": "BTO",
    "caro": "CARO",
    "cdao": "CDAO",
    "cdno": "CDNO",
    "ceph": "CEPH",
    "chebi": "CHEBI",
    "cheminf": "CHEMINF",
    "chiro": "CHIRO",
    "chmo": "CHMO",
    "cido": "CIDO",
    "cio": "CIO",
    "cl": "CL",
    "clao": "CLAO",
    "clo": "CLO",
    "clyh": "CLYH",
    "cmo": "CMO",
    "cob": "COB",
    "colao": "COLAO",
    "cro": "CRO",
    "cteno": "CTENO",
    "cto": "CTO",
    "cvdo": "CVDO",
    "ddanat": "DDANAT",
    "ddpheno": "DDPHENO",
    "dideo": "DIDEO",
    "dinto": "DINTO",
    "disdriv": "DISDRIV",
    "doid": "DOID",
    "dpo": "DPO",
    "dron": "DRON",
    "duo": "DUO",
    "ecao": "ECAO",
    "eco": "ECO",
    "ecocore": "ECOCORE",
    "ecto": "ECTO",
    "ehda": "EHDA",
    "ehdaa": "EHDAA",
    "ehdaa2": "EHDAA2",
    "emap": "EMAP",
    "emapa": "EMAPA",
    "envo": "ENVO",
    "epio": "EPIO",
    "epo": "EPO",
    "ero": "ERO",
    "eupath": "EUPATH",
    "exo": "EXO",
    "fao": "FAO",
    "fbbi": "FBbi",
    "fbbt": "FB-BT",
    "fbcv": "FB-CV",
    "fbdv": "FB-DV",
    "fbsp": "FB-SP",
    "fideo": "FIDEO",
    "fix": "FIX",
    "flopo": "FLOPO",
    "flu": "FLU",
    "fma": "FMA",
    "fobi": "FOBI",
    "foodon": "FOODON",
    "fovt": "FOVT",
    "fypo": "FYPO",
    "gaz": "GAZ",
    "gecko": "GECKO",
    "geno": "GENO",
    "geo": "GEO",
    "gno": "GNO",
    "go": "GO",
    "gro": "GRO-CPGA",
    "gsso": "GSSO",
    "hancestro": "HANCESTRO",
    "hao": "HAO",
    "hom": "HOM",
    "hp": "HP_O",
    "hsapdv": "HSAPDV",
    "hso": "HSO",
    "htn": "HTN",
    "iao": "IAO",
    "iceo": "ICEO",
    "ico": "ICO",
    "ido": "IDO",
    "idomal": "IDOMAL",
    "ino": "INO",
    "kisao": "KISAO",
    "labo": "LABO",
    "lepao": "LEPAO",
    "lipro": "LIPRO",
    "ma": "MA",
    "mamo": "MAMO",
    "mat": "MAT",
    "maxo": "MAXO",
    "mco": "MCO",
    "mf": "MF",
    "mfmo": "MFMO",
    "mfo": "MFO",
    "mfoem": "MFOEM",
    "mfomd": "MFOMD",
    "mi": "MI",
    "miapa": "MIAPA",
    "mirnao": "MIRNAO",
    "miro": "MIRO",
    "mmo": "MMO",
    "mmusdv": "MMUSDV",
    "mo": "MO",
    "mod": "PSIMOD",
    "mondo": "MONDO",
    "mop": "MOP",
    "mp": "MP",
    "mpath": "MPATH",
    "mpio": "MPIO",
    "mro": "MRO",
    "ms": "MS",
    "nbo": "NBO",
    "ncbitaxon": "NCBITAXON",
    "ncit": "NCIT",
    "ncro": "NCRO",
    "nif_cell": "NIFCELL",
    "nmr": "NMR",
    "nomen": "NOMEN",
    "oae": "OAE",
    "oarcs": "OARCS",
    "oba": "OBA",
    "obcs": "OBCS",
    "obi": "OBI",
    "obib": "OBIB",
    "ogg": "OGG",
    "ogi": "OGI",
    "ogms": "OGMS",
    "ogsf": "OGSF",
    "ohd": "OHD",
    "ohmi": "OHMI",
    "ohpi": "OHPI",
    "olatdv": "OLATDV",
    "omiabis": "OMIABIS",
    "omit": "OMIT",
    "omo": "OMO",
    "omp": "OMP",
    "omrse": "OMRSE",
    "one": "ONE",
    "ons": "ONS",
    "ontoavida": "ONTOAVIDA",
    "ontoneo": "ONTONEO",
    "oostt": "OOSTT",
    "opl": "OPL",
    "opmi": "OPMI",
    "ornaseq": "ORNASEQ",
    "ovae": "OVAE",
    "pato": "PATO",
    "pcl": "PCL",
    "pco": "PCO",
    "pdro": "PDRO",
    "pdumdv": "PDUMDV",
    "peco": "PECO",
    "phipo": "PHIPO",
    "plana": "PLANA",
    "planp": "PLANP",
    "po": "PO",
    "poro": "PORO",
    "ppo": "PPO",
    "pr": "PR",
    "propreo": "PROPREO",
    "psdo": "PSDO",
    "pso": "PSO",
    "pw": "PW",
    "rbo": "RBO",
    "rex": "REX",
    "rnao": "RNAO",
    "ro": "OBOREL",
    "rs": "RS",
    "rxno": "RXNO",
    "sao": "SAO",
    "sbo": "SBO",
    "scdo": "SCDO",
    "sep": "SEP",
    "sepio": "SEPIO",
    "sibo": "SIBO",
    "so": "SO",
    "sopharm": "SOPHARM",
    "spd": "SPD",
    "stato": "STATO",
    "swo": "SWO",
    "symp": "SYMP",
    "tads": "TADS",
    "tao": "TAO",
    "taxrank": "TAXRANK",
    "tgma": "TGMA",
    "to": "PTO",
    "trans": "TRANS",
    "tto": "TTO",
    "txpo": "TXPO",
    "uberon": "UBERON",
    "uo": "UO",
    "upa": "UPA",
    "upheno": "UPHENO",
    "vario": "VARIO",
    "vhog": "VHOG",
    "vo": "VO",
    "vsao": "VSAO",
    "vt": "VT",
    "vto": "VTO",
    "wbbt": "WB-BT",
    "wbls": "WB-LS",
    "wbphenotype": "WB-PHENOTYPE",
    "xao": "XAO",
    "xco": "XCO",
    "xlmod": "XLMOD",
    "xpo": "XPO",
    "zea": "ZEA",
    "zeco": "ZECO",
    "zfa": "ZFA",
    "zfs": "ZFS",
    "zp": "ZP"
  },
  "meta": {
    "len_overlap": 226,
    "len_source_only": 27,
    "len_target_only": 94,
    "source": "obofoundry",
    "source_only": [
      "aao",
      "bila",
      "bootstrep",
      "cmf",
      "dc_cl",
      "eo",
      "ev",
      "genepio",
      "habronattus",
      "iev",
      "imr",
      "ipr",
      "loggerhead",
      "mao",
      "micro",
      "nif_dysfunction",
      "nif_grossanatomy",
      "pao",
      "pd_st",
      "pgdso",
      "plo",
      "proco",
      "resid",
      "tahe",
      "tahh",
      "vbo",
      "ypo"
    ],
    "target": "bioportal",
    "target_only": [
      "ABA-AMB",
      "AFO",
      "APAONTO",
      "ATC",
      "ATOL",
      "BAO",
      "BCI-O",
      "BIOLINK",
      "BIRNLEX",
      "BKO",
      "CCO",
      "CHEMROF",
      "CMPO",
      "COVID19",
      "CPT",
      "CRISP",
      "CRYOEM",
      "CTCAE",
      "DATACITE",
      "DC",
      "DCAT",
      "DCM",
      "DCTERMS",
      "DERMO",
      "DTO",
      "ECG",
      "EDAM",
      "EDDA",
      "EFO",
      "ENM",
      "EOL",
      "EPSO",
      "FALDO",
      "FOAF",
      "FPLX",
      "GALEN",
      "GEXO",
      "GFO",
      "GRO",
      "HCPCS",
      "HGNC",
      "ICD10",
      "ICD10CM",
      "ICD10PCS",
      "ICD9CM",
      "ICF",
      "IDO-COVID-19",
      "IDODEN",
      "ITO",
      "LBO",
      "LOINC",
      "LPT",
      "MCCL",
      "MDM",
      "MEDDRA",
      "MEDLINEPLUS",
      "MESH",
      "NDDF",
      "NDFRT",
      "NEMO",
      "NIFSTD",
      "NPO",
      "OA",
      "OM",
      "OMIM",
      "OPB",
      "ORDO",
      "ORTH",
      "PAV",
      "PHARMGKB",
      "PHENX",
      "PMR",
      "QUDT",
      "RADLEX",
      "RDFS",
      "RDO",
      "REPRODUCE-ME",
      "RETO",
      "REXO",
      "RGD",
      "RO",
      "RXNORM",
      "SCHEMA",
      "SIO",
      "SNOMEDCT",
      "STY",
      "SWEET",
      "TEDDY",
      "TIME",
      "VANDF",
      "VIDO",
      "VSO",
      "WIKIPATHWAYS",
      "pseudo"
    ]
  }
}
```

</details>