### PR TITLE
Propogate RDF URI format string to API and update EDAM

### DIFF
--- a/src/bioregistry/app/utils.py
+++ b/src/bioregistry/app/utils.py
@@ -36,7 +36,7 @@ def _get_resource_providers(
             name = manager.get_name(prefix)
             homepage = manager.get_homepage(prefix)
         elif metaprefix == "rdf":
-            name = manager.get_name(prefix) + " (RDF)"
+            name = f"{manager.get_name(prefix)} (RDF)"
             homepage = manager.get_homepage(prefix)
         else:
             name = manager.get_registry_name(metaprefix)

--- a/src/bioregistry/app/utils.py
+++ b/src/bioregistry/app/utils.py
@@ -35,6 +35,9 @@ def _get_resource_providers(
             metaprefix = prefix
             name = manager.get_name(prefix)
             homepage = manager.get_homepage(prefix)
+        elif metaprefix == "rdf":
+            name = manager.get_name(prefix) + " (RDF)"
+            homepage = manager.get_homepage(prefix)
         else:
             name = manager.get_registry_name(metaprefix)
             homepage = manager.get_registry_homepage(metaprefix)

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -1228,6 +1228,7 @@ class Manager:
                 return 2
             else:
                 return 3
+
         rv = sorted(rv, key=_key)
         return rv
         # if a default URL is available, it goes first. otherwise the bioregistry URL goes first.

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -1052,8 +1052,8 @@ class Manager:
         :return: A IRI string corresponding to the canonical RDF provider, if available.
 
         >>> from bioregistry import manager
-        >>> manager.get_default_iri('chebi', '24867')
-        'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24867'
+        >>> manager.get_default_iri('edam', 'data_1153')
+        'http://edamontology.org/data_1153'
         """
         entry = self.get_resource(prefix)
         if entry is None:

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -1052,7 +1052,7 @@ class Manager:
         :return: A IRI string corresponding to the canonical RDF provider, if available.
 
         >>> from bioregistry import manager
-        >>> manager.get_default_iri('edam', 'data_1153')
+        >>> manager.get_rdf_uri('edam', 'data_1153')
         'http://edamontology.org/data_1153'
         """
         entry = self.get_resource(prefix)

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -685,6 +685,21 @@ class Resource(BaseModel):
             return None
         return fmt.replace("$1", identifier)
 
+    def get_rdf_uri(self, identifier: str) -> Optional[str]:
+        """Return the RDF URI for the identifier.
+
+        :param identifier: The local identifier in the nomenclature represented by this resource
+        :returns: The canonical RDF URI for the local identifier, if one can be constructed
+
+        >>> from bioregistry import get_resource
+        >>> get_resource("edam").get_rdf_uri("data_1153")
+        'http://edamontology.org/data_1153'
+        """
+        fmt = self.get_rdf_uri_format()
+        if fmt is None:
+            return None
+        return fmt.replace("$1", identifier)
+
     def __setitem__(self, key, value):  # noqa: D105
         setattr(self, key, value)
 


### PR DESCRIPTION
Closes #923

Now, the reference page for `edam:data_1153` looks like:

<img width="962" alt="Screenshot 2023-08-12 at 18 33 15" src="https://github.com/biopragmatics/bioregistry/assets/5069736/5081085f-b6bf-46c4-971d-fa5540b0473c">

