### PR TITLE
Cache compiled re pattern

### DIFF
--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -271,6 +271,8 @@ class Resource(BaseModel):
     """Metadata about an ontology, database, or other resource."""
 
     class Config:
+        """Configuration for pydantic class"""
+
         underscore_attrs_are_private = True
 
     prefix: str = Field(

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -271,7 +271,7 @@ class Resource(BaseModel):
     """Metadata about an ontology, database, or other resource."""
 
     class Config:
-        """Configuration for pydantic class"""
+        """Configuration for pydantic class."""
 
         underscore_attrs_are_private = True
 


### PR DESCRIPTION
Fixes #858. My quick benchmark shows that this results in an about 30x speedup when doing a large number of `is_valid_identifier` calls.