### PR TITLE
Add additional contact information and split `nemo` record

### DIFF
--- a/src/bioregistry/data/mismatch.json
+++ b/src/bioregistry/data/mismatch.json
@@ -78,6 +78,11 @@
   "ncbitaxon": {
     "prefixcommons": "uniprot.taxonomy"
   },
+  "nemo": {
+    "aberowl": "NEMO",
+    "bioportal": "NEMO",
+    "fairsharing": "FAIRsharing.n66krd"
+  },
   "ngl": {
     "bartoc": "20302"
   },


### PR DESCRIPTION
I have a local script I used to prioritize records that have a contact name and maybe an email, but no ORCID. I did some searching on ORCID for these people.

I also noticed that the `nemo` prefix has bad mismatches, so this record was split.

Some edits I pushed upstream to OBO foundry in https://github.com/OBOFoundry/OBOFoundry.github.io/pull/2321/files


## Code

```python
from collections import defaultdict

import click
from tabulate import tabulate

import bioregistry


#: People known to have retired pre-orcid should be skipped
SKIP = {
    "Jonathan Bard",
    "Vivian Lee", # maybe married and changed name?
}
SKIP_PARTS = {
    "helpdesk",
    "team",
    "customer service",
    "administrators",
}

@click.command()
def _main():
    data = defaultdict(list)
    for resource in bioregistry.resources():
        contact = resource.get_contact()
        if not contact or contact.name in SKIP:
            continue
        if any(p in contact.name.lower() for p in SKIP_PARTS):
            continue
        if contact and contact.email and not contact.orcid:
            data[contact.name.lower()].append((resource.prefix, contact.name, contact.email))

    rows = [
        row
        for _, rows in sorted(data.items())
        for row in rows
    ]
    click.echo(tabulate(rows, headers=["prefix", "name", "email"], tablefmt="github", showindex=True))


if __name__ == '__main__':
    _main()
```