### PR TITLE
Implement URI mapping service

### DIFF
--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
 
+from curies.mapping_service import get_flask_mapping_blueprint
 from flasgger import Swagger
 from flask import Flask
 from flask_bootstrap import Bootstrap4
@@ -168,6 +169,9 @@ def get_app(
 
     app.register_blueprint(api_blueprint)
     app.register_blueprint(ui_blueprint)
+
+    sparql_blueprint = get_flask_mapping_blueprint(app.manager.converter)
+    app.register_blueprint(sparql_blueprint)
 
     # Make manager available in all jinja templates
     app.jinja_env.globals.update(manager=app.manager, curie_to_str=curie_to_str)

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -982,7 +982,6 @@ def get_converter(**kwargs) -> curies.Converter:
     return manager.get_converter(**kwargs)
 
 
-@lru_cache(1)
 def get_default_converter() -> curies.Converter:
     """Get a converter from this manager."""
-    return manager.get_converter()
+    return manager.converter

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -159,6 +159,15 @@ class Manager:
         self.provided_by = dict(provided_by)
         self.has_parts = dict(has_parts)
 
+        self._converter = None
+
+    @property
+    def converter(self) -> curies.Converter:
+        """Get the default converter."""
+        if self._converter is None:
+            self._converter = curies.Converter(records=self.get_curies_records())
+        return self._converter
+
     def write_registry(self):
         """Write the registry."""
         write_registry(self.registry)


### PR DESCRIPTION
Closes #686

This adds the URI mapping service implemented in https://github.com/cthoyt/curies/pull/41. It will allow for SPARQL queries to be written that call the Bioregistry as a service for generating URI mappings (e.g., between OBO PURLs, Identifiers.org URIs, and first-party URIs whose URI prefixes are stored in the Bioregistry). 

Here's a simplified example that doesn't require any triple store, and can be directly executed with RDFLib:

```sparql
SELECT DISTINCT ?s ?o WHERE {
    VALUES ?s {
        <http://purl.obolibrary.org/obo/CHEBI_24867>
        <http://purl.obolibrary.org/obo/CHEBI_24868>
    }

    SERVICE <https://bioregistry.io/sparql> {
        ?s owl:sameAs ?o
    }
}
```

returns the following (some not shown, you should get the idea):

| subject                                |  object |
|---------------------------------------|------------------------------------------------- |
| http://purl.obolibrary.org/obo/CHEBI_24867  | http://purl.obolibrary.org/obo/CHEBI_24867 |
| http://purl.obolibrary.org/obo/CHEBI_24867  | http://identifiers.org/chebi/24867 |
| http://purl.obolibrary.org/obo/CHEBI_24867 | https://www.ebi.ac.uk/chebi/searchId.do?chebiId=24867 |
| ... | ... |

This is built on top of the [`curies.Converter.https://curies.readthedocs.io/en/latest/api/curies.Converter.html#curies.Converter.expand_pair_all](https://curies.readthedocs.io/en/latest/api/curies.Converter.html#curies.Converter.expand_pair_all), which itself is populated by all of the URI format strings available in the Bioregistry. To see examples of the possible ChEBI URIs, see https://bioregistry.io/registry/chebi.

