### PR TITLE
Improve NDEx uploader

### DIFF
--- a/src/bioregistry/cli.py
+++ b/src/bioregistry/cli.py
@@ -97,6 +97,9 @@ def update(ctx: click.Context):
         ctx.invoke(upload_ndex.main)
     except ImportError:
         click.secho("Could not import ndex", fg="red")
+    except Exception as e:
+        click.secho("Error uploading to ndex", fg="red")
+        click.secho(str(e), fg="red")
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/upload_ndex.py
+++ b/src/bioregistry/upload_ndex.py
@@ -39,11 +39,11 @@ def upload():
         "description",
         "An integrative meta-registry of biological databases, ontologies, and nomenclatures",
     )
-    cx.add_network_attribute("hash", bioregistry.version.get_git_hash())
-    cx.add_network_attribute("version", bioregistry.version.get_version())
-    cx.add_network_attribute("rights", "Waiver-No rights reserved (CC0)")
-    cx.add_network_attribute("rightsHolder", "Charles Tapley Hoyt")
-    cx.add_network_attribute("author", "Charles Tapley Hoyt")
+    cx.add_network_attribute("hash", bioregistry.version.get_git_hash(), type="string")
+    cx.add_network_attribute("version", bioregistry.version.get_version(), type="string")
+    cx.add_network_attribute("rights", "Waiver-No rights reserved (CC0)", type="string")
+    cx.add_network_attribute("rightsHolder", "Charles Tapley Hoyt", type="string")
+    cx.add_network_attribute("author", "Charles Tapley Hoyt", type="string")
     cx.set_context(
         {
             "bioregistry.collection": "https://bioregistry.io/collection/",
@@ -104,7 +104,7 @@ def upload():
             represents=f"bioregistry.collection:{collection_id}",
         )
         if collection.description:
-            cx.add_node_attribute(source, "description", collection.description)
+            cx.add_node_attribute(source, "description", collection.description, type="string")
         for prefix in collection.resources:
             cx.add_edge(
                 source=source,
@@ -129,10 +129,10 @@ def make_registry_node(cx: "ndex2.NiceCXBuilder", metaprefix: str) -> int:
     )
     homepage = bioregistry.get_registry_homepage(metaprefix)
     if homepage:
-        cx.add_node_attribute(node, "homepage", homepage)
+        cx.add_node_attribute(node, "homepage", homepage, type="string")
     description = bioregistry.get_registry_description(metaprefix)
     if description:
-        cx.add_node_attribute(node, "description", description)
+        cx.add_node_attribute(node, "description", description, type="string")
     return node
 
 
@@ -144,13 +144,13 @@ def make_resource_node(cx: "ndex2.NiceCXBuilder", prefix: str) -> int:
     )
     homepage = bioregistry.get_homepage(prefix)
     if homepage:
-        cx.add_node_attribute(node, "homepage", homepage)
+        cx.add_node_attribute(node, "homepage", homepage, type="string")
     description = bioregistry.get_description(prefix)
     if description:
-        cx.add_node_attribute(node, "description", description)
+        cx.add_node_attribute(node, "description", description, type="string")
     pattern = bioregistry.get_pattern(prefix)
     if pattern:
-        cx.add_node_attribute(node, "pattern", pattern)
+        cx.add_node_attribute(node, "pattern", pattern, type="string")
     # TODO add more
     return node
 


### PR DESCRIPTION
The NDEx package has now gotten out of sync with numpy and checks for `np.float`, which doesn't exist anymore. This PR more generally allows NDEx failures to occur (since issues pop up often) as well as making the typing more explicit so this check doesn't happen.