### PR TITLE
Update minimum versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.63-dev
+current_version = 0.10.0-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = f"{date.today().year}, Charles Tapley Hoyt"
 author = "Charles Tapley Hoyt"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.9.63-dev"
+release = "0.10.0-dev"
 
 # The short X.Y version.
 parsed_version = re.match(

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     pystow>=0.1.13
     click
     more_click>=0.1.2
-    pydantic<2.0
+    pydantic>=2.0
     curies>=0.5.1
 
 zip_safe = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # Configuring setup()
 [metadata]
 name = bioregistry
-version = 0.9.63-dev
+version = 0.10.0-dev
 description = Integrated registry of biological databases and nomenclatures
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -22,7 +22,7 @@ from typing import (
 import click
 import requests
 from pydantic import BaseModel
-from pydantic.json import ENCODERS_BY_TYPE
+from pydantic.v1.json import ENCODERS_BY_TYPE
 from pystow.utils import get_hashes
 
 from .constants import (

--- a/src/bioregistry/version.py
+++ b/src/bioregistry/version.py
@@ -12,7 +12,7 @@ __all__ = [
     "get_git_hash",
 ]
 
-VERSION = "0.9.63-dev"
+VERSION = "0.10.0-dev"
 
 
 def get_git_hash() -> Optional[str]:


### PR DESCRIPTION
Bioregistry v0.1.0 release includes the following upgrades:

- Pydantic (2.0 is out)
- Python >= 3.8 (3.7 is past end of life)