### PR TITLE
Add banana to `agrovoc`

### DIFF
--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -276,8 +276,8 @@ def resolve(prefix: str, identifier: Optional[str] = None):
     2. The prefix has a validation pattern and the identifier does not match it
     3. There are no providers available for the URL
     """  # noqa:DAR101,DAR201
-    norm_prefix = manager.normalize_prefix(prefix)
-    if norm_prefix is None:
+    _resource = manager.get_resource(prefix)
+    if _resource is None:
         return (
             render_template(
                 "resolve_errors/missing_prefix.html", prefix=prefix, identifier=identifier
@@ -285,10 +285,12 @@ def resolve(prefix: str, identifier: Optional[str] = None):
             404,
         )
     if identifier is None:
-        return redirect(url_for("." + resource.__name__, prefix=norm_prefix))
+        return redirect(url_for("." + resource.__name__, prefix=_resource.prefix))
 
-    pattern = manager.get_pattern(prefix)
-    if pattern and not manager.is_standardizable_identifier(prefix, identifier):
+    identifier = _resource.standardize_identifier(identifier)
+
+    pattern = _resource.get_pattern()
+    if pattern and not _resource.is_valid_identifier(identifier):
         return (
             render_template(
                 "resolve_errors/invalid_identifier.html",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -1397,6 +1397,8 @@
       "publication": "https://www.fao.org/agrovoc/publications",
       "version": "2022-09"
     },
+    "banana": "c_",
+    "banana_peel": "",
     "contributor": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -312,10 +312,10 @@ class TestRegistry(unittest.TestCase):
 
         resource = self.registry["agrovoc"]
         self.assertEqual(
-            "^C_[a-z0-9]+$",
+            "^c_[a-z0-9]+$",
             resource.get_pattern_with_banana(),
         )
-        self.assertEqual("^(C_)?[a-z0-9]+$", resource.get_pattern_with_banana(strict=False))
+        self.assertEqual("^(c_)?[a-z0-9]+$", resource.get_pattern_with_banana(strict=False))
 
     def test_examples(self):
         """Test examples for the required conditions.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -310,6 +310,13 @@ class TestRegistry(unittest.TestCase):
         )
         self.assertEqual("^(CHEBI:)?\\d+$", resource.get_pattern_with_banana(strict=False))
 
+        resource = self.registry["agrovoc"]
+        self.assertEqual(
+            "^C_[a-z0-9]+$",
+            resource.get_pattern_with_banana(),
+        )
+        self.assertEqual("^(C_)?[a-z0-9]+$", resource.get_pattern_with_banana(strict=False))
+
     def test_examples(self):
         """Test examples for the required conditions.
 
@@ -930,3 +937,15 @@ class TestRegistry(unittest.TestCase):
                     continue
                 with self.subTest(prefix=prefix, metaprefix=metaprefix):
                     self.assertRegex(metaidentifier, pattern)
+
+    def test_standardize_identifier(self):
+        """Standardize the identifier."""
+        examples = [
+            ("agrovoc", "1234", "1234"),
+            ("agrovoc", "c_1234", "1234"),
+        ]
+        for prefix, identifier, norm_identifier in examples:
+            with self.subTest(prefix=prefix, identifier=identifier):
+                self.assertEqual(
+                    norm_identifier, bioregistry.standardize_identifier(prefix, identifier)
+                )

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -71,6 +71,8 @@ class TestResolve(unittest.TestCase):
             ("OMIMPS", "214100"),
             ("PS", "214100"),
             ("PS", "PS214100"),
+            ("agrovoc", "1234"),
+            ("agrovoc", "c_1234"),
         ]
         for prefix, resource in bioregistry.read_registry().items():
             if bioregistry.is_deprecated(prefix):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -189,11 +189,11 @@ class TestWeb(unittest.TestCase):
     def test_banana_redirects(self):
         """Test banana redirects."""
         with self.app.test_client() as client:
-            for prefix, identifier, norm_identifier  in [
-                ("agrovoc", "c_1234", "1234"),
+            for prefix, identifier, norm_identifier, location in [
+                ("agrovoc", "c_1234", "1234", "http://aims.fao.org/aos/agrovoc/c_1234"),
+                ("agrovoc", "1234", "1234", "http://aims.fao.org/aos/agrovoc/c_1234"),
             ]:
                 with self.subTest(prefix=prefix, identifier=identifier):
                     res = client.get(f"{prefix}:{norm_identifier}")
                     self.assertEqual(302, res.status_code)
-                    print(res)
-                    raise NotImplementedError(f"need to check the URL requested in the end is correct: {res.headers}")
+                    self.assertEqual(location, res.headers["Location"])

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -189,11 +189,19 @@ class TestWeb(unittest.TestCase):
     def test_banana_redirects(self):
         """Test banana redirects."""
         with self.app.test_client() as client:
-            for prefix, identifier, norm_identifier, location in [
-                ("agrovoc", "c_2842", "2842", "http://aims.fao.org/aos/agrovoc/c_2842"),
-                ("agrovoc", "2842", "2842", "http://aims.fao.org/aos/agrovoc/c_2842"),
+            for prefix, identifier, location in [
+                ("agrovoc", "c_2842", "http://aims.fao.org/aos/agrovoc/c_2842"),
+                ("agrovoc", "2842", "http://aims.fao.org/aos/agrovoc/c_2842"),
+                # Related to https://github.com/biopragmatics/bioregistry/issues/93, the app route is not greedy,
+                # so it parses on the rightmost colon.
+                # ("go", "0032571", "http://amigo.geneontology.org/amigo/term/GO:0032571"),
+                # ("go", "GO:0032571", "http://amigo.geneontology.org/amigo/term/GO:0032571"),
             ]:
                 with self.subTest(prefix=prefix, identifier=identifier):
                     res = client.get(f"/{prefix}:{identifier}", follow_redirects=False)
-                    self.assertEqual(302, res.status_code)
+                    self.assertEqual(
+                        302,
+                        res.status_code,
+                        msg=f"{prefix}\nHeaders: {res.headers}\nRequest: {res.request}",
+                    )
                     self.assertEqual(location, res.headers["Location"])

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -190,10 +190,10 @@ class TestWeb(unittest.TestCase):
         """Test banana redirects."""
         with self.app.test_client() as client:
             for prefix, identifier, norm_identifier, location in [
-                ("agrovoc", "c_1234", "1234", "http://aims.fao.org/aos/agrovoc/c_1234"),
-                ("agrovoc", "1234", "1234", "http://aims.fao.org/aos/agrovoc/c_1234"),
+                ("agrovoc", "c_2842", "2842", "http://aims.fao.org/aos/agrovoc/c_2842"),
+                ("agrovoc", "2842", "2842", "http://aims.fao.org/aos/agrovoc/c_2842"),
             ]:
                 with self.subTest(prefix=prefix, identifier=identifier):
-                    res = client.get(f"{prefix}:{norm_identifier}")
+                    res = client.get(f"/{prefix}:{identifier}", follow_redirects=False)
                     self.assertEqual(302, res.status_code)
                     self.assertEqual(location, res.headers["Location"])

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -185,3 +185,15 @@ class TestWeb(unittest.TestCase):
                 with self.subTest(endpoint=endpoint):
                     res = client.get(endpoint)
                     self.assertEqual(302, res.status_code)
+
+    def test_banana_redirects(self):
+        """Test banana redirects."""
+        with self.app.test_client() as client:
+            for prefix, identifier, norm_identifier  in [
+                ("agrovoc", "c_1234", "1234"),
+            ]:
+                with self.subTest(prefix=prefix, identifier=identifier):
+                    res = client.get(f"{prefix}:{norm_identifier}")
+                    self.assertEqual(302, res.status_code)
+                    print(res)
+                    raise NotImplementedError(f"need to check the URL requested in the end is correct: {res.headers}")


### PR DESCRIPTION
Closes #660 by adding `c_` as the banana and an empty banana peel. This also updates the resolution workflow to better handle bananas, though doesn't address bananas with colons (re #93) because of issues with lazy colon parsing.