### PR TITLE
Add additional links for new prefix requests

### DIFF
--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -82,7 +82,9 @@ RESOURCES_SUBHEADER_DEFAULT = dedent(
     """\
     <p style="margin-bottom: 0">
         Anyone can <a href="https://github.com/biopragmatics/bioregistry/issues/new/choose">suggest
-        improvements</a> or make pull requests to update the underlying database, which is stored in
+        improvements</a>, <a href="https://github.com/biopragmatics/bioregistry/issues/new?labels=\
+            New%2CPrefix&template=new-prefix.yml&title=Add+prefix+%5BX%5D">request a new prefix</a>,
+             or make pull requests to update the underlying database, which is stored in
         <a href="https://github.com/biopragmatics/bioregistry/blob/main/src/bioregistry/data/bioregistry.json">
             JSON</a> on GitHub where the community can engage in an open review process.
     </p>

--- a/src/bioregistry/app/templates/base.html
+++ b/src/bioregistry/app/templates/base.html
@@ -121,6 +121,9 @@
                     </a>
                     <div class="dropdown-divider"></div>
                     <h6 class="dropdown-header">Getting Started</h6>
+                    <a class="dropdown-item" target="_blank" href="https://github.com/biopragmatics/bioregistry/issues/new?labels=New%2CPrefix&template=new-prefix.yml&title=Add+prefix+%5BX%5D">
+                        Request a Prefix <i class="fa fa-external-link" aria-hidden="true"></i>
+                    </a>
                     <a class="dropdown-item" target="_blank" href="https://biopragmatics.github.io/bioregistry/curation/">
                         Good First Contributions <i class="fa fa-external-link" aria-hidden="true"></i>
                     </a>

--- a/src/bioregistry/app/templates/home.html
+++ b/src/bioregistry/app/templates/home.html
@@ -120,6 +120,16 @@
                 </p>
                 {# <small class="text-muted">Donec id elit non mi porta.</small> #}
             </a>
+            <a href="https://github.com/biopragmatics/bioregistry/issues/new?labels=New%2CPrefix&template=new-prefix.yml&title=Add+prefix+%5BX%5D"
+               class="list-group-item list-group-item-action flex-column align-items-start">
+                <div class="d-flex w-100 justify-content-between">
+                    <h5 class="mb-1"><i class="fas fa-question"></i> Request a Prefix</h5>
+                </div>
+                <p class="mb-1">
+                    Request a new prefix in the Bioregistry via its GitHub Issue tracker.
+                </p>
+                {# <small class="text-muted">Donec id elit non mi porta.</small> #}
+            </a>
             <a href="{{ url_for('metaregistry_ui.download') }}"
                class="list-group-item list-group-item-action flex-column align-items-start">
                 <div class="d-flex w-100 justify-content-between">


### PR DESCRIPTION
Based on discussion in https://github.com/monarch-initiative/vertebrate-breed-ontology/issues/77, it appears that it wasn't so straightforward to find the new prefix request from the Bioregistry app.