### PR TITLE
Add additional clinical trial registries

### DIFF
--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -400,6 +400,7 @@
       "identifier": "0000012",
       "name": "Clinical Trial Registries",
       "resources": [
+        "95154",
         "anzctr",
         "chictr",
         "clinicaltrials",
@@ -415,6 +416,7 @@
         "kcris",
         "lbctr",
         "pactr",
+        "phrr",
         "rebec",
         "repec",
         "rpcec",

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -407,6 +407,7 @@
         "ctri",
         "drks",
         "euclinicaltrials",
+        "hc.trial",
         "irct",
         "isrctn",
         "itmctr",

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -400,7 +400,6 @@
       "identifier": "0000012",
       "name": "Clinical Trial Registries",
       "resources": [
-        "95154",
         "anzctr",
         "chictr",
         "clinicaltrials",

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -419,6 +419,7 @@
         "repec",
         "rpcec",
         "slctr",
+        "snctp",
         "tctr",
         "uminctr"
       ]


### PR DESCRIPTION
This PR adds several records for clinical trial registries listed in https://www.hhs.gov/ohrp/international/clinical-trial-registries/index.html (suggested by @bgyori)

It does not add the following:

1. Tanzania Clinical Trial Registry - I couldn't find on their site where the trial information actually lived
2. Dutch Clinical Trial Registry - they completely stopped maintaining their own and are just part of the WHO effort now, website is down
3. South African National Clinical Trials Register - couldn't get the site to load

Besides the ones added here, the rest are already available!