### PR TITLE
Remap orphanet.ordo in obo context

### DIFF
--- a/src/bioregistry/data/contexts.json
+++ b/src/bioregistry/data/contexts.json
@@ -33,7 +33,8 @@
       "icd10": "ICD10WHO",
       "pubmed": "PMID",
       "snomedct": "SCTID",
-      "umls": "UMLS"
+      "umls": "UMLS",
+      "orphanet.ordo": "Orphanet"
     },
     "uri_prefix_priority": [
       "obofoundry",


### PR DESCRIPTION
Having `Orphanet` changed to `orphanet.ordo` (due to upgrade to epm in sssom) caused a big issue in Mondo: https://github.com/monarch-initiative/mondo-ingest/issues/353#issuecomment-1690024800

We can revisit that mapping decision later, but for now, too much in OBO relies on it.