### PR TITLE
Add page describing usages of the Bioregistry

### DIFF
--- a/docs/_data/usages.yml
+++ b/docs/_data/usages.yml
@@ -1,5 +1,6 @@
 - name: Global Alliance for Genomics and Health
   abbreviation: GA4GH
+  link: https://www.ga4gh.org/
   type: organization
   uses:
     - description: Gave a tutorial at ISMB 2022 on how to run a local instance of the Bioregistry

--- a/docs/_data/usages.yml
+++ b/docs/_data/usages.yml
@@ -1,0 +1,49 @@
+- name: Global Alliance for Genomics and Health
+  abbreviation: GA4GH
+  type: organization
+  uses:
+    - description: Gave a tutorial at ISMB 2022 on how to run a local instance of the Bioregistry
+      links:
+        - https://github.com/ga4gh/ismb-2022-ga4gh-tutorial/blob/06ce0eb33137ccbc2db6888c487bb1e9c24f7c55/supporting/bioregistry/README.md
+
+- name: LinkML
+  type: project
+  link: https://linkml.io
+  uses:
+    - description: Uses the Bioregistry as a semantic space of other semantic spaces in prefix maps
+      links:
+        - https://github.com/linkml/linkml/blob/e8f6820d729c9d7e85fa751f3dee299ea4bb7bd8/docs/schemas/enums.md
+    - description: Caches the Bioregistry data with use case-specific preprocessing
+      links:
+        - https://github.com/linkml/prefixmaps/blob/a2d8c51e7c02cdbf0d2cbd07918c8314647fcd18/src/prefixmaps/ingest/ingest_bioregistry.py
+    - description: Uses the Bioregistry package for lookup of URI format strings
+      links:
+        - https://github.com/linkml/schemasheets/blob/2f64a5abcc01899a047e12b2261dadb88b9c3005/schemasheets/utils/prefixtool.py
+
+- name: Automating Scientific Knowledge Extraction and Modeling
+  abbreviation: ASKEM
+  type: project
+  link: https://indralab.github.io/#askem
+  uses:
+    - description: Deploys a custom instance of the Bioregistry including a subset of prefixes from the main services and additional custom prefixes for epidemiology modeling and space weather use cases
+
+- name: BioClients
+  link: https://github.com/jeremyjyang/BioClients
+  type: package
+  uses:
+    - description: Wraps the API of bioregistry.io in a Python package
+      links:
+        - https://github.com/jeremyjyang/BioClients/blob/fc12590a57c4cc49d01bf364ce51dbd955b69b5e/doc/bioregistry.md
+        - https://github.com/jeremyjyang/BioClients/blob/fc12590a57c4cc49d01bf364ce51dbd955b69b5e/BioClients/bioregistry/Client.py
+
+- name: BridgeDB
+  link: https://www.bridgedb.org
+  type: project
+  uses:
+    - description: Links prefixes used in BridgeDB's mapping database to Bioregistry prefixes, standardizing when possible
+      links:
+        - https://github.com/bridgedb/datasources/blob/09855e63b5db17fb27ac529192cad38396a3bf1f/scripts/align_bioregistry.py
+        - https://github.com/bridgedb/datasources/blob/76bcc4cb29e6d94b11661f0e54516f1c71435efb/tests/test_integrity.py
+    - description: Standardizes annotations of CURIEs that have been replaced in the TIWID database
+      links:
+        - https://github.com/bridgedb/tiwid/blob/f97575c7c48141acd5ec75c294c01e740fe014ea/tests/test_integrity.py

--- a/docs/_data/usages.yml
+++ b/docs/_data/usages.yml
@@ -145,3 +145,65 @@
     - description: Uses the Bioregistry Python package for normalizing prefixes
       links:
         - https://github.com/dmis-lab/BERN2/blob/e783813c7a08852a18741057920e59949af7ca6b/bern2/bern2.py
+
+- name: OntoGPT
+  description: A knowledge extraction tool that uses a large language model to extract semantic information from text.
+  link: https://monarch-initiative.github.io/ontogpt/
+  type: package
+  repository: https://github.com/monarch-initiative/ontogpt
+  uses:
+    - description: Generate links from CURIEs
+      links:
+        - https://github.com/monarch-initiative/ontogpt/blob/d22fe590ca9bfcd1b7421d7c2399711ea19f5124/src/ontogpt/io/markdown_exporter.py
+        - https://github.com/monarch-initiative/ontogpt/blob/d22fe590ca9bfcd1b7421d7c2399711ea19f5124/src/ontogpt/io/html_exporter.py
+
+- name: OBO Foundry
+  link: https://obofoundry.org/
+  repository: https://github.com/OBOFoundry/OBOFoundry.github.io
+  type: organization
+  uses:
+    - description: Uses the Bioregistry in order to identify if proposed ontologies' prefixes collide with existing prefixes
+      links:
+        - https://github.com/OBOFoundry/OBOFoundry.github.io/blob/af5bf3bb2fee6bfffde5dcf98a09a79b90520277/docs/ReservePrefix.md
+        - https://github.com/OBOFoundry/OBOFoundry.github.io/blob/334d2d6882f22094af29640fc126e0ab70c06e2a/id-policy.md
+
+- name: Ontology Quality 2022 Analysis
+  link: https://github.com/Ostrzyciel/ontology-quality-2022
+  repository: https://github.com/Ostrzyciel/ontology-quality-2022
+  type: analysis
+  uses:
+    - description: Uses Bioregistry data directly to identify prefixes in ontologies that aren't OBO Foundry prefixes
+      links:
+        - https://github.com/Ostrzyciel/ontology-quality-2022/blob/aca8bea664a99b52a39c8f727b59149730738952/obo/3_cross_refs/xrefs.ipynb
+
+- name: iSamples.org
+  repository: https://github.com/isamplesorg
+  type: organization
+  uses:
+    - description: Uses the Bioregistry as a semantic space for referencing prefixes (in LinkML)
+      links:
+        - https://github.com/isamplesorg/metadata/blob/28954e4b69ad40a47828bb631f4bf9f98b03bc1c/notes/evaluation/test_dynamic_vocab.yml
+
+- name: BioCypher
+  link: https://biocypher.org/
+  type: project
+  uses:
+    - description: Uses the Bioregistry Python package for normalizing CURIEs
+      links:
+        - https://github.com/saezlab/DepMap-BioCypher/blob/4c84fdc24f414a05ed68820096d55c09b6a81877/dmb/adapter.py
+
+- name: Babel Validator
+  link: https://github.com/TranslatorSRI/babel-validation
+  uses:
+    - description: Uses the Bioregistry resolver for creating resolvable links
+      links:
+        - https://github.com/TranslatorSRI/babel-validation/blob/827c26c27d5f49f6959f0dbded3cde48f1fcde44/website/src/models/tests.js
+
+- name: National Microbiome Data Collaborative
+  abbreviation: NMDC
+  uses:
+    - description: Uses the Bioregistry Python package to normalize prefixes, look up patterns, etc.
+      links:
+        - https://github.com/microbiomedata/sample-annotator/blob/81b994d342945da0189aaf34e3a86d6a5acd30cc/sample_annotator/sample_annotator.py
+
+

--- a/docs/_data/usages.yml
+++ b/docs/_data/usages.yml
@@ -1,6 +1,6 @@
 - name: Global Alliance for Genomics and Health
   abbreviation: GA4GH
-  link: https://www.ga4gh.org/
+  homepage: https://www.ga4gh.org/
   type: organization
   uses:
     - description: Gave a tutorial at ISMB 2022 on how to run a local instance of the Bioregistry
@@ -9,7 +9,7 @@
 
 - name: LinkML
   type: project
-  link: https://linkml.io
+  homepage: https://linkml.io
   uses:
     - description: Uses the Bioregistry as a semantic space of other semantic spaces in prefix maps
       links:
@@ -24,12 +24,13 @@
 - name: Automating Scientific Knowledge Extraction and Modeling
   abbreviation: ASKEM
   type: project
-  link: https://indralab.github.io/#askem
+  homepage: https://indralab.github.io/#askem
   uses:
     - description: Deploys a custom instance of the Bioregistry including a subset of prefixes from the main services and additional custom prefixes for epidemiology modeling and space weather use cases
 
 - name: BioClients
-  link: https://github.com/jeremyjyang/BioClients
+  homepage: https://github.com/jeremyjyang/BioClients
+  repository: https://github.com/jeremyjyang/BioClients
   type: package
   uses:
     - description: Wraps the API of bioregistry.io in a Python package
@@ -38,7 +39,7 @@
         - https://github.com/jeremyjyang/BioClients/blob/fc12590a57c4cc49d01bf364ce51dbd955b69b5e/BioClients/bioregistry/Client.py
 
 - name: BridgeDB
-  link: https://www.bridgedb.org
+  homepage: https://www.bridgedb.org
   type: project
   uses:
     - description: Links prefixes used in BridgeDB's mapping database to Bioregistry prefixes, standardizing when possible
@@ -52,7 +53,7 @@
 - name: Ontology Lookup Service
   abbreviation: OLS
   type: project
-  link: https://www.ebi.ac.uk/ols/index
+  homepage: https://www.ebi.ac.uk/ols/index
   uses:
     - description: Uses the Bioregistry to parse CURIEs in ontologies and generate links
       links:
@@ -61,7 +62,7 @@
 - name: FAIRsFAIR Research Data Object Assessment Service
   abbreviation: F-UJI
   type: project
-  link: https://github.com/pangaea-data-publisher/fuji
+  homepage: https://github.com/pangaea-data-publisher/fuji
   uses:
     - description: Uses the Bioregistry data file directly to implement its own URI parser
       links:
@@ -69,7 +70,7 @@
 
 - name: Manubot
   type: project
-  link: https://manubot.org/
+  homepage: https://manubot.org/
   uses:
     - description: Uses the Bioregistry python package to parse CURIEs appearing in scholarly articles, generate links, and retrieve metadata
       links:
@@ -77,14 +78,14 @@
 
 - name: LOTUS Iniative
   type: project
-  link: https://lotus.naturalproducts.net/
+  homepage: https://lotus.naturalproducts.net/
   uses:
     - description: Generates Bioregistry links for resolving CURIEs for taxa and natural products
       links:
         - https://github.com/lotusnprod/lotus-web/blob/f7b06f29de1a5e49b85c070ebc80e8f063954365/src/main/js/components/compoundcard/Representations.js
 
 - name: Text2Term Ontology Mapper
-  link: https://github.com/ccb-hms/ontology-mapper
+  homepage: https://github.com/ccb-hms/ontology-mapper
   type: package
   uses:
     - description: Uses the Bioregistry python package for parsing URIs
@@ -92,7 +93,7 @@
         - https://github.com/ccb-hms/ontology-mapper/blob/0b4edd50da0144ec317e77b265f93e3d6655a64e/text2term/onto_utils.py
 
 
-- link: https://lamin.ai/docs/bionty
+- homepage: https://lamin.ai/docs/bionty
   name: Bionty
   type: project
   uses:
@@ -102,7 +103,7 @@
         - https://github.com/laminlabs/bionty/blob/3f2f3bf1f9acb2e0c33c4ee885997ea7fb681ba2/bionty/_table.py
 
 - name: Related Sciences
-  link: https://www.related.vc
+  homepage: https://www.related.vc
   type: organization
   uses:
     - description: Uses the Bioregistry Python package to normalize prefixes and CURIEs in its ENSEMBL pre-processing pipeline
@@ -112,14 +113,14 @@
 
 - name: Gut-brain Axis Knowledge Graph
   abbreviation: GBA-KG
-  link: https://github.com/liwenqingi/GBA-KG
+  homepage: https://github.com/liwenqingi/GBA-KG
   type: package
   uses:
     - description: Uses the Bioregistry via BERN2
 
 - name: Wikipathways
   type: project
-  link: https://www.wikipathways.org
+  homepage: https://www.wikipathways.org
   uses:
     - description: Standardizes cross-references with the Bioregistry (via BridgeDB)
       links:
@@ -127,7 +128,7 @@
 
 - name: Ensmallen / Grape
   type: package
-  link: https://github.com/AnacletoLAB/ensmallen
+  homepage: https://github.com/AnacletoLAB/ensmallen
   uses:
     - description: Uses the Bioregistry Python package to standardize CURIEs in knowledge graphs generated from ontologies and other sources
       links:
@@ -137,7 +138,7 @@
 - name: Advanced Biomedical Entity Recognition and Normalization
   abbreviation: BERN2
   type: package
-  link: https://github.com/dmis-lab/BERN2
+  homepage: https://github.com/dmis-lab/BERN2
   uses:
     - description: Uses the Bioregistry web service for expanding CURIEs into URIs
       links:
@@ -148,7 +149,7 @@
 
 - name: OntoGPT
   description: A knowledge extraction tool that uses a large language model to extract semantic information from text.
-  link: https://monarch-initiative.github.io/ontogpt/
+  homepage: https://monarch-initiative.github.io/ontogpt/
   type: package
   repository: https://github.com/monarch-initiative/ontogpt
   uses:
@@ -158,7 +159,7 @@
         - https://github.com/monarch-initiative/ontogpt/blob/d22fe590ca9bfcd1b7421d7c2399711ea19f5124/src/ontogpt/io/html_exporter.py
 
 - name: OBO Foundry
-  link: https://obofoundry.org/
+  homepage: https://obofoundry.org/
   repository: https://github.com/OBOFoundry/OBOFoundry.github.io
   type: organization
   uses:
@@ -168,7 +169,7 @@
         - https://github.com/OBOFoundry/OBOFoundry.github.io/blob/334d2d6882f22094af29640fc126e0ab70c06e2a/id-policy.md
 
 - name: Ontology Quality 2022 Analysis
-  link: https://github.com/Ostrzyciel/ontology-quality-2022
+  homepage: https://github.com/Ostrzyciel/ontology-quality-2022
   repository: https://github.com/Ostrzyciel/ontology-quality-2022
   type: analysis
   uses:
@@ -179,13 +180,14 @@
 - name: iSamples.org
   repository: https://github.com/isamplesorg
   type: organization
+  homepage: https://isamplesorg.github.io/
   uses:
     - description: Uses the Bioregistry as a semantic space for referencing prefixes (in LinkML)
       links:
         - https://github.com/isamplesorg/metadata/blob/28954e4b69ad40a47828bb631f4bf9f98b03bc1c/notes/evaluation/test_dynamic_vocab.yml
 
 - name: BioCypher
-  link: https://biocypher.org/
+  homepage: https://biocypher.org/
   type: project
   uses:
     - description: Uses the Bioregistry Python package for normalizing CURIEs
@@ -193,7 +195,8 @@
         - https://github.com/saezlab/DepMap-BioCypher/blob/4c84fdc24f414a05ed68820096d55c09b6a81877/dmb/adapter.py
 
 - name: Babel Validator
-  link: https://github.com/TranslatorSRI/babel-validation
+  homepage: https://github.com/TranslatorSRI/babel-validation
+  type: package
   uses:
     - description: Uses the Bioregistry resolver for creating resolvable links
       links:
@@ -201,9 +204,50 @@
 
 - name: National Microbiome Data Collaborative
   abbreviation: NMDC
+  homepage: https://microbiomedata.org/
+  type: organization
   uses:
     - description: Uses the Bioregistry Python package to normalize prefixes, look up patterns, etc.
       links:
         - https://github.com/microbiomedata/sample-annotator/blob/81b994d342945da0189aaf34e3a86d6a5acd30cc/sample_annotator/sample_annotator.py
 
+- name: PheKnowLator
+  repository: https://github.com/callahantiff/PheKnowLator
+  homepage: https://github.com/callahantiff/PheKnowLator/wiki
+  type: package
+  uses:
+    - description: Normalizing IRIs and CURIEs during the construction of the knowledge graph
 
+- name: Natural Product Knowledge Graph
+  abbreviation: NP-KG
+  repository: https://github.com/sanyabt/np-kg
+  homepage: https://github.com/sanyabt/np-kg
+  type: package
+  description: A graph framework that creates a biomedical knowledge graph to identify and generate mechanistic hypotheses for pharmacokinetic natural product-drug interactions.
+  uses:
+    - description: Normalizing IRIs and CURIEs during the construction of the knowledge graph via PheKnowLator
+
+- name: Ontology Quality Assessment Toolkit
+  repository: https://github.com/cthoyt/oquat
+  homepage: https://cthoyt.github.io/oquat
+  type: package
+  uses:
+    - description: Uses the Bioregistry Python package to check the standardization of prefixes in OBO Foundry ontologies
+    - description: Uses the Bioregistry to get a list of ontologies and their download links
+
+- name: PyOBO
+  repository: https://github.com/pyobo/pyobo
+  homepage: https://github.com/pyobo/pyobo
+  type: package
+  uses:
+    - description: Uses the Bioregistry Python package to get a list of ontologies and their download links
+    - description: Uses the Bioregistry Python package to standardize prefixes, CURIEs, and IRIs in ontologies
+    - description: Uses the Bioregistry Python package to validate prefixes, CURIEs, and IRIs in ontologies during the construction of custom ontologies, e.g., from biological databases
+
+
+- name: SSSOM
+  type: project
+  homepage: https://mapping-commons.github.io/sssom/
+  repository: https://github.com/mapping-commons/sssom
+  uses:
+    - description: Uses the Bioregistry as a default prefix map

--- a/docs/_data/usages.yml
+++ b/docs/_data/usages.yml
@@ -48,3 +48,100 @@
     - description: Standardizes annotations of CURIEs that have been replaced in the TIWID database
       links:
         - https://github.com/bridgedb/tiwid/blob/f97575c7c48141acd5ec75c294c01e740fe014ea/tests/test_integrity.py
+
+- name: Ontology Lookup Service
+  abbreviation: OLS
+  type: project
+  link: https://www.ebi.ac.uk/ols/index
+  uses:
+    - description: Uses the Bioregistry to parse CURIEs in ontologies and generate links
+      links:
+        - https://github.com/EBISPOT/ols4/blob/cea7a92f46f05b78a8dd5f74a0c37fccf0c6ddb3/dataload/linker/src/main/java/Bioregistry.java
+
+- name: FAIRsFAIR Research Data Object Assessment Service
+  abbreviation: F-UJI
+  type: project
+  link: https://github.com/pangaea-data-publisher/fuji
+  uses:
+    - description: Uses the Bioregistry data file directly to implement its own URI parser
+      links:
+        - https://github.com/pangaea-data-publisher/fuji/blob/f28f51d49d95994e15ff265ada14dfeac0b0adf8/fuji_server/helper/linked_vocab_helper.py
+
+- name: Manubot
+  type: project
+  link: https://manubot.org/
+  uses:
+    - description: Uses the Bioregistry python package to parse CURIEs appearing in scholarly articles, generate links, and retrieve metadata
+      links:
+        - https://github.com/manubot/manubot/blob/f6c1fcd3781fd25574cd23100155b1b1d2783515/manubot/cite/curie/__init__.py
+
+- name: LOTUS Iniative
+  type: project
+  link: https://lotus.naturalproducts.net/
+  uses:
+    - description: Generates Bioregistry links for resolving CURIEs for taxa and natural products
+      links:
+        - https://github.com/lotusnprod/lotus-web/blob/f7b06f29de1a5e49b85c070ebc80e8f063954365/src/main/js/components/compoundcard/Representations.js
+
+- name: Text2Term Ontology Mapper
+  link: https://github.com/ccb-hms/ontology-mapper
+  type: package
+  uses:
+    - description: Uses the Bioregistry python package for parsing URIs
+      links:
+        - https://github.com/ccb-hms/ontology-mapper/blob/0b4edd50da0144ec317e77b265f93e3d6655a64e/text2term/onto_utils.py
+
+
+- link: https://lamin.ai/docs/bionty
+  name: Bionty
+  type: project
+  uses:
+    - description: Uses the Bioregistry Python package to normalize prefixes
+      links:
+        - https://github.com/laminlabs/bionty/issues/199
+        - https://github.com/laminlabs/bionty/blob/3f2f3bf1f9acb2e0c33c4ee885997ea7fb681ba2/bionty/_table.py
+
+- name: Related Sciences
+  link: https://www.related.vc
+  type: organization
+  uses:
+    - description: Uses the Bioregistry Python package to normalize prefixes and CURIEs in its ENSEMBL pre-processing pipeline
+      links:
+        - https://github.com/related-sciences/ensembl-genes/blob/d251894f4b8af164230a08849a81f8af76be8039/ensembl_genes/ensembl_genes.py
+        - https://github.com/related-sciences/ensembl-genes/blob/50af2fca19dab904b7f2a70737a9ee027f2f8205/ensembl_genes/notebooks/ensembl_genes_eda.ipynb
+
+- name: Gut-brain Axis Knowledge Graph
+  abbreviation: GBA-KG
+  link: https://github.com/liwenqingi/GBA-KG
+  type: package
+  uses:
+    - description: Uses the Bioregistry via BERN2
+
+- name: Wikipathways
+  type: project
+  link: https://www.wikipathways.org
+  uses:
+    - description: Standardizes cross-references with the Bioregistry (via BridgeDB)
+      links:
+        - https://github.com/wikipathways/meta-data-action/blob/03e965afed8ae8837cc54d9e87f78ac12f8c4bf2/meta.data.action/src/main/java/meta/data/action/MetaDataExtractor.java
+
+- name: Ensmallen / Grape
+  type: package
+  link: https://github.com/AnacletoLAB/ensmallen
+  uses:
+    - description: Uses the Bioregistry Python package to standardize CURIEs in knowledge graphs generated from ontologies and other sources
+      links:
+        - https://github.com/AnacletoLAB/ensmallen/blob/c4a931dea9b83df64b2d1dd6aa717e9f563f3aa2/bindings/python/ensmallen/datasets/kgobo.py
+
+
+- name: Advanced Biomedical Entity Recognition and Normalization
+  abbreviation: BERN2
+  type: package
+  link: https://github.com/dmis-lab/BERN2
+  uses:
+    - description: Uses the Bioregistry web service for expanding CURIEs into URIs
+      links:
+        - https://github.com/dmis-lab/BERN2/blob/53a72b528e7a09bee2646c95ccf1103cfa9c8cf6/app/result_parser.py
+    - description: Uses the Bioregistry Python package for normalizing prefixes
+      links:
+        - https://github.com/dmis-lab/BERN2/blob/e783813c7a08852a18741057920e59949af7ca6b/bern2/bern2.py

--- a/docs/users.md
+++ b/docs/users.md
@@ -5,8 +5,28 @@ permalink: /usages/
 ---
 {% for entry in site.data.usages %}
 
-## {{ entry.name }}
+### {{ entry.name }}
 
-{{ entry }}
+<table class="table">
+<tr>
+<td><strong>Type</strong></td>
+<td>{{ entry.type | capitalize }}</td>
+</tr>
+<tr>
+<td><strong>Homepage</strong></td>
+<td><a href="{{ entry.link }}">{{ entry.link }}</a></td>
+</tr>
+</table>
+
+<ul>
+{% for usage in entry['uses'] %}
+<li>
+{{ usage['description'] }}
+{% for link in usage['links'] %}
+ <a href="{{ link }}">(ref)</a>
+{% endfor %}
+</li>
+{% endfor %}
+</ul>
 
 {% endfor %}

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Who's Using the Bioregistry?
+permalink: /usages/
+---
+{% for entry in site.data.usages %}
+
+## {{ entry.name }}
+
+{{ entry }}
+
+{% endfor %}

--- a/docs/users.md
+++ b/docs/users.md
@@ -8,16 +8,29 @@ permalink: /usages/
 ### {{ entry.name }}
 
 <table class="table">
+{% if entry.description %}
+<tr>
+<td><strong>Description</strong></td>
+<td>{{ entry.description }}</td>
+</tr>
+{% endif %}
 <tr>
 <td><strong>Type</strong></td>
 <td>{{ entry.type | capitalize }}</td>
 </tr>
 <tr>
 <td><strong>Homepage</strong></td>
-<td><a href="{{ entry.link }}">{{ entry.link }}</a></td>
+<td><a href="{{ entry.homepage }}">{{ entry.homepage }}</a></td>
 </tr>
-</table>
-
+{% if entry.repository and entry.repository != entry.homepage %}
+<tr>
+<td><strong>Repository</strong></td>
+<td><a href="{{ entry.repository }}">{{ entry.repository }}</a></td>
+</tr>
+{% endif %}
+<tr>
+<td><strong>Usages</strong></td>
+<td>
 <ul>
 {% for usage in entry['uses'] %}
 <li>
@@ -28,5 +41,8 @@ permalink: /usages/
 </li>
 {% endfor %}
 </ul>
+</td>
+</tr>
+</table>
 
 {% endfor %}

--- a/tests/test_usages.py
+++ b/tests/test_usages.py
@@ -1,0 +1,27 @@
+"""Test the integrity of the usages annotations."""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.resolve()
+USAGES_PATH = ROOT.joinpath("docs", "_data", "usages.yml")
+
+
+class TestUsages(unittest.TestCase):
+    """Test the integrity of the usages annotations."""
+
+    def test_usages(self):
+        """Test the integrity of the usages annotations."""
+        data = yaml.safe_load(USAGES_PATH.read_text())
+        self.assertIsNotNone(data)
+        for record in data:
+            self.assertIn("name", record)
+            name = record["name"]
+            with self.subTest(name=name):
+                self.assertIn("homepage", record)
+                self.assertIn("uses", record)
+                for use in record["uses"]:
+                    self.assertIn("description", use)

--- a/tests/test_usages.py
+++ b/tests/test_usages.py
@@ -22,6 +22,9 @@ class TestUsages(unittest.TestCase):
             name = record["name"]
             with self.subTest(name=name):
                 self.assertIn("homepage", record)
+                self.assertIsInstance(record["homepage"], str)
+                self.assertIn("type", record)
+                self.assertIn(record["type"], {"organization", "project", "package", "analysis"})
                 self.assertIn("uses", record)
                 for use in record["uses"]:
                     self.assertIn("description", use)


### PR DESCRIPTION
This PR adds a manually curated list of organizations/projects/software packages using the Bioregistry in a YAML file and an auto-generated web page to go on https://biopragmatics.github.io/bioregistry