### PR TITLE
UI Improvements

### DIFF
--- a/src/bioregistry/app/templates/macros.html
+++ b/src/bioregistry/app/templates/macros.html
@@ -54,6 +54,11 @@
             Has Canonical <i class="fas fa-exclamation-triangle"></i>
         </a>
     {% endif %}
+    {% if resource.proprietary %}
+        <span class="badge badge-warning" style="display: inline-block;">
+            Proprietary <i class="fas fa-exclamation-triangle"></i>
+        </span>
+    {% endif %}
 {% endmacro %}
 
 {% macro render_provider_table(prefix, identifier, providers) -%}

--- a/src/bioregistry/app/templates/macros.html
+++ b/src/bioregistry/app/templates/macros.html
@@ -73,6 +73,7 @@
             </thead>
             <tbody>
             {% for provider in providers %}
+                {% if provider.name %}
                 <tr>
                     <td>
                         {% if provider.homepage %}
@@ -86,6 +87,7 @@
                         <a href="{{ provider.uri }}">{{ provider.uri }}</a>
                     </td>
                 </tr>
+                {% endif %}
             {% endfor %}
             </tbody>
         </table>

--- a/src/bioregistry/app/templates/metaresource.html
+++ b/src/bioregistry/app/templates/metaresource.html
@@ -32,7 +32,7 @@
         </div>
         <div class="card-body">
             {% if entry.logo_url %}
-                <img style="max-height: 100px;" src="{{ entry.logo_url }}"/>
+                <img style="max-height: 100px;" src="{{ entry.logo_url }}" alt="Logo for {{ name }}"/>
             {% endif %}
             <p>{{ description }}</p>
             <dl>

--- a/src/bioregistry/app/templates/metaresource.html
+++ b/src/bioregistry/app/templates/metaresource.html
@@ -56,6 +56,13 @@
                     {% else %}
                         <span class="badge badge-pill badge-warning">Missing Homepage</span>
                     {% endif %}
+                    {% if entry.governance.issue_tracker %}
+                        <a class="badge badge-pill badge-light" href="{{ entry.governance.issue_tracker }}">
+                            Issue Tracker <i class="fas fa-check"></i>
+                        </a>
+                    {% else %}
+                        <span class="badge badge-pill badge-light text-muted">No Issue Tracker</span>
+                    {% endif %}
                     {% if entry.download %}
                         <a class="badge badge-pill badge-light" href="{{ entry.download }}">
                             Download <i class="fas fa-download"></i>

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -373,7 +373,7 @@
                 {% endif %}
                 {% if part_of %}
                     <dt>
-                        Part Of
+                        Part Of ({{ utils.code_curie("bfo", "0000050") }})
                     </dt>
                     <dd>
                         {% if manager.get_name(part_of) %}
@@ -389,7 +389,7 @@
                 {% endif %}
                 {% if has_parts %}
                     <dt>
-                        Has Part
+                        Has Part ({{ utils.code_curie("bfo", "0000051") }})
                     </dt>
                     <dd>
                         {% for rel_prefix in has_parts %}
@@ -403,7 +403,7 @@
                 {% endif %}
                 {% if has_canonical %}
                     <dt>
-                        Has Canonical
+                        Has Canonical ({{ utils.code_curie("bioregistry.schema", "0000016") }})
                     </dt>
                     <dd>
                         <a href="{{ url_for("metaregistry_ui.resource", prefix=has_canonical) }}"
@@ -429,7 +429,7 @@
                 {% endif %}
                 {% if depends_on %}
                     <dt>
-                        Depends On ({{ depends_on | length }})
+                        Depends On ({{ depends_on | length }}) ({{ utils.code_curie("bioregistry.schema", "0000017") }})
                     </dt>
                     <dd>
                         {% for rel_prefix in depends_on %}
@@ -443,7 +443,7 @@
                 {% endif %}
                 {% if appears_in %}
                     <dt>
-                        Appears In ({{ appears_in | length }})
+                        Appears In ({{ appears_in | length }}) ({{ utils.code_curie("bioregistry.schema", "0000018") }})
                     </dt>
                     <dd>
                         {% for rel_prefix in appears_in %}

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -480,9 +480,9 @@
                     <tr>
                         <td>
                             {% if mapping.homepage %}
-                                <a href="{{ mapping.homepage }}">{{ mapping.name }}</a>
+                                <a href="{{ mapping.homepage }}" title="{{ mapping.name }}">{{ mapping.short_name }}</a>
                             {% else %}
-                                {{ mapping.name }}
+                                {{ mapping.short_name }}
                             {% endif %}
                             {% if mapping.metaresource.logo_url %}
                                 <img style="max-height: 1em" alt="{{ mapping.name }} logo" src="{{ mapping.metaresource.logo_url }}" />

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -77,6 +77,13 @@
                     instead of <code>{{ prefix }}</code>.
                 </p>
             {% endif %}
+            {% if resource.proprietary %}
+                <p>
+                    This resource is <span class="badge badge-warning">proprietary</span>. This means that it is not
+                    freely and publicly available without restriction. Such resources are still valuable to include
+                    in the Bioregistry as they may appear in other non-proprietary resources.
+                </p>
+            {% endif %}
 
             <dl>
                 {% if resource.comment %}

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -239,33 +239,25 @@
                         <span class="badge badge-pill badge-warning">Missing Example Local Unique Identifier</span>
                     {% endif %}
                 </dd>
+                {% if pattern and curie_pattern %}
                 <dt>Pattern for CURIES</dt>
                 <dd>
-                    {% if curie_pattern %}
-                        <p>
-                            Compact URIs (CURIEs) constructed from {{ name }} should match
-                            this regular expression:<br/><kbd>{{ curie_pattern }}</kbd>
-                        </p>
-                    {% elif has_no_terms %}
-                        <span class="badge badge-pill badge-secondary">No terms in {{ prefix }}</span>
-                    {% else %}
-                        <span class="badge badge-pill badge-warning">Could not construct CURIE pattern</span>
-                    {% endif %}
+                    <p>
+                        Compact URIs (CURIEs) constructed from {{ name }} should match
+                        this regular expression:<br/><kbd>{{ curie_pattern }}</kbd>
+                    </p>
                 </dd>
+                {% endif %}
+                {% if example and example_curie %}
                 <dt>Example CURIE{% if resource.example_extras %}s{% endif %}</dt>
                 <dd>
-                    {% if example_curie %}
-                        <a href="{{ url_for("metaregistry_ui.reference", prefix=prefix, identifier=example) }}">{{ example_curie }}</a>
-                        {% for example_curie_extra, example_extra in zip(example_curie_extras, example_extras) %}
-                            <br />
-                            <a href="{{ url_for("metaregistry_ui.reference", prefix=prefix, identifier=example_extra) }}">{{ example_curie_extra }}</a>
-                        {% endfor %}
-                    {% elif has_no_terms %}
-                        <span class="badge badge-pill badge-secondary">No Terms in {{ prefix }}</span>
-                    {% else %}
-                        <span class="badge badge-pill badge-warning">Missing Example Local Unique Identifier</span>
-                    {% endif %}
+                    <a href="{{ url_for("metaregistry_ui.reference", prefix=prefix, identifier=example) }}">{{ example_curie }}</a>
+                    {% for example_curie_extra, example_extra in zip(example_curie_extras, example_extras) %}
+                        <br />
+                        <a href="{{ url_for("metaregistry_ui.reference", prefix=prefix, identifier=example_extra) }}">{{ example_curie_extra }}</a>
+                    {% endfor %}
                 </dd>
+                {% endif %}
                 {% if namespace_in_lui %}
                     <dt><i class="fas fa-info-circle"></i> MIRIAM Namespace Embedded in LUI</dt>
                     <dd>

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -141,6 +141,7 @@ def resource(prefix: str):
                 xref=xref,
                 homepage=manager.get_registry_homepage(metaprefix),
                 name=manager.get_registry_name(metaprefix),
+                short_name=manager.get_registry_short_name(metaprefix),
                 uri=manager.get_registry_provider_uri_format(metaprefix, xref),
             )
             for metaprefix, xref in _resource.get_mappings().items()

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -174,6 +174,13 @@ class Manager:
             return None
         return registry.name
 
+    def get_registry_short_name(self, metaprefix: str) -> Optional[str]:
+        """Get the registry short name."""
+        registry = self.get_registry(metaprefix)
+        if registry is None:
+            return None
+        return registry.get_short_name()
+
     def get_registry_homepage(self, metaprefix: str) -> Optional[str]:
         """Get the registry homepage."""
         registry = self.get_registry(metaprefix)


### PR DESCRIPTION
- Add label to resource page about proprietary prefixes 
<img width="947" alt="Screenshot 2023-02-25 at 13 35 52" src="https://user-images.githubusercontent.com/5069736/221357090-2451e8fd-6014-4747-acaf-82637c19b6ca.png">

- Add CURIEs for ontology relations in resource page
- Don't show extra providers in metaregistry table
- If no example/pattern are available, don't double up showing the example CURIE and CURIE patttern boxes