### PR TITLE
Enable overriding auto-generated URLs from registries

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -6366,7 +6366,7 @@
         "description": "An override for the default construction of OLS URI patterns, since this ontology does not use OBO PURLs",
         "homepage": "https://www.ebi.ac.uk/ols",
         "name": "OLS",
-        "uri_format": "https://www.ebi.ac.uk/ols/ontologies/kisao/terms?iri=http%3A%2F%2Fwww.biomodels.net%2Fkisao%2FKISAO%23KISAO_$1"
+        "uri_format": "https://www.ebi.ac.uk/ols/ontologies/kisao/terms?iri=http://www.biomodels.net/kisao/KISAO#KISAO_$1"
       },
       {
         "code": "bioportal",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -6360,6 +6360,20 @@
         "homepage": "https://www.biomodels.net",
         "name": "Legacy Biomodels URL",
         "uri_format": "https://www.biomodels.net/kisao/KISAO#KISAO_$1"
+      },
+      {
+        "code": "ols",
+        "description": "An override for the default construction of OLS URI patterns, since this ontology does not use OBO PURLs",
+        "homepage": "https://www.ebi.ac.uk/ols",
+        "name": "OLS",
+        "uri_format": "https://www.ebi.ac.uk/ols/ontologies/kisao/terms?iri=http%3A%2F%2Fwww.biomodels.net%2Fkisao%2FKISAO%23KISAO_$1"
+      },
+      {
+        "code": "bioportal",
+        "description": "An override for the default construction of BioPortal URI patterns, since this ontology does not use OBO PURLs",
+        "homepage": "https://www.ebi.ac.uk/ols",
+        "name": "BioPortal",
+        "uri_format": "https://bioportal.bioontology.org/ontologies/KISAO?p=classes&conceptid=kisao:KISAO_$1"
       }
     ],
     "publications": [

--- a/src/bioregistry/resolve_identifier.py
+++ b/src/bioregistry/resolve_identifier.py
@@ -468,6 +468,12 @@ def get_iri(
     A custom provider is given, which makes the Bioregistry very extensible
     >>> get_iri("chebi:24867", provider="chebi-img")
     'https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=24867'
+
+    An override for a metaregistry is built-in to the record
+    >>> get_iri("kisao:0000057", provider="ols")
+    'https://www.ebi.ac.uk/ols/ontologies/kisao/terms?iri=http://www.biomodels.net/kisao/KISAO#KISAO_0000057'
+    >>> get_iri("kisao:0000057", provider="bioportal")
+    'https://bioportal.bioontology.org/ontologies/KISAO?p=classes&conceptid=kisao:KISAO_0000057'
     """
     return manager.get_iri(
         prefix=prefix,


### PR DESCRIPTION
Closes #572

There are some overly-generic rules that help generate URIs for various registries. For example, the OLS almost only contained OBO Foundry ontologies at the start of the Bioregistry, so it was a reasonable assumption to make the provider URI for OLS possible to construct in a similar way to OBO Foundry PURLs. This isn't generally the case, so there are a few options:

1. make a more complicated set of rules for each registry where this is the case
2. make a quick and dirty override system, that can be used in a small set of cases.

This PR implements option 2 and uses KISAO as an example.