### PR TITLE
Remove flasgger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.11", "3.7" ]
     steps:
       - uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip install "tox<4.0.0"
+          pip install tox
       - name: Test with pytest
         run:
           tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ "3.11", "3.7" ]
     steps:
       - uses: actions/checkout@v2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -227,7 +227,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
+    "python": ("https://docs.python.org/3", None),
     "rdflib": ("https://rdflib.readthedocs.io/en/stable/", None),
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,7 @@ web =
     rdflib
     rdflib-jsonld
     rdflib-endpoint
-    flask<2.3.0
+    flask<2.2.4
     fastapi
     uvicorn
     bootstrap-flask<=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,7 @@ web =
     rdflib
     rdflib-jsonld
     rdflib-endpoint
-    flask
+    flask<2.3.0
     fastapi
     uvicorn
     bootstrap-flask<=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,6 @@ web =
     rdflib-jsonld
     rdflib-endpoint
     flask
-    flasgger
     fastapi
     uvicorn
     bootstrap-flask<=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,8 @@ maintainer_email = cthoyt@gmail.com
 
 # License information
 license = MIT
-license_file = LICENSE
+license_files =
+    LICENSE
 
 # Search tags
 classifiers =

--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -118,22 +118,24 @@ def get_app(
 
     if isinstance(config, (str, Path)):
         with open(config) as file:
-            config = json.load(file)
+            conf = json.load(file)
     elif config is None:
-        config = {}
-    config.setdefault("METAREGISTRY_TITLE", TITLE_DEFAULT)
-    config.setdefault("METAREGISTRY_DESCRIPTION", DESCRIPTION_DEFAULT)
-    config.setdefault("METAREGISTRY_FOOTER", FOOTER_DEFAULT)
-    config.setdefault("METAREGISTRY_HEADER", HEADER_DEFAULT)
-    config.setdefault("METAREGISTRY_RESOURCES_SUBHEADER", RESOURCES_SUBHEADER_DEFAULT)
-    config.setdefault("METAREGISTRY_VERSION", version.get_version())
-    example_prefix = config.setdefault("METAREGISTRY_EXAMPLE_PREFIX", "chebi")
-    config.setdefault("METAREGISTRY_EXAMPLE_IDENTIFIER", "138488")
-    config.setdefault("METAREGISTRY_FIRST_PARTY", first_party)
-    config.setdefault("METAREGISTRY_CONTACT_NAME", "Charles Tapley Hoyt")
-    config.setdefault("METAREGISTRY_CONTACT_EMAIL", "cthoyt@gmail.com")
-    config.setdefault("METAREGISTRY_LICENSE_NAME", "MIT License")
-    config.setdefault(
+        conf = {}
+    else:
+        conf = config
+    conf.setdefault("METAREGISTRY_TITLE", TITLE_DEFAULT)
+    conf.setdefault("METAREGISTRY_DESCRIPTION", DESCRIPTION_DEFAULT)
+    conf.setdefault("METAREGISTRY_FOOTER", FOOTER_DEFAULT)
+    conf.setdefault("METAREGISTRY_HEADER", HEADER_DEFAULT)
+    conf.setdefault("METAREGISTRY_RESOURCES_SUBHEADER", RESOURCES_SUBHEADER_DEFAULT)
+    conf.setdefault("METAREGISTRY_VERSION", version.get_version())
+    example_prefix = conf.setdefault("METAREGISTRY_EXAMPLE_PREFIX", "chebi")
+    conf.setdefault("METAREGISTRY_EXAMPLE_IDENTIFIER", "138488")
+    conf.setdefault("METAREGISTRY_FIRST_PARTY", first_party)
+    conf.setdefault("METAREGISTRY_CONTACT_NAME", "Charles Tapley Hoyt")
+    conf.setdefault("METAREGISTRY_CONTACT_EMAIL", "cthoyt@gmail.com")
+    conf.setdefault("METAREGISTRY_LICENSE_NAME", "MIT License")
+    conf.setdefault(
         "METAREGISTRY_LICENSE_URL", "https://github.com/biopragmatics/bioregistry/blob/main/LICENSE"
     )
 
@@ -152,22 +154,22 @@ def get_app(
     app.register_blueprint(api_blueprint)
     app.register_blueprint(ui_blueprint)
 
-    app.config.update(config)
+    app.config.update(conf)
     app.manager = manager
 
     if app.config.get("METAREGISTRY_FIRST_PARTY"):
         app.config.setdefault("METAREGISTRY_BIOSCHEMAS", BIOSCHEMAS)
 
     fast_api = FastAPI(
-        title=config["METAREGISTRY_TITLE"],
-        description=config["METAREGISTRY_DESCRIPTION"],
+        title=conf["METAREGISTRY_TITLE"],
+        description=conf["METAREGISTRY_DESCRIPTION"],
         contact={
-            "name": config["METAREGISTRY_CONTACT_NAME"],
-            "email": config["METAREGISTRY_CONTACT_EMAIL"],
+            "name": conf["METAREGISTRY_CONTACT_NAME"],
+            "email": conf["METAREGISTRY_CONTACT_EMAIL"],
         },
         license_info={
-            "name": config["METAREGISTRY_LICENSE_NAME"],
-            "url": config["METAREGISTRY_LICENSE_URL"],
+            "name": conf["METAREGISTRY_LICENSE_NAME"],
+            "url": conf["METAREGISTRY_LICENSE_URL"],
         },
     )
     fast_api.include_router(_get_sparql_router(app))

--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -26,7 +26,12 @@ __all__ = [
 ]
 
 TITLE_DEFAULT = "Bioregistry"
-DESCRIPTION_DEFAULT = "A service for resolving CURIEs"
+DESCRIPTION_DEFAULT = dedent(
+    """\
+    An open source, community curated registry, meta-registry,
+    and compact identifier (CURIE) resolver.
+"""
+)
 FOOTER_DEFAULT = dedent(
     """\
     Developed with ❤️ by the <a href="https://indralab.github.io">INDRA Lab</a> in the

--- a/src/bioregistry/app/templates/base.html
+++ b/src/bioregistry/app/templates/base.html
@@ -141,7 +141,6 @@
                     {% if config.METAREGISTRY_FIRST_PARTY %}
                     <a class="dropdown-item" href="{{ url_for('metaregistry_ui.download') }}">Downloads</a>
                     {% endif %}
-                    <a class="dropdown-item" href="{{ url_for('flasgger.apidocs') }}">API Documentation</a>
                     <a class="dropdown-item" href="{{ url_for("metaregistry_ui.usage") }}">Programmatic Usage Guide</a>
                 </div>
             </li>

--- a/src/bioregistry/app/templates/base.html
+++ b/src/bioregistry/app/templates/base.html
@@ -29,7 +29,7 @@
 
         <script src="https://kit.fontawesome.com/4c86883252.js" crossorigin="anonymous"></script>
         <title>{% block title %}{% endblock %}</title>
-        <meta name="description" content="The Bioregistry is an open source, community curated registry, meta-registry, and compact identifier (CURIE) resolver" />
+        <meta name="description" content="{{ config.METAREGISTRY_DESCRIPTION }}" />
         <link rel="icon" type="image/svg+xml" href="/static/logo.svg">
     {% endblock %}
 </head>

--- a/src/bioregistry/app/templates/base.html
+++ b/src/bioregistry/app/templates/base.html
@@ -141,6 +141,7 @@
                     {% if config.METAREGISTRY_FIRST_PARTY %}
                     <a class="dropdown-item" href="{{ url_for('metaregistry_ui.download') }}">Downloads</a>
                     {% endif %}
+                    <a class="dropdown-item" href="{{ url_for('metaregistry_ui.apidocs') }}">API Documentation</a>
                     <a class="dropdown-item" href="{{ url_for("metaregistry_ui.usage") }}">Programmatic Usage Guide</a>
                 </div>
             </li>

--- a/src/bioregistry/app/templates/meta/access.html
+++ b/src/bioregistry/app/templates/meta/access.html
@@ -19,12 +19,11 @@
         The {{ config.METAREGISTRY_TITLE }} web application is built on <a href="https://flask.palletsprojects.com">Flask</a>
         as a thin wrapper around the <a href="https://github.com/biopragmatics/bioregistry"><code>bioregistry</code></a>
         Python package. It exposes several endpoints for accessing the registry, metaregistry, collections, and search
-        functionality for which <a href="https://swagger.io/">Swagger</a> API documentation is automatically generated
-        by <a href="https://github.com/flasgger/flasgger">Flasgger</a>.
+        functionality.
     </p>
     <p>
-        See the remaining {{ config.METAREGISTRY_TITLE }} <a href="{{ url_for('flasgger.apidocs') }}">
-        <i class="fas fa-book"></i> API documentation</a> or follow some of these examples using Python:
+        We're currently working to automatically document this API with FastAPI. In the meantime,
+        you can follow some of these examples using Python:
     </p>
     <h3>Registry</h3>
     <p>

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -587,3 +587,10 @@ def highlights_owners():
     return render_template(
         "highlights/owners.html", owners=owners, owner_to_resources=owner_to_resources
     )
+
+
+@ui_blueprint.route("/apidocs")
+@ui_blueprint.route("/apidocs/")
+def apidocs():
+    """Render api documentation page."""
+    return redirect(url_for(".usage"))

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -47,8 +47,6 @@ class TestWeb(unittest.TestCase):
                 "sustainability",
                 "related",
                 "acknowledgements",
-                # API
-                "apidocs",
             ]:
                 with self.subTest(endpoint=endpoint):
                     res = client.get(endpoint, follow_redirects=True)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -318,7 +318,7 @@ class TestWeb(unittest.TestCase):
             ]:
                 with self.subTest(endpoint=endpoint):
                     res = client.get(endpoint)
-                    self.assertEqual(302, res.status_code)
+                    self.assertEqual(302, res.status_code, msg=f"\n\nFailed on {endpoint}\n\n{res.text}")
 
     def test_banana_redirects(self):
         """Test banana redirects."""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -318,9 +318,7 @@ class TestWeb(unittest.TestCase):
             ]:
                 with self.subTest(endpoint=endpoint):
                     res = client.get(endpoint, follow_redirects=False)
-                    self.assertEqual(
-                        302, res.status_code, msg=f"\n\nFailed on {endpoint}\n\n{res.text}"
-                    )
+                    self.assertEqual(302, res.status_code)
 
     def test_banana_redirects(self):
         """Test banana redirects."""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -317,7 +317,7 @@ class TestWeb(unittest.TestCase):
                 "health/go",
             ]:
                 with self.subTest(endpoint=endpoint):
-                    res = client.get(endpoint)
+                    res = client.get(endpoint, follow_redirects=False)
                     self.assertEqual(
                         302, res.status_code, msg=f"\n\nFailed on {endpoint}\n\n{res.text}"
                     )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -318,7 +318,9 @@ class TestWeb(unittest.TestCase):
             ]:
                 with self.subTest(endpoint=endpoint):
                     res = client.get(endpoint)
-                    self.assertEqual(302, res.status_code, msg=f"\n\nFailed on {endpoint}\n\n{res.text}")
+                    self.assertEqual(
+                        302, res.status_code, msg=f"\n\nFailed on {endpoint}\n\n{res.text}"
+                    )
 
     def test_banana_redirects(self):
         """Test banana redirects."""


### PR DESCRIPTION
This is in the lead up to switching over to using FastAPI for generating the API. Unfortunately, Flask has dropped py37 support and this is a reminder that flasgger is no longer maintained, and is not smart to rely on. 