### PR TITLE
Identifier Space Owners

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -165,3 +165,7 @@ allowed to be done in a more *ad-hoc* manner. The Bioregistry Review Team may
 later make explicit criteria for accepting changes to this governance.
 
 ## Partners
+
+Please see https://github.com/biopragmatics/bioregistry/issues/755
+for discussions about a governance model for partnerships between
+the Bioregistry and identifier space owners.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -163,3 +163,5 @@ This governance must updated through the following steps:
 This procedure doesn't apply to cosmetic or ergonomics changes, which are
 allowed to be done in a more *ad-hoc* manner. The Bioregistry Review Team may
 later make explicit criteria for accepting changes to this governance.
+
+## Partners

--- a/src/bioregistry/app/templates/highlights/owners.html
+++ b/src/bioregistry/app/templates/highlights/owners.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% import "macros.html" as utils %}
+
+{% block title %}{{ config.METAREGISTRY_TITLE }} - Owners{% endblock %}
+
+{% block container %}
+    <div class="card">
+        <h5 class="card-header">
+            Partners
+        </h5>
+        <table class="table">
+            <thead>
+            <tr>
+                <th>CURIE</th>
+                <th>Name</th>
+                <th>Resources</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for curie, resources in owner_to_resources|dictsort %}
+                <tr>
+                    <td>{{ utils.code_curie(*curie) }}</td>
+                    <td><a href="{{ owners[curie].link }}">{{ owners[curie].name }}</a></td>
+                    <td>
+                        {% for resource in resources %}
+                            {{ utils.render_prefix(resource.prefix, classes="badge badge-pill badge-primary") }}
+                        {% endfor %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -204,6 +204,17 @@
                         <span class="badge badge-pill badge-warning">Missing Contact</span>
                     {% endif %}
                 </dd>
+                {% if resource.owner %}
+                    <dt>
+                    Identifier Space Owner
+                    </dt>
+                    <dd>
+                    <a href="{{ resource.owner.link }}">{{ resource.owner.name }}</a>
+                    {% if resource.owner.active %}
+                        <span class="badge badge-pill badge-info">Active</span>
+                        {% endif %}
+                    </dd>
+                {% endif %}
                 <dt>Pattern for Local Unique Identifiers</dt>
                 <dd>
                     {% if pattern %}

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -210,7 +210,11 @@
                     <dd>
                     <a href="{{ owner.link }}">{{ owner.name }}</a>
                     {% if owner.partnered %}
-                        <span class="badge badge-pill badge-info">Partnered</span>
+                    <a href="https://github.com/biopragmatics/bioregistry/blob/main/docs/GOVERNANCE.md#partners"
+                           class="badge badge-pill badge-info" data-toggle="tooltip"
+                           title="This organization has partnered with the Bioregistry to proactively maintain this record. Click to see related project governance.">
+                        Partnered
+                    </a>
                     {% endif %}
                     </dd>
                     {% endfor %}

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -204,16 +204,16 @@
                         <span class="badge badge-pill badge-warning">Missing Contact</span>
                     {% endif %}
                 </dd>
-                {% if resource.owner %}
-                    <dt>
-                    Identifier Space Owner
-                    </dt>
+                {% if resource.owners %}
+                    <dt>Identifier Space Owner</dt>
+                    {% for owner in resource.owners %}
                     <dd>
-                    <a href="{{ resource.owner.link }}">{{ resource.owner.name }}</a>
-                    {% if resource.owner.active %}
-                        <span class="badge badge-pill badge-info">Active</span>
-                        {% endif %}
+                    <a href="{{ owner.link }}">{{ owner.name }}</a>
+                    {% if owner.partnered %}
+                        <span class="badge badge-pill badge-info">Partnered</span>
+                    {% endif %}
                     </dd>
+                    {% endfor %}
                 {% endif %}
                 <dt>Pattern for Local Unique Identifiers</dt>
                 <dd>

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -205,7 +205,7 @@
                     {% endif %}
                 </dd>
                 {% if resource.owners %}
-                    <dt>Identifier Space Owner</dt>
+                    <dt>Identifier Space Owner{% if resource.owners | length > 1 %}s{% endif %}</dt>
                     {% for owner in resource.owners %}
                     <dd>
                     <a href="{{ owner.link }}">{{ owner.name }}</a>

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -583,4 +583,6 @@ def highlights_owners():
         for owner in resource.owners or []:
             owners[owner.pair] = owner
             owner_to_resources[owner.pair].append(resource)
-    return render_template("highlights/owners.html", owners=owners, owner_to_resources=owner_to_resources)
+    return render_template(
+        "highlights/owners.html", owners=owners, owner_to_resources=owner_to_resources
+    )

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -572,3 +572,15 @@ def highlights_keywords():
             keyword_to_prefix[keyword].append(resource)
 
     return render_template("highlights/keywords.html", keywords=keyword_to_prefix)
+
+
+@ui_blueprint.route("/highlights/owners")
+def highlights_owners():
+    """Render the partners highlights page."""
+    owner_to_resources = defaultdict(list)
+    owners = {}
+    for resource in manager.registry.values():
+        for owner in resource.owners or []:
+            owners[owner.pair] = owner
+            owner_to_resources[owner.pair].append(resource)
+    return render_template("highlights/owners.html", owners=owners, owner_to_resources=owner_to_resources)

--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -1301,7 +1301,7 @@
       "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/66/Wikidata-logo-en.svg",
       "name": "Wikidata Property",
       "prefix": "wikidata",
-      "provider_uri_format": "https://www.wikidata.org/entity/$1",
+      "provider_uri_format": "http://www.wikidata.org/entity/$1",
       "qualities": {
         "automatable_download": true,
         "bulk_data": true,

--- a/src/bioregistry/export/rdf_export.py
+++ b/src/bioregistry/export/rdf_export.py
@@ -160,7 +160,7 @@ def _get_resource_functions() -> List[Tuple[Union[str, URIRef], Callable[[Resour
     ]
 
 
-def _add_resource(resource: Resource, *, manager: Manager, graph: rdflib.Graph):
+def _add_resource(resource: Resource, *, manager: Manager, graph: rdflib.Graph):  # noqa:C901
     node = cast(URIRef, bioregistry_resource[resource.prefix])
     graph.add((node, RDF.type, bioregistry_schema["0000001"]))
     graph.add((node, RDFS.label, Literal(resource.get_name())))

--- a/src/bioregistry/export/rdf_export.py
+++ b/src/bioregistry/export/rdf_export.py
@@ -24,6 +24,7 @@ from bioregistry.constants import (
 from bioregistry.schema.constants import (
     IDOT,
     OBOINOWL,
+    ROR,
     VANN,
     WIKIDATA,
     _add_schema,
@@ -97,6 +98,7 @@ def _graph(manager: Manager) -> rdflib.Graph:
     graph.namespace_manager.bind("idot", IDOT)
     graph.namespace_manager.bind("wikidata", WIKIDATA)
     graph.namespace_manager.bind("vann", VANN)
+    graph.namespace_manager.bind("ror", ROR)
     graph.namespace_manager.bind("oboinowl", OBOINOWL)
     for key, value in manager.get_internal_prefix_map().items():
         graph.namespace_manager.bind(key, value)
@@ -196,9 +198,9 @@ def _add_resource(resource: Resource, *, manager: Manager, graph: rdflib.Graph):
 
     for owner in resource.owners or []:
         if owner.ror:
-            obj = NAMESPACES["ror"][owner.ror]
+            obj = ROR[owner.ror]
         elif owner.wikidata:
-            obj = NAMESPACES["wikidata"][owner.wikidata]
+            obj = WIKIDATA[owner.wikidata]
         else:
             continue
         graph.add((node, bioregistry_schema["0000026"], obj))

--- a/src/bioregistry/export/rdf_export.py
+++ b/src/bioregistry/export/rdf_export.py
@@ -194,6 +194,15 @@ def _add_resource(resource: Resource, *, manager: Manager, graph: rdflib.Graph):
     for appears_in in manager.get_appears_in(resource.prefix) or []:
         graph.add((node, bioregistry_schema["0000018"], bioregistry_resource[appears_in]))
 
+    for owner in resource.owners or []:
+        if owner.ror:
+            obj = NAMESPACES["ror"][owner.ror]
+        elif owner.wikidata:
+            obj = NAMESPACES["wikidata"][owner.wikidata]
+        else:
+            continue
+        graph.add((node, bioregistry_schema["0000026"], obj))
+
     part_of = manager.get_part_of(resource.prefix)
     if part_of:
         graph.add((node, DCTERMS.isPartOf, bioregistry_resource[part_of]))

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -644,6 +644,7 @@ class Manager:
             contributor=resource.contributor,
             contributor_extras=resource.contributor_extras,
             reviewer=resource.reviewer,
+            owners=resource.owners,
             twitter=resource.get_twitter(),
             github_request_issue=resource.github_request_issue,
             # Ontology Relations

--- a/src/bioregistry/schema/constants.py
+++ b/src/bioregistry/schema/constants.py
@@ -48,6 +48,7 @@ class PropertyTerm(Term):
 
 
 IDOT = rdflib.Namespace("http://identifiers.org/idot/")
+ROR = rdflib.Namespace("https://ror.org/")
 VANN = rdflib.Namespace("http://purl.org/vocab/vann/")
 WIKIDATA = rdflib.Namespace("http://www.wikidata.org/entity/")
 OBOINOWL = rdflib.Namespace("http://www.geneontology.org/formats/oboInOwl#")

--- a/src/bioregistry/schema/constants.py
+++ b/src/bioregistry/schema/constants.py
@@ -251,6 +251,20 @@ bioregistry_schema_terms = [
             VANN["preferredNamespaceUri"],
         ],
     ),
+    ClassTerm(
+        "0000025",
+        "Class",
+        "Organization",
+        "An organization",
+    ),
+    PropertyTerm(
+        "0000026",
+        "Property",
+        "has identifier space owner",
+        "An organization",
+        domain="0000001",
+        range="0000025",
+    ),
 ]
 bioregistry_schema_extras = [
     ("0000001", DCTERMS.isPartOf, "part of", "0000002"),  # resource part of registry

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -154,6 +154,37 @@
         "name"
       ]
     },
+    "Organization": {
+      "title": "Organization",
+      "description": "Model for organizataions.",
+      "type": "object",
+      "properties": {
+        "ror": {
+          "title": "Research Organization Registry identifier",
+          "description": "ROR identifier for a record about the organization",
+          "type": "string"
+        },
+        "wikidata": {
+          "title": "Wikidata identifier",
+          "description": "Wikidata identifier for a record about the organization",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "Name of the organization",
+          "type": "string"
+        },
+        "active": {
+          "title": "Active",
+          "description": "Has this organization made a specific connection with Bioregistry?",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "Publication": {
       "title": "Publication",
       "description": "Metadata about a publication.",
@@ -247,6 +278,15 @@
           "allOf": [
             {
               "$ref": "#/definitions/Attributable"
+            }
+          ]
+        },
+        "owner": {
+          "title": "Owner",
+          "description": "The owner of the corresponding identifier space. See also https://github.com/biopragmatics/bioregistry/issues/755.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Organization"
             }
           ]
         },

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -174,11 +174,6 @@
           "description": "Name of the organization",
           "type": "string"
         },
-        "logo_url": {
-          "title": "Logo Url",
-          "description": "A URL resolving to an image for the organization.",
-          "type": "string"
-        },
         "partnered": {
           "title": "Partnered",
           "description": "Has this organization made a specific connection with Bioregistry?",

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -174,8 +174,13 @@
           "description": "Name of the organization",
           "type": "string"
         },
-        "active": {
-          "title": "Active",
+        "logo_url": {
+          "title": "Logo Url",
+          "description": "A URL resolving to an image for the organization.",
+          "type": "string"
+        },
+        "partnered": {
+          "title": "Partnered",
           "description": "Has this organization made a specific connection with Bioregistry?",
           "default": false,
           "type": "boolean"
@@ -281,14 +286,13 @@
             }
           ]
         },
-        "owner": {
-          "title": "Owner",
+        "owners": {
+          "title": "Owners",
           "description": "The owner of the corresponding identifier space. See also https://github.com/biopragmatics/bioregistry/issues/755.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Organization"
-            }
-          ]
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Organization"
+          }
         },
         "example": {
           "title": "Example",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -122,7 +122,6 @@ class Organization(BaseModel):
         description="Wikidata identifier for a record about the organization",
     )
     name: str = Field(..., description="Name of the organization")
-    logo_url: Optional[str] = Field(description="A URL resolving to an image for the organization.")
     partnered: bool = Field(
         False, description="Has this organization made a specific connection with Bioregistry?"
     )

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -110,6 +110,33 @@ URI_FORMAT_PATHS = [
 ]
 
 
+class Organization(BaseModel):
+    """Model for organizataions."""
+
+    ror: Optional[str] = Field(
+        title="Research Organization Registry identifier",
+        description="ROR identifier for a record about the organization",
+    )
+    wikidata: Optional[str] = Field(
+        title="Wikidata identifier",
+        description="Wikidata identifier for a record about the organization",
+    )
+    name: str = Field(description="Name of the organization")
+    active: bool = Field(
+        False, description="Has this organization made a specific connection with Bioregistry?"
+    )
+
+    @property
+    def link(self) -> str:
+        """Get a link for the organization."""
+        if self.ror:
+            return f"https://ror.org/{self.ror}"
+        elif self.wikidata:
+            return f"https://www.wikidata.org/wiki/{self.wikidata}"
+        else:
+            raise ValueError
+
+
 class Attributable(BaseModel):
     """An upper-level metadata for a researcher."""
 
@@ -265,6 +292,10 @@ class Resource(BaseModel):
             "person and not be a listserve nor a shared email account."
         ),
         integration_status="suggested",
+    )
+    owner: Optional[Organization] = Field(
+        description="The owner of the corresponding identifier space. See also https://github.com/biopragmatics/"
+        "bioregistry/issues/755."
     )
     example: Optional[str] = Field(
         description="An example local identifier for the resource, explicitly excluding any redundant "

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -121,8 +121,9 @@ class Organization(BaseModel):
         title="Wikidata identifier",
         description="Wikidata identifier for a record about the organization",
     )
-    name: str = Field(description="Name of the organization")
-    active: bool = Field(
+    name: str = Field(..., description="Name of the organization")
+    logo_url: Optional[str] = Field(description="A URL resolving to an image for the organization.")
+    partnered: bool = Field(
         False, description="Has this organization made a specific connection with Bioregistry?"
     )
 
@@ -293,7 +294,7 @@ class Resource(BaseModel):
         ),
         integration_status="suggested",
     )
-    owner: Optional[Organization] = Field(
+    owners: Optional[List[Organization]] = Field(
         description="The owner of the corresponding identifier space. See also https://github.com/biopragmatics/"
         "bioregistry/issues/755."
     )

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -133,7 +133,7 @@ class Organization(BaseModel):
         if self.ror:
             return f"https://ror.org/{self.ror}"
         elif self.wikidata:
-            return f"https://www.wikidata.org/wiki/{self.wikidata}"
+            return f"https://scholia.toolforge.org/{self.wikidata}"
         else:
             raise ValueError
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -127,6 +127,15 @@ class Organization(BaseModel):
     )
 
     @property
+    def pair(self) -> Tuple[str, str]:
+        """Get a CURIE pair."""
+        if self.ror:
+            return "ror", self.ror
+        elif self.wikidata:
+            return "wikidata", self.wikidata
+        raise ValueError
+
+    @property
     def link(self) -> str:
         """Get a link for the organization."""
         if self.ror:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -984,13 +984,16 @@ class TestRegistry(unittest.TestCase):
     def test_owners(self):
         """Test owner annotations."""
         for prefix, resource in self.registry.items():
-            if not resource.owner:
+            if not resource.owners:
                 continue
-            with self.subTest(prefix=prefix):
-                self.assertTrue(resource.owner.ror is not None or resource.wikidata is not None)
-                if resource.owner.active:
+            with self.subTest(prefix=prefix, owner=owner.name):
+                # If any organizations are partnered, ensure fully
+                # filled out contact.
+                if any(owner.partnered for owner in resource.owners):
                     self.assertIsNotNone(resource.contact)
                     self.assertIsNotNone(resource.contact.github)
                     self.assertIsNotNone(resource.contact.email)
                     self.assertIsNotNone(resource.contact.orcid)
                     self.assertIsNotNone(resource.contact.name)
+                for owner in resource.owners:
+                    self.assertTrue(owner.ror is not None or owner.wikidata is not None)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -986,7 +986,7 @@ class TestRegistry(unittest.TestCase):
         for prefix, resource in self.registry.items():
             if not resource.owners:
                 continue
-            with self.subTest(prefix=prefix, owner=owner.name):
+            with self.subTest(prefix=prefix):
                 # If any organizations are partnered, ensure fully
                 # filled out contact.
                 if any(owner.partnered for owner in resource.owners):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -980,3 +980,17 @@ class TestRegistry(unittest.TestCase):
                 keywords = resource.get_keywords()
                 self.assertIsNotNone(keywords)
                 self.assertLess(0, len(keywords), msg=f"{resource.prefix} is missing keywords")
+
+    def test_owners(self):
+        """Test owner annotations."""
+        for prefix, resource in self.registry.items():
+            if not resource.owner:
+                continue
+            with self.subTest(prefix=prefix):
+                self.assertTrue(resource.owner.ror is not None or resource.wikidata is not None)
+                if resource.owner.active:
+                    self.assertIsNotNone(resource.contact)
+                    self.assertIsNotNone(resource.contact.github)
+                    self.assertIsNotNone(resource.contact.email)
+                    self.assertIsNotNone(resource.contact.orcid)
+                    self.assertIsNotNone(resource.contact.name)


### PR DESCRIPTION
References #755

This PR does the following:

1. Adds a data model for identifier space owners. Each resource can have zero, one, or many identifier space owners. Each identifier space owner needs to be identified by a ROR identifier (preferred) or Wikidata identifier. These can be annotated to any record.
2. Resources' identifier space owners can be marked as "partnered", meaning that they have established a more formal relationship with the Bioregistry. The implications of this relationship are TBD.
3. Adds identifier space owners to resouce page (see screenshot below)
4. Adds identifier space owners to RDF export
5. Curates several owners, mostly focusing on big organizations like NLM, NCI, and EBI. Uses `semapv` as the first example of a "partnered" resource

## Screenshot

The following screenshot shows what it looks like for an organization that has partnered with Bioregistry.

<img width="1036" alt="Screenshot 2023-03-03 at 17 12 51" src="https://user-images.githubusercontent.com/5069736/222770576-4e688ed6-bc91-4ba4-9bac-99733fc9be20.png">

