### PR TITLE
Improve CURIE and URI handling

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.12-dev
+current_version = 0.8.0-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = f"{date.today().year}, Charles Tapley Hoyt"
 author = "Charles Tapley Hoyt"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.7.12-dev"
+release = "0.8.0-dev"
 
 # The short X.Y version.
 parsed_version = re.match(

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # Configuring setup()
 [metadata]
 name = bioregistry
-version = 0.7.12-dev
+version = 0.8.0-dev
 description = Integrated registry of biological databases and nomenclatures
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bioregistry/__init__.py
+++ b/src/bioregistry/__init__.py
@@ -13,12 +13,7 @@ from .metaresource_api import (  # noqa:F401
     get_registry_short_name,
     get_registry_uri,
 )
-from .parse_iri import (  # noqa:F401
-    curie_from_iri,
-    ensure_prefix_list,
-    parse_iri,
-    parse_obolibrary_purl,
-)
+from .parse_iri import curie_from_iri, parse_iri  # noqa:F401
 from .resolve import (  # noqa:F401
     count_mappings,
     get_appears_in,

--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -5,6 +5,7 @@
 import os
 import pathlib
 import re
+from typing import Tuple, Union
 
 import pystow
 
@@ -145,3 +146,5 @@ EXTRAS = f"%20Community%20Health%20Score&link={CH_BASE}"
 # not a perfect email regex, but close enough
 EMAIL_RE_STR = r"^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,5}$"
 EMAIL_RE = re.compile(EMAIL_RE_STR)
+
+MaybeCURIE = Union[Tuple[str, str], Tuple[None, None]]

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -19,7 +19,7 @@ you should pre-process the prefix map with:
 >>> from bioregistry import get_default_converter
 >>> from curies import Converter, chain
 >>> prefix_map = {"chebi": "https://example.org/chebi:"}
->>> converter = chain(Converter.from_prefix_map(prefix_map), get_default_converter())
+>>> converter = chain([Converter.from_prefix_map(prefix_map), get_default_converter()])
 >>> converter.compress("https://example.org/chebi:1234")
 'chebi:1234'
 """.rstrip()
@@ -31,7 +31,7 @@ you should pre-process the prefix map with:
 >>> from bioregistry import get_default_converter
 >>> from curies import Converter, chain
 >>> prefix_map = {"chebi": "https://example.org/chebi:"}
->>> converter = chain(Converter.from_prefix_map(prefix_map), get_default_converter())
+>>> converter = chain([Converter.from_prefix_map(prefix_map), get_default_converter()])
 >>> converter.parse_uri("https://example.org/chebi:1234")
 ('chebi', '1234')
 """.rstrip()
@@ -43,6 +43,18 @@ def curie_from_iri(
     prefix_map=None,
     use_preferred: bool = False,
 ) -> Optional[str]:
+    """Generate a CURIE from an IRI via :meth:`Manager.compress`.
+
+    :param iri: A valid IRI.
+    :param prefix_map:
+        This functionality was removed in Bioregistry v0.8.0.
+        Leave this as None. Will be removed in Bioregistry v0.9.0.
+    :param use_preferred:
+        If set to true, uses the "preferred prefix", if available, instead
+        of the canonicalized Bioregistry prefix.
+    :return: A CURIE string, if the IRI can be parsed.
+    :raises NotImplementedError: If ``prefix_map`` is not None.
+    """
     if prefix_map is not None:
         raise NotImplementedError(COMPRESS_ERROR_TEXT)
     return manager.compress(iri, use_preferred=use_preferred)
@@ -56,10 +68,13 @@ def parse_iri(
 ) -> MaybeCURIE:
     """Parse a compact identifier from an IRI that wraps :meth:`Manager.parse_uri`.
 
-    :param iri: A valid IRI. See
+    :param iri: A valid IRI.
     :param prefix_map:
         This functionality was removed in Bioregistry v0.8.0.
         Leave this as None. Will be removed in Bioregistry v0.9.0.
+    :param use_preferred:
+        If set to true, uses the "preferred prefix", if available, instead
+        of the canonicalized Bioregistry prefix.
     :return: A pair of prefix/identifier, if can be parsed
     :raises NotImplementedError: If ``prefix_map`` is not None.
     """

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -2,240 +2,67 @@
 
 """Functionality for parsing IRIs."""
 
-import warnings
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import Optional
 
-from .resolve import get_default_converter, get_preferred_prefix, parse_curie
-from .resource_manager import prepare_prefix_list
-from .uri_format import get_prefix_map
-from .utils import curie_to_str
+from .constants import MaybeCURIE
+from .resource_manager import manager
 
 __all__ = [
     "curie_from_iri",
     "parse_iri",
-    "parse_obolibrary_purl",
-    "ensure_prefix_list",
 ]
 
-OLS_URL_PREFIX = "https://www.ebi.ac.uk/ols/ontologies/"
-BIOREGISTRY_PREFIX = "https://bioregistry.io"
-OBO_PREFIX = "http://purl.obolibrary.org/obo/"
-IDOT_HTTPS_PREFIX = "https://identifiers.org/"
-IDOT_HTTP_PREFIX = "http://identifiers.org/"
-N2T_PREFIX = "https://n2t.net/"
+COMPRESS_ERROR_TEXT = """\
+If you provide your own prefix map but want to do compression in bulk,
+you should pre-process the prefix map with:
 
-PrefixList = List[Tuple[str, str]]
+>>> from bioregistry import get_default_converter
+>>> from curies import Converter, chain
+>>> prefix_map = {"chebi": "https://example.org/chebi:"}
+>>> converter = chain(Converter.from_prefix_map(prefix_map), get_default_converter())
+>>> converter.compress("https://example.org/chebi:1234")
+'chebi:1234'
+""".rstrip()
+
+PARSE_IRI_ERROR_TEXT = """\
+If you provide your own prefix map but want to do parsing in bulk,
+you should pre-process the prefix map with:
+
+>>> from bioregistry import get_default_converter
+>>> from curies import Converter, chain
+>>> prefix_map = {"chebi": "https://example.org/chebi:"}
+>>> converter = chain(Converter.from_prefix_map(prefix_map), get_default_converter())
+>>> converter.parse_uri("https://example.org/chebi:1234")
+('chebi', '1234')
+""".rstrip()
 
 
 def curie_from_iri(
     iri: str,
     *,
-    prefix_map: Union[Mapping[str, str], PrefixList, None] = None,
+    prefix_map=None,
     use_preferred: bool = False,
 ) -> Optional[str]:
-    """Parse a compact identifier from an IRI using :func:`parse_iri` and reconstitute it.
-
-    :param iri: A valid IRI
-    :param prefix_map: See :func:`parse_iri`
-    :param use_preferred: Should the preferred prefix be used instead
-        of the Bioregistry prefix (if it exists)?
-    :return: A CURIE string, if the IRI can be parsed by :func:`parse_iri`.
-
-    IRI from an OBO PURL:
-
-    >>> curie_from_iri("http://purl.obolibrary.org/obo/DRON_00023232")
-    'dron:00023232'
-
-    IRI from the OLS:
-
-    >>> curie_from_iri("https://www.ebi.ac.uk/ols/ontologies/ecao/terms?iri=http://purl.obolibrary.org/obo/ECAO_1")
-    'ecao:1'
-
-    .. todo:: IRI from bioportal
-
-    IRI from native provider
-
-    >>> curie_from_iri("https://www.alzforum.org/mutations/1234")
-    'alzforum.mutation:1234'
-
-    Dog food:
-
-    >>> curie_from_iri("https://bioregistry.io/DRON:00023232")
-    'dron:00023232'
-
-    IRIs from Identifiers.org (https and http, colon and slash):
-
-    >>> curie_from_iri("https://identifiers.org/aop.relationships:5")
-    'aop.relationships:5'
-    >>> curie_from_iri("http://identifiers.org/aop.relationships:5")
-    'aop.relationships:5'
-    >>> curie_from_iri("https://identifiers.org/aop.relationships/5")
-    'aop.relationships:5'
-    >>> curie_from_iri("http://identifiers.org/aop.relationships/5")
-    'aop.relationships:5'
-
-    IRI from N2T
-    >>> curie_from_iri("https://n2t.net/aop.relationships:5")
-    'aop.relationships:5'
-
-    IRI from an OBO PURL (with preferred prefix)
-    >>> curie_from_iri("http://purl.obolibrary.org/obo/DRON_00023232", use_preferred=True)
-    'DRON:00023232'
-    """
-    prefix, identifier = parse_iri(iri=iri, prefix_map=prefix_map)
-    if prefix is None or identifier is None:
-        return None
-    if use_preferred:
-        prefix = get_preferred_prefix(prefix) or prefix
-    return curie_to_str(prefix, identifier)
+    if prefix_map is not None:
+        raise NotImplementedError(COMPRESS_ERROR_TEXT)
+    return manager.compress(iri, use_preferred=use_preferred)
 
 
 def parse_iri(
     iri: str,
     *,
-    prefix_map: Union[Mapping[str, str], PrefixList, None] = None,
-) -> Union[Tuple[str, str], Tuple[None, None]]:
-    """Parse a compact identifier from an IRI.
+    prefix_map=None,
+    use_preferred: bool = False,
+) -> MaybeCURIE:
+    """Parse a compact identifier from an IRI that wraps :meth:`Manager.parse_uri`.
 
-    :param iri: A valid IRI
+    :param iri: A valid IRI. See
     :param prefix_map:
-        If None, will use the default prefix map. If a mapping, will convert into a sorted
-        list using :func:`ensure_prefix_list`. If you plan
-        to use this function in a loop, pre-compute this and pass it instead.
-        If a list of pairs is passed, will use it directly.
+        This functionality was removed in Bioregistry v0.8.0.
+        Leave this as None. Will be removed in Bioregistry v0.9.0.
     :return: A pair of prefix/identifier, if can be parsed
-
-    IRI from an OBO PURL:
-
-    >>> parse_iri("http://purl.obolibrary.org/obo/DRON_00023232")
-    ('dron', '00023232')
-
-    IRI from the OLS:
-
-    >>> parse_iri("https://www.ebi.ac.uk/ols/ontologies/ecao/terms?iri=http://purl.obolibrary.org/obo/ECAO_0107180")
-    ('ecao', '0107180')
-
-    .. todo:: IRI from bioportal
-
-    IRI from native provider
-
-    >>> parse_iri("https://www.alzforum.org/mutations/1234")
-    ('alzforum.mutation', '1234')
-
-    Dog food:
-
-    >>> parse_iri("https://bioregistry.io/DRON:00023232")
-    ('dron', '00023232')
-
-    IRIs from Identifiers.org (https and http, colon and slash):
-
-    >>> parse_iri("https://identifiers.org/aop.relationships:5")
-    ('aop.relationships', '5')
-    >>> parse_iri("http://identifiers.org/aop.relationships:5")
-    ('aop.relationships', '5')
-    >>> parse_iri("https://identifiers.org/aop.relationships/5")
-    ('aop.relationships', '5')
-    >>> parse_iri("http://identifiers.org/aop.relationships/5")
-    ('aop.relationships', '5')
-
-    IRI from N2T
-    >>> parse_iri("https://n2t.net/aop.relationships:5")
-    ('aop.relationships', '5')
-
-    Handle either HTTP or HTTPS:
-    >>> parse_iri("http://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=268")
-    ('neuronames', '268')
-    >>> parse_iri("https://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=268")
-    ('neuronames', '268')
-
-    Provide your own prefix map for one-off parsing (i.e., not in bulk):
-    >>> prefix_map = {"chebi": "https://example.org/chebi:"}
-    >>> parse_iri("https://example.org/chebi:1234", prefix_map=prefix_map)
-    ('chebi', '1234')
-
-    If you provide your own prefix map but want to do parsing in bulk,
-    you should pre-process the prefix map with:
-
-    >>> from bioregistry import ensure_prefix_list
-    >>> prefix_map = {"chebi": "https://example.org/chebi:"}
-    >>> prefix_list = ensure_prefix_list(prefix_map)
-    >>> parse_iri("https://example.org/chebi:1234", prefix_map=prefix_list)
-    ('chebi', '1234')
-
-    Corner cases:
-
-    >>> parse_iri("https://omim.org/MIM:PS214100")
-    ('omim.ps', '214100')
-
-    .. todo:: IRI with weird embedding, like ones that end in .html
+    :raises NotImplementedError: If ``prefix_map`` is not None.
     """
-    if prefix_map is None:
-        return get_default_converter().parse_uri(iri)
-
-    warnings.warn(
-        "Parsing without a pre-compiled `curies.Converter` class is very slow. "
-        "This functionality will be removed from the Bioregistry in a future version.",
-    )
-    # TODO remove this and update all relevant docstrings and README
-    if isinstance(prefix_map, list):
-        return _parse_iri(iri, prefix_map)
-    prefix_list = ensure_prefix_list(prefix_map)
-    return _parse_iri(iri, prefix_list)
-
-
-def _parse_iri(iri: str, prefix_list: List[Tuple[str, str]]):
-    if iri.startswith(BIOREGISTRY_PREFIX):
-        curie = iri[len(BIOREGISTRY_PREFIX) :]
-        return parse_curie(curie)
-    if iri.startswith(OLS_URL_PREFIX):
-        sub_iri = iri.rsplit("=", 1)[1]
-        return parse_obolibrary_purl(sub_iri)
-    if iri.startswith(OBO_PREFIX):
-        return parse_obolibrary_purl(iri)
-    if iri.startswith(IDOT_HTTPS_PREFIX):
-        curie = iri[len(IDOT_HTTPS_PREFIX) :]
-        return _safe_parse_curie(curie)
-    if iri.startswith(IDOT_HTTP_PREFIX):
-        curie = iri[len(IDOT_HTTP_PREFIX) :]
-        return _safe_parse_curie(curie)
-    if iri.startswith(N2T_PREFIX):
-        curie = iri[len(N2T_PREFIX) :]
-        return parse_curie(curie)
-    for prefix, prefix_url in prefix_list:
-        if iri.startswith(prefix_url):
-            return prefix, iri[len(prefix_url) :]
-    return None, None
-
-
-def ensure_prefix_list(
-    prefix_map: Optional[Mapping[str, str]] = None, **kwargs
-) -> List[Tuple[str, str]]:
-    """Ensure a prefix list, using the given merge strategy with default."""
-    _prefix_map = dict(get_prefix_map(**kwargs))
-    if prefix_map:
-        _prefix_map.update(prefix_map)
-    return prepare_prefix_list(_prefix_map)
-
-
-def _safe_parse_curie(curie: str) -> Union[Tuple[str, str], Tuple[None, None]]:
-    for sep in "_/:":
-        prefix, identifier = parse_curie(curie, sep)
-        if prefix is not None and identifier is not None:
-            return prefix, identifier
-    return None, None
-
-
-def parse_obolibrary_purl(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
-    """Parse an OBO Library PURL.
-
-    :param iri: A valid IRI
-    :return: A pair of prefix/identifier, if can be parsed
-
-    >>> parse_obolibrary_purl("http://purl.obolibrary.org/obo/DRON_00023232")
-    ('dron', '00023232')
-
-    >>> parse_obolibrary_purl("http://purl.obolibrary.org/obo/FBbt_0000001")
-    ('fbbt', '0000001')
-    """
-    curie = iri[len(OBO_PREFIX) :]
-    return parse_curie(curie, sep="_")
+    if prefix_map is not None:
+        raise NotImplementedError(PARSE_IRI_ERROR_TEXT)
+    return manager.parse_uri(iri, use_preferred=use_preferred)

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -45,7 +45,7 @@ def curie_from_iri(
 ) -> Optional[str]:
     """Generate a CURIE from an IRI via :meth:`Manager.compress`.
 
-    :param iri: A valid IRI.
+    :param iri: A valid IRI
     :param prefix_map:
         This functionality was removed in Bioregistry v0.8.0.
         Leave this as None. This argument will be removed in Bioregistry v0.9.0.
@@ -68,7 +68,7 @@ def parse_iri(
 ) -> MaybeCURIE:
     """Parse a compact identifier from an IRI that wraps :meth:`Manager.parse_uri`.
 
-    :param iri: A valid IRI.
+    :param iri: A valid IRI
     :param prefix_map:
         This functionality was removed in Bioregistry v0.8.0.
         Leave this as None. This argument will be removed in Bioregistry v0.9.0.

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -48,7 +48,7 @@ def curie_from_iri(
     :param iri: A valid IRI.
     :param prefix_map:
         This functionality was removed in Bioregistry v0.8.0.
-        Leave this as None. Will be removed in Bioregistry v0.9.0.
+        Leave this as None. This argument will be removed in Bioregistry v0.9.0.
     :param use_preferred:
         If set to true, uses the "preferred prefix", if available, instead
         of the canonicalized Bioregistry prefix.
@@ -71,7 +71,7 @@ def parse_iri(
     :param iri: A valid IRI.
     :param prefix_map:
         This functionality was removed in Bioregistry v0.8.0.
-        Leave this as None. Will be removed in Bioregistry v0.9.0.
+        Leave this as None. This argument will be removed in Bioregistry v0.9.0.
     :param use_preferred:
         If set to true, uses the "preferred prefix", if available, instead
         of the canonicalized Bioregistry prefix.

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 import curies
 
+from .constants import MaybeCURIE
 from .resource_manager import manager
 from .schema import Attributable, Resource
 
@@ -777,7 +778,7 @@ def parse_curie(
     *,
     sep: str = ":",
     use_preferred: bool = False,
-) -> Union[Tuple[str, str], Tuple[None, None]]:
+) -> MaybeCURIE:
     """Parse a CURIE, normalizing the prefix and identifier if necessary.
 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
@@ -830,7 +831,7 @@ def parse_curie(
     ('go', '1234')
 
     Use preferred (unavailable)
-    >>> parse_curie('pdb:1234', use_preferred=True))
+    >>> parse_curie('pdb:1234', use_preferred=True)
     ('pdb', '1234')
     """
     return manager.parse_curie(curie, sep=sep, use_preferred=use_preferred)
@@ -841,7 +842,7 @@ def normalize_parsed_curie(
     identifier: str,
     *,
     use_preferred: bool = False,
-) -> Union[Tuple[str, str], Tuple[None, None]]:
+) -> MaybeCURIE:
     """Normalize a prefix/identifier pair.
 
     :param prefix: The prefix in the CURIE

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -848,7 +848,7 @@ def normalize_parsed_curie(
     return manager.normalize_parsed_curie(prefix, identifier)
 
 
-def normalize_curie(curie: str, sep: str = ":") -> Optional[str]:
+def normalize_curie(curie: str, sep: str = ":", use_preferred: bool = False) -> Optional[str]:
     """Normalize a CURIE.
 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
@@ -891,7 +891,7 @@ def normalize_curie(curie: str, sep: str = ":") -> Optional[str]:
     >>> normalize_curie('GO_1234', sep="_")
     'go:1234'
     """
-    return manager.normalize_curie(curie, sep=sep)
+    return manager.normalize_curie(curie, sep=sep, use_preferred=use_preferred)
 
 
 def normalize_prefix(prefix: str) -> Optional[str]:

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -854,6 +854,9 @@ def normalize_curie(curie: str, sep: str = ":", use_preferred: bool = False) -> 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
     :param sep: The separator for the CURIE. Defaults to the colon ":" however the slash
         "/" is sometimes used in Identifiers.org and the underscore "_" is used for OBO PURLs.
+    :param use_preferred:
+        If set to true, uses the "preferred prefix", if available, instead
+        of the canonicalized Bioregistry prefix.
     :return: A normalized CURIE, if possible using the colon as a separator
 
     >>> normalize_curie('pdb:1234')
@@ -890,6 +893,10 @@ def normalize_curie(curie: str, sep: str = ":", use_preferred: bool = False) -> 
     Parse OBO PURL curies
     >>> normalize_curie('GO_1234', sep="_")
     'go:1234'
+
+    Use preferred
+    >>> normalize_curie('GO_1234', sep="_", use_preferred=True)
+    'GO:1234'
     """
     return manager.normalize_curie(curie, sep=sep, use_preferred=use_preferred)
 

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -772,7 +772,11 @@ def is_proprietary(prefix: str) -> Optional[bool]:
     return entry.proprietary
 
 
-def parse_curie(curie: str, sep: str = ":") -> Union[Tuple[str, str], Tuple[None, None]]:
+def parse_curie(
+    curie: str,
+    sep: str = ":",
+    use_preferred: bool = False,
+) -> Union[Tuple[str, str], Tuple[None, None]]:
     """Parse a CURIE, normalizing the prefix and identifier if necessary.
 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
@@ -817,7 +821,7 @@ def parse_curie(curie: str, sep: str = ":") -> Union[Tuple[str, str], Tuple[None
     >>> parse_curie("omim.ps:PS12345")
     ('omim.ps', '12345')
     """
-    return manager.parse_curie(curie, sep=sep)
+    return manager.parse_curie(curie, sep=sep, use_preferred=use_preferred)
 
 
 def normalize_parsed_curie(

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -5,7 +5,7 @@
 import logging
 import typing
 from functools import lru_cache
-from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Set
 
 import curies
 

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -828,7 +828,7 @@ def parse_curie(
 
     Use preferred (available)
     >>> parse_curie('GO_1234', sep="_", use_preferred=True)
-    ('go', '1234')
+    ('GO', '1234')
 
     Use preferred (unavailable)
     >>> parse_curie('pdb:1234', use_preferred=True)

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -774,6 +774,7 @@ def is_proprietary(prefix: str) -> Optional[bool]:
 
 def parse_curie(
     curie: str,
+    *,
     sep: str = ":",
     use_preferred: bool = False,
 ) -> Union[Tuple[str, str], Tuple[None, None]]:
@@ -828,7 +829,7 @@ def parse_curie(
     >>> parse_curie('GO_1234', sep="_", use_preferred=True)
     ('go', '1234')
 
-    Use preferred (unavailable):
+    Use preferred (unavailable)
     >>> parse_curie('pdb:1234', use_preferred=True))
     ('pdb', '1234')
     """
@@ -836,19 +837,25 @@ def parse_curie(
 
 
 def normalize_parsed_curie(
-    prefix: str, identifier: str
+    prefix: str,
+    identifier: str,
+    *,
+    use_preferred: bool = False,
 ) -> Union[Tuple[str, str], Tuple[None, None]]:
     """Normalize a prefix/identifier pair.
 
     :param prefix: The prefix in the CURIE
     :param identifier: The identifier in the CURIE
+    :param use_preferred:
+        If set to true, uses the "preferred prefix", if available, instead
+        of the canonicalized Bioregistry prefix.
     :return: A normalized prefix/identifier pair, conforming to Bioregistry standards. This means no redundant
         prefixes or bananas, all lowercase.
     """
-    return manager.normalize_parsed_curie(prefix, identifier)
+    return manager.normalize_parsed_curie(prefix, identifier, use_preferred=use_preferred)
 
 
-def normalize_curie(curie: str, sep: str = ":", use_preferred: bool = False) -> Optional[str]:
+def normalize_curie(curie: str, *, sep: str = ":", use_preferred: bool = False) -> Optional[str]:
     """Normalize a CURIE.
 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
@@ -901,11 +908,14 @@ def normalize_curie(curie: str, sep: str = ":", use_preferred: bool = False) -> 
     return manager.normalize_curie(curie, sep=sep, use_preferred=use_preferred)
 
 
-def normalize_prefix(prefix: str) -> Optional[str]:
+def normalize_prefix(prefix: str, *, use_preferred: bool = False) -> Optional[str]:
     """Get the normalized prefix, or return None if not registered.
 
     :param prefix: The prefix to normalize, which could come from Bioregistry,
         OBO Foundry, OLS, or any of the curated synonyms in the Bioregistry
+    :param use_preferred:
+        If set to true, uses the "preferred prefix", if available, instead
+        of the canonicalized Bioregistry prefix.
     :returns: The canonical Bioregistry prefix, it could be looked up. This
         will usually take precedence: MIRIAM, OBO Foundry / OLS, Custom except
         in a few cases, such as NCBITaxon.
@@ -922,8 +932,13 @@ def normalize_prefix(prefix: str) -> Optional[str]:
 
     >>> assert 'eccode' == normalize_prefix('ec-code')
     >>> assert 'eccode' == normalize_prefix('EC_CODE')
+
+    Get a "preferred" prefix:
+
+    >>> normalize_prefix("go", use_preferred=True)
+    'GO'
     """
-    return manager.normalize_prefix(prefix)
+    return manager.normalize_prefix(prefix, use_preferred=use_preferred)
 
 
 def get_version(prefix: str) -> Optional[str]:
@@ -940,7 +955,7 @@ def get_versions() -> Mapping[str, str]:
     return manager.get_versions()
 
 
-def get_curie_pattern(prefix: str, use_preferred: bool = False) -> Optional[str]:
+def get_curie_pattern(prefix: str, *, use_preferred: bool = False) -> Optional[str]:
     """Get the CURIE pattern for this resource.
 
     :param prefix: The prefix to look up

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -782,6 +782,9 @@ def parse_curie(
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
     :param sep: The separator for the CURIE. Defaults to the colon ":" however the slash
         "/" is sometimes used in Identifiers.org and the underscore "_" is used for OBO PURLs.
+    :param use_preferred:
+        If set to true, uses the "preferred prefix", if available, instead
+        of the canonicalized Bioregistry prefix.
     :returns: A tuple of the prefix, identifier. If not parsable, returns a tuple of None, None
 
     The algorithm for parsing a CURIE is very simple: it splits the string on the leftmost occurrence
@@ -820,6 +823,14 @@ def parse_curie(
     Banana with no peel:
     >>> parse_curie("omim.ps:PS12345")
     ('omim.ps', '12345')
+
+    Use preferred (available)
+    >>> parse_curie('GO_1234', sep="_", use_preferred=True)
+    ('go', '1234')
+
+    Use preferred (unavailable):
+    >>> parse_curie('pdb:1234', use_preferred=True))
+    ('pdb', '1234')
     """
     return manager.parse_curie(curie, sep=sep, use_preferred=use_preferred)
 

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -979,8 +979,7 @@ class Manager:
         :param identifier: The identifier in the CURIE
         :return: A link to the Bioregistry resolver
         """
-        norm_prefix, norm_identifier = self.normalize_parsed_curie(prefix, identifier)
-        curie = _safe_curie_to_str(norm_prefix, norm_identifier)
+        curie = self.normalize_curie(prefix, identifier)
         if curie is None:
             return None
         return f"{self.base_url}/{curie}"

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -381,7 +381,9 @@ class Manager:
             return None, None
         return self.normalize_parsed_curie(prefix, identifier, use_preferred=use_preferred)
 
-    def normalize_curie(self, curie: str, sep: str = ":", use_preferred: bool = False) -> Optional[str]:
+    def normalize_curie(
+        self, curie: str, sep: str = ":", use_preferred: bool = False
+    ) -> Optional[str]:
         """Normalize the prefix and identifier in the CURIE."""
         prefix, identifier = self.parse_curie(curie, sep=sep, use_preferred=use_preferred)
         return _safe_curie_to_str(prefix, identifier)

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -35,6 +35,7 @@ from .constants import (
     LINK_PRIORITY,
     METAREGISTRY_PATH,
     SHIELDS_BASE,
+    MaybeCURIE,
 )
 from .license_standardizer import standardize_license
 from .schema import (
@@ -61,8 +62,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-
-MaybeCURIE = Union[Tuple[str, str], Tuple[None, None]]
 
 
 def _synonym_to_canonical(registry: Mapping[str, Resource]) -> NormDict:

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -62,6 +62,8 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+MaybeCURIE = Union[Tuple[str, str], Tuple[None, None]]
+
 
 def _synonym_to_canonical(registry: Mapping[str, Resource]) -> NormDict:
     """Return a mapping from several variants of each synonym to the canonical namespace."""
@@ -83,6 +85,13 @@ def _synonym_to_canonical(registry: Mapping[str, Resource]) -> NormDict:
                 logger.debug(f"[{identifier}] missing potential synonym: {external_prefix}")
 
     return norm_synonym_to_key
+
+
+def _safe_curie_to_str(prefix: Optional[str], identifier: Optional[str]) -> Optional[str]:
+    """Combine a prefix and identifier into a CURIE string, if available."""
+    if prefix is None or identifier is None:
+        return None
+    return curie_to_str(prefix, identifier)
 
 
 class Manager:
@@ -235,24 +244,158 @@ class Manager:
             return None
         return self.registry.get(norm_prefix)
 
-    def parse_curie(self, curie: str, sep: str = ":") -> Union[Tuple[str, str], Tuple[None, None]]:
+    def parse_uri(self, uri: str, use_preferred: bool = False) -> MaybeCURIE:
+        """Parse a compact identifier from a URI.
+
+        :param iri: A valid IRI
+        :param prefix_map:
+            If None, will use the default prefix map. If a mapping, will convert into a sorted
+            list using :func:`ensure_prefix_list`. If you plan
+            to use this function in a loop, pre-compute this and pass it instead.
+            If a list of pairs is passed, will use it directly.
+        :return: A pair of prefix/identifier, if can be parsed
+
+        IRI from an OBO PURL:
+
+        >>> from bioregistry import manager
+        >>> manager.parse_uri("http://purl.obolibrary.org/obo/DRON_00023232")
+        ('dron', '00023232')
+
+        IRI from the OLS:
+
+        >>> manager.parse_uri("https://www.ebi.ac.uk/ols/ontologies/ecao/terms?iri=http://purl.obolibrary.org/obo/ECAO_0107180")
+        ('ecao', '0107180')
+
+        .. todo:: IRI from bioportal
+
+        IRI from native provider
+
+        >>> manager.parse_uri("https://www.alzforum.org/mutations/1234")
+        ('alzforum.mutation', '1234')
+
+        Dog food:
+
+        >>> manager.parse_uri("https://bioregistry.io/DRON:00023232")
+        ('dron', '00023232')
+
+        IRIs from Identifiers.org (https and http, colon and slash):
+
+        >>> manager.parse_uri("https://identifiers.org/aop.relationships:5")
+        ('aop.relationships', '5')
+        >>> manager.parse_uri("http://identifiers.org/aop.relationships:5")
+        ('aop.relationships', '5')
+        >>> manager.parse_uri("https://identifiers.org/aop.relationships/5")
+        ('aop.relationships', '5')
+        >>> manager.parse_uri("http://identifiers.org/aop.relationships/5")
+        ('aop.relationships', '5')
+
+        IRI from N2T
+        >>> manager.parse_uri("https://n2t.net/aop.relationships:5")
+        ('aop.relationships', '5')
+
+        Handle either HTTP or HTTPS:
+        >>> manager.parse_uri("http://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=268")
+        ('neuronames', '268')
+        >>> manager.parse_uri("https://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=268")
+        ('neuronames', '268')
+
+        Provide your own prefix map for one-off parsing (i.e., not in bulk):
+        >>> prefix_map = {"chebi": "https://example.org/chebi:"}
+        >>> manager.parse_uri("https://example.org/chebi:1234", prefix_map=prefix_map)
+        ('chebi', '1234')
+
+        If you provide your own prefix map but want to do parsing in bulk,
+        you should pre-process the prefix map with:
+
+        >>> from curies import Converter, chain
+        >>> prefix_map = {"chebi": "https://example.org/chebi:"}
+        >>> converter = chain(Converter.from_prefix_map(prefix_map), manager.converter)
+        >>> converter.parse_uri("https://example.org/chebi:1234")
+        ('chebi', '1234')
+
+        Corner cases:
+
+        >>> manager.parse_uri("https://omim.org/MIM:PS214100")
+        ('omim.ps', '214100')
+
+        .. todo:: IRI with weird embedding, like ones that end in .html
+        """
+        prefix, identifier = self.converter.parse_uri(uri)
+        if prefix is None or identifier is None:
+            return None, None
+        if use_preferred:
+            prefix = self.get_preferred_prefix(prefix) or prefix
+        return prefix, identifier
+
+    def compress(self, uri: str, use_preferred: bool = False) -> Optional[str]:
+        """Parse a compact identifier from an IRI using :func:`parse_iri` and reconstitute it.
+
+        :param uri: A valid URI
+
+        IRI from an OBO PURL:
+
+        >>> from bioregistry import manager
+        >>> manager.compress("http://purl.obolibrary.org/obo/DRON_00023232")
+        'dron:00023232'
+
+        IRI from the OLS:
+
+        >>> manager.compress("https://www.ebi.ac.uk/ols/ontologies/ecao/terms?iri=http://purl.obolibrary.org/obo/ECAO_1")
+        'ecao:1'
+
+        .. todo:: IRI from bioportal
+
+        IRI from native provider
+
+        >>> manager.compress("https://www.alzforum.org/mutations/1234")
+        'alzforum.mutation:1234'
+
+        Dog food:
+
+        >>> manager.compress("https://bioregistry.io/DRON:00023232")
+        'dron:00023232'
+
+        IRIs from Identifiers.org (https and http, colon and slash):
+
+        >>> manager.compress("https://identifiers.org/aop.relationships:5")
+        'aop.relationships:5'
+        >>> manager.compress("http://identifiers.org/aop.relationships:5")
+        'aop.relationships:5'
+        >>> manager.compress("https://identifiers.org/aop.relationships/5")
+        'aop.relationships:5'
+        >>> manager.compress("http://identifiers.org/aop.relationships/5")
+        'aop.relationships:5'
+
+        IRI from N2T
+        >>> manager.compress("https://n2t.net/aop.relationships:5")
+        'aop.relationships:5'
+
+        IRI from an OBO PURL (with preferred prefix)
+        >>> manager.compress("http://purl.obolibrary.org/obo/DRON_00023232", use_preferred=True)
+        'DRON:00023232'
+        """
+        prefix, identifier = self.parse_uri(uri, use_preferred=use_preferred)
+        return _safe_curie_to_str(prefix, identifier)
+
+    def parse_curie(self, curie: str, sep: str = ":", use_preferred: bool = False) -> MaybeCURIE:
         """Parse a CURIE and normalize its prefix and identifier."""
         try:
             prefix, identifier = curie.split(sep, 1)
         except ValueError:
             return None, None
-        return self.normalize_parsed_curie(prefix, identifier)
+        return self.normalize_parsed_curie(prefix, identifier, use_preferred=use_preferred)
 
     def normalize_curie(self, curie: str, sep: str = ":") -> Optional[str]:
         """Normalize the prefix and identifier in the CURIE."""
         prefix, identifier = self.parse_curie(curie, sep=sep)
-        if prefix is None or identifier is None:
-            return None
-        return curie_to_str(prefix, identifier)
+        return _safe_curie_to_str(prefix, identifier)
 
     def normalize_parsed_curie(
-        self, prefix: str, identifier: str
-    ) -> Union[Tuple[str, str], Tuple[None, None]]:
+        self,
+        prefix: str,
+        identifier: str,
+        use_preferred: bool = False,
+    ) -> MaybeCURIE:
         """Normalize a prefix/identifier pair.
 
         :param prefix: The prefix in the CURIE
@@ -835,9 +978,10 @@ class Manager:
         :return: A link to the Bioregistry resolver
         """
         norm_prefix, norm_identifier = self.normalize_parsed_curie(prefix, identifier)
-        if norm_prefix is None or norm_identifier is None:
+        curie = _safe_curie_to_str(norm_prefix, norm_identifier)
+        if curie is None:
             return None
-        return f"{self.base_url}/{curie_to_str(norm_prefix, norm_identifier)}"
+        return f"{self.base_url}/{curie}"
 
     def get_default_iri(self, prefix: str, identifier: str) -> Optional[str]:
         """Get the default URL for the given CURIE.
@@ -1364,23 +1508,6 @@ class Manager:
             contexts=self.contexts,
             direct_only=direct_only,
         )
-
-
-def prepare_prefix_list(prefix_map: Mapping[str, str]) -> List[Tuple[str, str]]:
-    """Prepare a priority prefix list from a prefix map."""
-    rv = []
-    for prefix, uri_prefix in sorted(prefix_map.items(), key=_sort_key):
-        rv.append((prefix, uri_prefix))
-        if uri_prefix.startswith("https://"):
-            rv.append((prefix, "http://" + uri_prefix[8:]))
-        elif uri_prefix.startswith("http://"):
-            rv.append((prefix, "https://" + uri_prefix[7:]))
-    return rv
-
-
-def _sort_key(kv: Tuple[str, str]) -> int:
-    """Return a value appropriate for sorting a pair of prefix/IRI."""
-    return -len(kv[0])
 
 
 def _read_contributors(

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -297,13 +297,7 @@ class Manager:
         >>> manager.parse_uri("https://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=268")
         ('neuronames', '268')
 
-        Provide your own prefix map for one-off parsing (i.e., not in bulk):
-        >>> prefix_map = {"chebi": "https://example.org/chebi:"}
-        >>> manager.parse_uri("https://example.org/chebi:1234", prefix_map=prefix_map)
-        ('chebi', '1234')
-
-        If you provide your own prefix map but want to do parsing in bulk,
-        you should pre-process the prefix map with:
+        If you provide your own prefix map, you should pre-process the prefix map with:
 
         >>> from curies import Converter, chain
         >>> prefix_map = {"chebi": "https://example.org/chebi:"}
@@ -326,7 +320,7 @@ class Manager:
         return prefix, identifier
 
     def compress(self, uri: str, use_preferred: bool = False) -> Optional[str]:
-        """Parse a compact identifier from an URI.
+        """Parse a compact uniform resource identifier (CURIE) from a URI.
 
         :param uri: A valid URI
         :param use_preferred:
@@ -387,9 +381,9 @@ class Manager:
             return None, None
         return self.normalize_parsed_curie(prefix, identifier, use_preferred=use_preferred)
 
-    def normalize_curie(self, curie: str, sep: str = ":") -> Optional[str]:
+    def normalize_curie(self, curie: str, sep: str = ":", use_preferred: bool = False) -> Optional[str]:
         """Normalize the prefix and identifier in the CURIE."""
-        prefix, identifier = self.parse_curie(curie, sep=sep)
+        prefix, identifier = self.parse_curie(curie, sep=sep, use_preferred=use_preferred)
         return _safe_curie_to_str(prefix, identifier)
 
     def normalize_parsed_curie(

--- a/src/bioregistry/version.py
+++ b/src/bioregistry/version.py
@@ -12,7 +12,7 @@ __all__ = [
     "get_git_hash",
 ]
 
-VERSION = "0.7.12-dev"
+VERSION = "0.8.0-dev"
 
 
 def get_git_hash() -> Optional[str]:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -364,7 +364,7 @@ class TestRegistry(unittest.TestCase):
         regex = entry.get_pattern()
         if not regex:
             return
-        self.assertRegexpMatches(example, regex, msg=f"[{prefix}] invalid LUID: {example}")
+        self.assertRegex(example, regex, msg=f"[{prefix}] invalid LUID: {example}")
         canonical = entry.is_valid_identifier(example)
         self.assertTrue(canonical is None or canonical, msg=f"[{prefix}] invalid LUID: {example}")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -5,7 +5,7 @@
 import unittest
 
 import bioregistry
-from bioregistry import Manager
+from bioregistry import Manager, parse_curie
 from bioregistry.export.rdf_export import get_full_rdf
 
 
@@ -225,3 +225,25 @@ class TestResourceManager(unittest.TestCase):
             )
         }
         self.assertEqual(set(self.manager.registry), prefixes)
+
+    def test_parse_curie(self):
+        """Test parsing CURIEs."""
+        for curie, pref, sep, p, i in [
+            ("pdb:1234", False, ":", "pdb", "1234"),
+            ("go:GO:1234", False, ":", "go", "1234"),
+            ("go:go:1234", False, ":", "go", "1234"),
+            ("go:1234", False, ":", "go", "1234"),
+            ("fbbt:FBbt:1234", False, ":", "fbbt", "1234"),
+            ("fbbt:fbbt:1234", False, ":", "fbbt", "1234"),
+            ("fbbt:1234", False, ":", "fbbt", "1234"),
+            ("go.ref:GO_REF:1234", False, ":", "go.ref", "1234"),
+            ("go.ref:1234", False, ":", "go.ref", "1234"),
+            ("GO_1234", False, "_", "go", "1234"),
+            ("omim.ps:PS12345", False, ":", "omim.ps", "12345"),
+            ("GO_1234", True, "_", "GO", "1234"),
+            ("pdb:1234", True, ":", "pdb", "1234"),
+        ]:
+            with self.subTest(curie=curie, use_preferred=pref, sep=sep):
+                actual_prefix, actual_i = parse_curie(curie, sep=sep, use_preferred=pref)
+                self.assertEqual(p, actual_prefix)
+                self.assertEqual(i, actual_i)

--- a/tests/test_metaregistry.py
+++ b/tests/test_metaregistry.py
@@ -147,7 +147,7 @@ class TestMetaregistry(unittest.TestCase):
             if pattern is None:
                 continue
             with self.subTest(metaprefix=metaprefix):
-                self.assertRegexpMatches(registry.example, pattern)
+                self.assertRegex(registry.example, pattern)
 
             # Test URI format string
             if registry.provider_uri_format:


### PR DESCRIPTION
This PR does the following:

1. Finally removes the `prefix_map` option from parsing URIs/IRIs and bumps by a minor version. Also removes some related code in the public API that was used to support this functionality, including the `ensure_prefix_list()` function. This probably wasn't used by anyone.
2. Consolidates implementation of IRI parsing into the `Manager` class
3. Enables `use_preferred` on the relevant functions as suggested in #790 
4. Updates deprecated testing