### PR TITLE
Add bio2rdf links

### DIFF
--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1251,6 +1251,10 @@ class Resource(BaseModel):
         """
         return self.get_external("biocontext").get(URI_FORMAT_KEY)
 
+    def get_prefixcommons_prefix(self) -> Optional[str]:
+        """Get the Prefix Commons prefix."""
+        return self.get_mapped_prefix("prefixcommons")
+
     def get_prefixcommons_uri_format(self) -> Optional[str]:
         """Get the Prefix Commons URI format string for this entry, if available.
 
@@ -1601,6 +1605,17 @@ class Resource(BaseModel):
         if self.miriam:
             for p in self.miriam.get("providers", []):
                 rv.append(Provider(**p))
+        prefixcommons_prefix = self.get_prefixcommons_prefix()
+        if prefixcommons_prefix:
+            rv.append(
+                Provider(
+                    code="bio2rdf",
+                    name="Bio2RDF",
+                    homepage="http://bio2rdf.org",
+                    uri_format=f"http://bio2rdf.org/{prefixcommons_prefix}:$1",
+                    description="Bio2RDF connects life science data in RDF",
+                )
+            )
         return sorted(rv, key=attrgetter("code"))
 
     def get_curie(self, identifier: str, use_preferred: bool = False) -> str:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1611,9 +1611,12 @@ class Resource(BaseModel):
                 Provider(
                     code="bio2rdf",
                     name="Bio2RDF",
-                    homepage="http://bio2rdf.org",
+                    homepage="https://bio2rdf.org",
                     uri_format=f"http://bio2rdf.org/{prefixcommons_prefix}:$1",
-                    description="Bio2RDF connects life science data in RDF",
+                    description="Bio2RDF is an open-source project that uses Semantic Web technologies to "
+                    "build and provide the largest network of Linked Data for the Life Sciences. Bio2RDF "
+                    "defines a set of simple conventions to create RDF(S) compatible Linked Data from a diverse "
+                    "set of heterogeneously formatted sources obtained from multiple data providers.",
                 )
             )
         return sorted(rv, key=attrgetter("code"))


### PR DESCRIPTION
Closes #787

This adds Bio2RDF links for all resources that have been mapped to a Prefix Commons prefix so the mapping service can handle bio2rdf URIs. It will now also display on the website too.

<img width="1433" alt="Screenshot 2023-03-26 at 13 17 24" src="https://user-images.githubusercontent.com/5069736/227772134-9f879a21-f9ff-4a64-9ed0-5f3025c10909.png">


