### PR TITLE
Make explicit cross-version support for Pydantic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.11", "3.8" ]
+        pydantic: [ "pydantic1", "pydantic2" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -72,7 +73,7 @@ jobs:
           pip install tox
       - name: Test with pytest
         run:
-          tox -e py
+          tox -e py-${{ matrix.pydantic }}
       - name: Doctests
         run:
           tox -e doctests

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,6 @@ extensions = [
     "sphinx.ext.todo",
     # 'sphinx.ext.mathjax',
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
     "sphinx_click.ext",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,8 @@ install_requires =
     pystow>=0.1.13
     click
     more_click>=0.1.2
-    pydantic<2.0
-    curies>=0.5.6
+    pydantic
+    curies>=0.6.0
 
 zip_safe = false
 include_package_data = True
@@ -75,7 +75,6 @@ docs =
     sphinx
     sphinx-rtd-theme
     sphinx-click
-    sphinx-autodoc-typehints==1.21.1
     sphinx_automodapi
     autodoc_pydantic
 gha =

--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -18,6 +18,7 @@ from bioregistry import curie_to_str, resource_manager, version
 from .api import api_router
 from .constants import BIOSCHEMAS
 from .ui import ui_blueprint
+from ..constants import PYDANTIC_1
 
 if TYPE_CHECKING:
     import bioregistry
@@ -192,6 +193,7 @@ def get_app(
         curie_to_str=curie_to_str,
         fastapi_url_for=fast_api.url_path_for,
         markdown=markdown,
+        is_pydantic_1=PYDANTIC_1,
     )
 
     if return_flask:

--- a/src/bioregistry/app/templates/meta/related.html
+++ b/src/bioregistry/app/templates/meta/related.html
@@ -11,9 +11,15 @@
 {% endmacro %}
 
 {% macro registry_field_dl(cls, key) -%}
-    {% set field = cls.__fields__[key].field_info %}
-    <dt>{{ field.title or key.replace("_", " ").title() }}</dt>
-    <dd>{{ field.description }}</dd>
+    {% if is_pydantic_1 %}
+        {% set field = cls.__fields__[key].field_info %}
+        <dt>{{ field.title or key.replace("_", " ").title() }}</dt>
+        <dd>{{ field.description }}</dd>
+    {% else %}
+        {% set field = cls.__fields__[key] %}
+        <dt>{{ field.title or key.replace("_", " ").title() }}</dt>
+        <dd>{{ field.description }}</dd>
+    {% endif %}
 {% endmacro %}
 
 {% block styles %}

--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -2,6 +2,7 @@
 
 """Constants and utilities for registries."""
 
+import importlib.metadata
 import os
 import pathlib
 import re
@@ -18,6 +19,8 @@ __all__ = [
     "MISMATCH_PATH",
     "BIOREGISTRY_MODULE",
 ]
+
+PYDANTIC_1 = importlib.metadata.version("pydantic").startswith("1.")
 
 HERE = pathlib.Path(os.path.abspath(os.path.dirname(__file__)))
 DATA_DIRECTORY = HERE / "data"

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -832,6 +832,7 @@
         },
         "comments": {
           "title": "Comments",
+          "description": "Optional additional comments about the registry's governance model",
           "type": "string"
         },
         "accepts_external_contributions": {

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -2699,24 +2699,40 @@ def get_json_schema():
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "https://bioregistry.io/schema.json",
     }
-    rv.update(
-        pydantic.schema.schema(
-            [
-                Author,
-                Collection,
-                Provider,
-                Resource,
-                Registry,
-                RegistrySchema,
-                Context,
-                Publication,
-            ],
-            title="Bioregistry JSON Schema",
-            description="The Bioregistry JSON Schema describes the shapes of the objects in"
-            " the registry, metaregistry, collections, and their other related"
-            " resources",
-        )
+    models = [
+        Author,
+        Collection,
+        Provider,
+        Resource,
+        Registry,
+        RegistrySchema,
+        Context,
+        Publication,
+    ]
+
+    title = "Bioregistry JSON Schema"
+    description = (
+        "The Bioregistry JSON Schema describes the shapes of the objects in"
+        " the registry, metaregistry, collections, and their other related"
+        " resources"
     )
+
+    try:
+        # see https://docs.pydantic.dev/latest/usage/json_schema/#general-notes-on-json-schema-generation
+        from pydantic.json_schema import models_json_schema
+    except ImportError:
+        _schema = pydantic.schema.schema(
+            models,
+            title=title,
+            description=description,
+        )
+    else:
+        _schema = models_json_schema(
+            [(model, "validation") for model in models],
+            title=title,
+            description=description,
+        )
+    rv.update(_schema)
     return rv
 
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -2454,11 +2454,7 @@ class Registry(BaseModel):
 class Collection(BaseModel):
     """A collection of resources."""
 
-    identifier: str = Field(
-        ...,
-        description="The collection's identifier",
-        regex=r"^\d{7}$",
-    )
+    identifier: str = Field(..., description="The collection's identifier")
     name: str = Field(
         ...,
         description="The name of the collection",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -2337,7 +2337,9 @@ class Registry(BaseModel):
     description: str = Field(..., description="A full description of the registry.")
     homepage: str = Field(..., description="The URL for the homepage of the registry.")
     example: str = Field(..., description="An example prefix inside the registry.")
-    bibtex: Optional[str] = Field(description="Citation key used in BibTex for this registry.")
+    bibtex: Optional[str] = Field(
+        default=None, description="Citation key used in BibTex for this registry."
+    )
     availability: RegistrySchema = Field(
         ..., description="A structured description of the metadata that the registry collects"
     )

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -281,35 +281,42 @@ class Resource(BaseModel):
         integration_status="required",
     )
     name: Optional[str] = Field(
-        description="The name of the resource", integration_status="required"
+        default=None, description="The name of the resource", integration_status="required"
     )
     description: Optional[str] = Field(
-        description="A description of the resource", integration_status="required"
+        default=None, description="A description of the resource", integration_status="required"
     )
     pattern: Optional[str] = Field(
+        default=None,
         description="The regular expression pattern for local unique identifiers in the resource",
         integration_status="required_for_new",
     )
     uri_format: Optional[str] = Field(
+        default=None,
         title="URI format string",
         description=f"The URI format string, which must have at least one ``$1`` in it. {URI_IRI_INFO}",
         integration_status="required_for_new",
     )
     rdf_uri_format: Optional[str] = Field(
+        default=None,
         title="RDF URI format string",
         description=f"The RDF URI format string, which must have at least one ``$1`` in it. {URI_IRI_INFO}",
     )
     providers: Optional[List[Provider]] = Field(
+        default=None,
         description="Additional, non-default providers for the resource",
     )
     homepage: Optional[str] = Field(
+        default=None,
         description="The URL for the homepage of the resource, preferably using HTTPS",
         integration_status="required",
     )
     repository: Optional[str] = Field(
+        default=None,
         description="The URL for the repository of the resource",
     )
     contact: Optional[Attributable] = Field(
+        default=None,
         description=(
             "The contact email address for the resource. This must correspond to a specific "
             "person and not be a listserve nor a shared email account."
@@ -317,34 +324,42 @@ class Resource(BaseModel):
         integration_status="suggested",
     )
     owners: Optional[List[Organization]] = Field(
+        default=None,
         description="The owner of the corresponding identifier space. See also https://github.com/biopragmatics/"
-        "bioregistry/issues/755."
+        "bioregistry/issues/755.",
     )
     example: Optional[str] = Field(
+        default=None,
         description="An example local identifier for the resource, explicitly excluding any redundant "
         "usage of the prefix in the identifier. For example, a GO identifier should only "
         "look like ``1234567`` and not like ``GO:1234567``",
         integration_status="required",
     )
     example_extras: Optional[List[str]] = Field(
+        default=None,
         description="Extra example identifiers",
     )
     example_decoys: Optional[List[str]] = Field(
+        default=None,
         description="Extra example identifiers that explicitly fail regex tests",
     )
     license: Optional[str] = Field(
+        default=None,
         description="The license for the resource",
     )
     version: Optional[str] = Field(
+        default=None,
         description="The version for the resource",
     )
     part_of: Optional[str] = Field(
+        default=None,
         description=(
             "An annotation between this prefix and a super-prefix. For example, "
             "``chembl.compound`` is a part of ``chembl``."
-        )
+        ),
     )
     provides: Optional[str] = Field(
+        default=None,
         description=(
             "An annotation between this prefix and a prefix for which it is redundant. "
             "For example, ``ctd.gene`` has been given a prefix by Identifiers.org, but it "
@@ -352,6 +367,7 @@ class Resource(BaseModel):
         ),
     )
     download_owl: Optional[str] = Field(
+        default=None,
         title="OWL Download URL",
         description=_dedent(
             """\
@@ -361,6 +377,7 @@ class Resource(BaseModel):
         ),
     )
     download_obo: Optional[str] = Field(
+        default=None,
         title="OBO Download URL",
         description=_dedent(
             """\
@@ -370,6 +387,7 @@ class Resource(BaseModel):
         ),
     )
     download_json: Optional[str] = Field(
+        default=None,
         title="OBO Graph JSON Download URL",
         description=_dedent(
             """
@@ -379,6 +397,7 @@ class Resource(BaseModel):
         ),
     )
     download_rdf: Optional[str] = Field(
+        default=None,
         title="RDF Download URL",
         description=_dedent(
             """
@@ -387,6 +406,7 @@ class Resource(BaseModel):
         ),
     )
     banana: Optional[str] = Field(
+        default=None,
         description=_dedent(
             """\
     The `banana` is a generalization of the concept of the "namespace embedded in local unique identifier".
@@ -403,8 +423,9 @@ class Resource(BaseModel):
     """
         ),
     )
-    banana_peel: Optional[str] = Field(description="Delimiter used in banana")
+    banana_peel: Optional[str] = Field(default=None, description="Delimiter used in banana")
     deprecated: Optional[bool] = Field(
+        default=None,
         description=_dedent(
             """\
     A flag denoting if this resource is deprecated. Currently, this is a blanket term
@@ -2069,7 +2090,9 @@ class RegistryGovernance(BaseModel):
         " some registries are limited to ontologies, some have a full scope over the life sciences,"
         " and some are general purpose.",
     )
-    comments: Optional[str] = None
+    comments: Optional[str] = Field(
+        description="Optional additional comments about the registry's governance model"
+    )
     accepts_external_contributions: bool = Field(
         description="This field denotes if the registry (in theory) accepts external contributions, either via "
         "suggestion or proactive improvement. This field does not pass judgement on the difficult of this"

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -2721,18 +2721,18 @@ def get_json_schema():
         # see https://docs.pydantic.dev/latest/usage/json_schema/#general-notes-on-json-schema-generation
         from pydantic.json_schema import models_json_schema
     except ImportError:
-        _schema = pydantic.schema.schema(
+        schema_dict = pydantic.schema.schema(
             models,
             title=title,
             description=description,
         )
     else:
-        _schema = models_json_schema(
+        _, schema_dict = models_json_schema(
             [(model, "validation") for model in models],
             title=title,
             description=description,
         )
-    rv.update(_schema)
+    rv.update(schema_dict)
     return rv
 
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -120,10 +120,12 @@ class Organization(BaseModel):
     """Model for organizataions."""
 
     ror: Optional[str] = Field(
+        default=None,
         title="Research Organization Registry identifier",
         description="ROR identifier for a record about the organization",
     )
     wikidata: Optional[str] = Field(
+        default=None,
         title="Wikidata identifier",
         description="Wikidata identifier for a record about the organization",
     )
@@ -158,11 +160,13 @@ class Attributable(BaseModel):
     name: str = Field(..., description="The full name of the researcher")
 
     orcid: Optional[str] = Field(
+        default=None,
         title="Open Researcher and Contributor Identifier",
         description=ORCID_DESCRIPTION,
     )
 
     email: Optional[str] = Field(
+        default=None,
         title="Email address",
         description="The email address specific to the researcher.",
         # regex=EMAIL_RE_STR,
@@ -170,6 +174,7 @@ class Attributable(BaseModel):
 
     #: The GitHub handle for the author
     github: Optional[str] = Field(
+        default=None,
         title="GitHub handle",
         description=_dedent(
             """\
@@ -238,18 +243,19 @@ class Publication(BaseModel):
     """Metadata about a publication."""
 
     pubmed: Optional[str] = Field(
-        title="PubMed", description="The PubMed identifier for the article"
+        default=None, title="PubMed", description="The PubMed identifier for the article"
     )
     doi: Optional[str] = Field(
+        default=None,
         title="DOI",
         description="The DOI for the article. DOIs are case insensitive, so these are "
         "required by the Bioregistry to be standardized to their lowercase form.",
     )
     pmc: Optional[str] = Field(
-        title="PMC", description="The PubMed Central identifier for the article"
+        default=None, title="PMC", description="The PubMed Central identifier for the article"
     )
-    title: Optional[str] = Field(description="The title of the article")
-    year: Optional[int] = Field(description="The year the article was published")
+    title: Optional[str] = Field(default=None, description="The title of the article")
+    year: Optional[int] = Field(default=None, description="The year the article was published")
 
     def key(self) -> Tuple[str, ...]:
         """Create a key based on identifiers in this data structure."""
@@ -439,6 +445,7 @@ class Resource(BaseModel):
         ),
     )
     mappings: Optional[Dict[str, str]] = Field(
+        default=None,
         description=_dedent(
             """\
     A dictionary of metaprefixes (i.e., prefixes for registries) to prefixes in external registries.
@@ -447,6 +454,7 @@ class Resource(BaseModel):
         ),
     )
     synonyms: Optional[List[str]] = Field(
+        default=None,
         description=_dedent(
             """\
     A list of synonyms for the prefix of this resource. These are used in normalization of
@@ -457,21 +465,28 @@ class Resource(BaseModel):
     """
         ),
     )
-    keywords: Optional[List[str]] = Field(description="A list of keywords for the resource")
+    keywords: Optional[List[str]] = Field(
+        default=None, description="A list of keywords for the resource"
+    )
     references: Optional[List[str]] = Field(
+        default=None,
         description="A list of URLs to also see, such as publications describing the resource",
     )
     publications: Optional[List[Publication]] = Field(
+        default=None,
         description="A list of URLs to also see, such as publications describing the resource",
     )
     appears_in: Optional[List[str]] = Field(
+        default=None,
         description="A list of prefixes that use this resource for xrefs, provenance, etc.",
     )
     depends_on: Optional[List[str]] = Field(
+        default=None,
         description="A list of prefixes that use this resource depends on, e.g., ontologies that import each other.",
     )
 
     namespace_in_lui: Optional[bool] = Field(
+        default=None,
         title="Namespace Embedded in Local Unique Identifier",
         description=_dedent(
             """\
@@ -482,6 +497,7 @@ class Resource(BaseModel):
         ),
     )
     no_own_terms: Optional[bool] = Field(
+        default=None,
         description=_dedent(
             """\
     A flag denoting if the resource mints its own identifiers. Omission or explicit marking as false means
@@ -492,10 +508,12 @@ class Resource(BaseModel):
     )
     #: A field for a free text comment.
     comment: Optional[str] = Field(
+        default=None,
         description="A field for a free text comment",
     )
 
     contributor: Optional[Author] = Field(
+        default=None,
         description=_dedent(
             """\
     The contributor of the prefix to the Bioregistry, including at a minimum their name and ORCiD and
@@ -506,10 +524,12 @@ class Resource(BaseModel):
         integration_status="required_for_new",
     )
     contributor_extras: Optional[List[Author]] = Field(
+        default=None,
         description="Additional contributors besides the original submitter.",
     )
 
     reviewer: Optional[Author] = Field(
+        default=None,
         description=_dedent(
             """\
     The reviewer of the prefix to the Bioregistry, including at a minimum their name and ORCiD and
@@ -520,6 +540,7 @@ class Resource(BaseModel):
         integration_status="required_for_new",
     )
     proprietary: Optional[bool] = Field(
+        default=None,
         description=_dedent(
             """\
     A flag to denote if this database is proprietary and therefore can not be included in normal quality control
@@ -534,9 +555,11 @@ class Resource(BaseModel):
     #:
     #:    This field was added and described in detail in https://github.com/biopragmatics/bioregistry/pull/164
     has_canonical: Optional[str] = Field(
+        default=None,
         description="If this shares an IRI with another entry, maps to which should be be considered as canonical",
     )
     preferred_prefix: Optional[str] = Field(
+        default=None,
         description=_dedent(
             """\
     An annotation of stylization of the prefix. This appears in OBO ontologies like
@@ -545,12 +568,14 @@ class Resource(BaseModel):
     """
         ),
     )
-    twitter: Optional[str] = Field(description="The twitter handle for the project")
-    mastodon: Optional[str] = Field(description="The mastodon handle for the project")
+    twitter: Optional[str] = Field(default=None, description="The twitter handle for the project")
+    mastodon: Optional[str] = Field(default=None, description="The mastodon handle for the project")
     github_request_issue: Optional[int] = Field(
-        description="The GitHub issue for the new prefix request"
+        default=None, description="The GitHub issue for the new prefix request"
     )
-    logo: Optional[str] = Field(description="The URL of the logo for the project/resource")
+    logo: Optional[str] = Field(
+        default=None, description="The URL of the logo for the project/resource"
+    )
 
     #: External data from Identifiers.org's MIRIAM Database
     miriam: Optional[Mapping[str, Any]] = None
@@ -2091,14 +2116,16 @@ class RegistryGovernance(BaseModel):
         " and some are general purpose.",
     )
     comments: Optional[str] = Field(
-        description="Optional additional comments about the registry's governance model"
+        default=None,
+        description="Optional additional comments about the registry's governance model",
     )
     accepts_external_contributions: bool = Field(
+        ...,
         description="This field denotes if the registry (in theory) accepts external contributions, either via "
         "suggestion or proactive improvement. This field does not pass judgement on the difficult of this"
         " process from the perspective of the submitter nor the responsiveness of the registry."
         " This field does not consider the ability for insiders (i.e., people with private relationships"
-        " to the maintainers) to affect change."
+        " to the maintainers) to affect change.",
     )
     public_version_controlled_data: bool = Field(
         ...,
@@ -2107,10 +2134,12 @@ class RegistryGovernance(BaseModel):
         " system, such as GitHub or GitLab",
     )
     data_repository: Optional[str] = Field(
-        description="This field denotes the address of the registry's data version control repository."
+        default=None,
+        description="This field denotes the address of the registry's data version control repository.",
     )
     code_repository: Optional[str] = Field(
-        description="This field denotes the address of the registry's code version control repository."
+        default=None,
+        description="This field denotes the address of the registry's code version control repository.",
     )
     review_team: Literal["public", "inferrable", "private", "democratic", "n/a"] = Field(
         ...,
@@ -2129,8 +2158,9 @@ class RegistryGovernance(BaseModel):
         "repository is no longer being proactively maintained (though may receive occasional patches).",
     )
     issue_tracker: Optional[str] = Field(
+        default=None,
         description="This field denotes the public issue tracker for issues related to the code and data of the "
-        "repository."
+        "repository.",
     )
 
     @property
@@ -2318,32 +2348,37 @@ class Registry(BaseModel):
         ..., description="A structured description of the governance for the registry"
     )
     download: Optional[str] = Field(
-        description="A download link for the data contained in the registry"
+        default=None, description="A download link for the data contained in the registry"
     )
     provider_uri_format: Optional[str] = Field(
-        description="A URL with a $1 for a prefix to resolve in the registry"
+        default=None, description="A URL with a $1 for a prefix to resolve in the registry"
     )
     search_uri_format: Optional[str] = Field(
-        description="A URL with a $1 for a prefix or string for searching for prefixes"
+        default=None,
+        description="A URL with a $1 for a prefix or string for searching for prefixes",
     )
     resolver_uri_format: Optional[str] = Field(
-        description="A URL with a $1 for a prefix and $2 for an identifier to resolve in the registry"
+        default=None,
+        description="A URL with a $1 for a prefix and $2 for an identifier to resolve in the registry",
     )
     resolver_type: Optional[str] = Field(
-        description="An optional type annotation for what kind of resolver it is (i.e., redirect or lookup)"
+        default=None,
+        description="An optional type annotation for what kind of resolver it is (i.e., redirect or lookup)",
     )
     contact: Attributable = Field(..., description="The contact for the registry.")
     bioregistry_prefix: Optional[str] = Field(
-        description="The prefix for this registry in the Bioregistry"
+        default=None, description="The prefix for this registry in the Bioregistry"
     )
     logo_url: Optional[str] = Field(
+        default=None,
         description="The URL for the logo of the resource",
     )
     license: Optional[str] = Field(
+        default=None,
         description="The license under which the resource is redistributed",
     )
     short_name: Optional[str] = Field(
-        description="A short name for the resource, e.g., for use in charts"
+        default=None, description="A short name for the resource, e.g., for use in charts"
     )
 
     def score(self) -> int:
@@ -2514,8 +2549,8 @@ class Collection(BaseModel):
         ...,
         description="A list of authors/contributors to the collection",
     )
-    context: Optional[str] = Field(description="The JSON-LD context's name")
-    references: Optional[List[str]] = Field(description="URL references")
+    context: Optional[str] = Field(default=None, description="The JSON-LD context's name")
+    references: Optional[List[str]] = Field(default=None, description="URL references")
 
     def add_triples(self, graph):
         """Add triples to an RDF graph for this collection.

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -248,4 +248,4 @@ def get_field_annotation(field, key, default=None):
     if PYDANTIC_1:
         return field.field_info.extra.get(key, default)
     else:
-        return field.json_schema_extra.get(key, default)
+        return (field.json_schema_extra or {}).get(key, default)

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -22,7 +22,6 @@ from typing import (
 import click
 import requests
 from pydantic import BaseModel
-from pydantic.json import ENCODERS_BY_TYPE
 from pystow.utils import get_hashes
 
 from .constants import (
@@ -32,6 +31,11 @@ from .constants import (
     REGISTRY_YAML_PATH,
 )
 from .version import get_version
+
+try:
+    from pydantic.v1 import ENCODERS_BY_TYPE
+except ImportError:
+    from pydantic.json import ENCODERS_BY_TYPE
 
 logger = logging.getLogger(__name__)
 

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -33,9 +33,10 @@ from .constants import (
 from .version import get_version
 
 try:
-    from pydantic.v1 import ENCODERS_BY_TYPE
-except ImportError:
     from pydantic.json import ENCODERS_BY_TYPE
+except ImportError:
+    from pydantic.v1.utils import ENCODERS_BY_TYPE
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -26,6 +26,7 @@ from .constants import (
     BIOREGISTRY_PATH,
     COLLECTIONS_YAML_PATH,
     METAREGISTRY_YAML_PATH,
+    PYDANTIC_1,
     REGISTRY_YAML_PATH,
 )
 from .version import get_version
@@ -240,3 +241,11 @@ def deduplicate(records: Iterable[Dict[str, Any]], keys: Sequence[str]) -> Seque
     rv = [dict(ChainMap(*v)) for v in dd.values()]
 
     return sorted(rv, key=_key, reverse=True)
+
+
+def get_field_annotation(field, key, default=None):
+    """Get a field annotation."""
+    if PYDANTIC_1:
+        return field.field_info.extra.get(key, default)
+    else:
+        return field.json_schema_extra.get(key, default)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -20,7 +20,7 @@ from bioregistry.license_standardizer import REVERSE_LICENSES, standardize_licen
 from bioregistry.resolve import get_obo_context_prefix_map
 from bioregistry.schema.struct import SCHEMA_PATH, Attributable, get_json_schema
 from bioregistry.schema_utils import is_mismatch
-from bioregistry.utils import _norm
+from bioregistry.utils import _norm, get_field_annotation
 
 logger = logging.getLogger(__name__)
 
@@ -83,18 +83,9 @@ class TestRegistry(unittest.TestCase):
         valid = {"required", "optional", "suggested", "required_for_new"}
         for name, field in Resource.__fields__.items():
             with self.subTest(name=name):
-                if PYDANTIC_1:
-                    status = field.field_info.extra.get("integration_status", None)
-                else:
-                    status = field.json_schema_extra.get("integration_status", None)
-                if field.required:
-                    self.assertEqual(
-                        "required",
-                        status,
-                        msg=f"required field {name} is not marked with integration_status",
-                    )
-                elif status:
-                    self.assertIn(status, valid, msg=f"invalid integration status for field {name}")
+                status = get_field_annotation(field, "integration_status")
+                if status:
+                    self.assertIn(status, valid)
 
     def test_keys(self):
         """Check the required metadata is there."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,7 +14,7 @@ import rdflib
 
 import bioregistry
 from bioregistry import Resource, manager
-from bioregistry.constants import BIOREGISTRY_PATH, EMAIL_RE
+from bioregistry.constants import BIOREGISTRY_PATH, EMAIL_RE, PYDANTIC_1
 from bioregistry.export.rdf_export import resource_to_rdf_str
 from bioregistry.license_standardizer import REVERSE_LICENSES, standardize_license
 from bioregistry.resolve import get_obo_context_prefix_map
@@ -33,6 +33,10 @@ class TestRegistry(unittest.TestCase):
         self.registry = bioregistry.read_registry()
         self.metaregistry = bioregistry.read_metaregistry()
 
+    @unittest.skipUnless(
+        PYDANTIC_1,
+        reason="Only run this test on Pydantic 1, until feature parity is simple enough.",
+    )
     def test_schema(self):
         """Test the schema is up-to-date."""
         actual = SCHEMA_PATH.read_text()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -83,7 +83,10 @@ class TestRegistry(unittest.TestCase):
         valid = {"required", "optional", "suggested", "required_for_new"}
         for name, field in Resource.__fields__.items():
             with self.subTest(name=name):
-                status = field.field_info.extra.get("integration_status", None)
+                if PYDANTIC_1:
+                    status = field.field_info.extra.get("integration_status", None)
+                else:
+                    status = field.json_schema_extra.get("integration_status", None)
                 if field.required:
                     self.assertEqual(
                         "required",

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ envlist =
     docstr-coverage
     docs
     # the actual tests
-    py
+    py-pydantic1
+    py-pydantic2
     doctests
     # always keep coverage-report last
     #coverage-report
@@ -29,6 +30,9 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
+deps =
+    pydantic1: pydantic<2.0
+    pydantic2: pydantic>=2.0
 passenv =
     HOME
 extras =


### PR DESCRIPTION
As a follow-up to https://github.com/cthoyt/curies/pull/64 (and related to #920 and https://github.com/biopragmatics/bioregistry/issues/899), this PR makes Bioregistry support both Pydantic v1 and v2