### PR TITLE
Mount onto FastAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.10-alpine
+FROM python:3.11-alpine
 
 RUN python -m pip install --upgrade pip
 RUN python -m pip install --upgrade wheel
-RUN python -m pip install gunicorn bioregistry[web]
-ENTRYPOINT python -m bioregistry web --port 8766 --host "0.0.0.0" --with-gunicorn --workers 4
+RUN python -m pip install bioregistry[web]
+ENTRYPOINT python -m bioregistry web --port 8766 --host "0.0.0.0" --workers 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,6 +107,8 @@ web =
     rdflib-jsonld
     flask
     flasgger
+    fastapi
+    uvicorn
     bootstrap-flask<=2.0.0
     markdown
 

--- a/src/bioregistry/app/wsgi.py
+++ b/src/bioregistry/app/wsgi.py
@@ -7,4 +7,6 @@ from bioregistry.app.impl import get_app
 app = get_app()
 
 if __name__ == "__main__":
-    app.run(debug=True)  # noqa
+    import uvicorn
+
+    uvicorn.run(app, port=5000, host="0.0.0.0")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -18,7 +18,7 @@ class TestWeb(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up the test case with an app."""
-        self.app = get_app()
+        _, self.app = get_app(return_flask=True)
         self.manager = Manager()
 
     def test_ui(self):


### PR DESCRIPTION
This PR creates a FastAPI and mounts the whole Bioregistry web app on to it wholesale. This doesn't affect anything about how the app works. 

Here's the specifics

- `get_app()` now returns a `fastapi.FastAPI` instance. if you need to get at the flask app (e.g., for testing), then you can now use `return_flask` to get a pair of the fastapi and flask instances.
- `uvicorn` is now used to run the app instead of werkzeug or gunicorn. besides needing some new dependencies, all of the interfaces should work the same
- slight exception being `--with-gunicorn` is now not doing anything. You can just delete those options.