### PR TITLE
Add field for annotating unresolvable ontologies, update OLS processing, and better annotate HPATH

### DIFF
--- a/src/bioregistry/data/external/ols/processed.json
+++ b/src/bioregistry/data/external/ols/processed.json
@@ -1,7 +1,7 @@
 {
   "ado": {
     "description": "Alzheimer's Disease Ontology is a knowledge-based ontology that encompasses varieties of concepts related to Alzheimer'S Disease, foundamentally structured by upper level Basic Formal Ontology(BFO). This Ontology is enriched by the interrelational entities that demonstrate the nextwork of the understanding on Alzheimer's disease and can be readily applied for text mining.",
-    "download": "http://purl.obolibrary.org/obo/ado.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ado.owl",
     "homepage": "https://github.com/Fraunhofer-SCAI-Applied-Semantics/ADO",
     "name": "Alzheimer's Disease Ontology (ADO)",
     "prefix": "ado",
@@ -10,7 +10,7 @@
   },
   "aeo": {
     "description": "AEO is an ontology of anatomical structures that expands CARO, the Common Anatomy Reference Ontology",
-    "download": "http://purl.obolibrary.org/obo/aeo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/aeo.owl",
     "homepage": "https://github.com/obophenotype/human-developmental-anatomy-ontology/",
     "name": "Anatomical Entity Ontology",
     "prefix": "aeo",
@@ -25,7 +25,6 @@
   },
   "afo": {
     "description": "Allotrope Merged Ontology Suite",
-    "download": "http://purl.allotrope.org/voc/afo/latest.xml",
     "name": "Allotrope Merged Ontology Suite",
     "prefix": "afo",
     "version": "2023/09",
@@ -33,7 +32,7 @@
   },
   "agro": {
     "description": "AgrO is an ontlogy for representing agronomic practices, techniques, variables and related entities",
-    "download": "http://purl.obolibrary.org/obo/agro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/agro.owl",
     "homepage": "https://github.com/AgriculturalSemantics/agro",
     "name": "Agronomy Ontology",
     "prefix": "agro",
@@ -42,7 +41,7 @@
   },
   "aism": {
     "description": "The ontology for the Anatomy of the Insect SkeletoMuscular system (AISM) contains terms used to describe the cuticle - as a single anatomical structure - and the skeletal muscle system, to be used in insect biodiversity research.",
-    "download": "http://purl.obolibrary.org/obo/aism.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/aism.owl",
     "homepage": "https://github.com/insect-morphology/aism",
     "name": "Ontology for the Anatomy of the Insect SkeletoMuscular system",
     "prefix": "aism",
@@ -51,7 +50,7 @@
   },
   "amphx": {
     "description": "An ontology for the development and anatomy of Amphioxus (Branchiostoma lanceolatum).",
-    "download": "http://purl.obolibrary.org/obo/amphx.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/amphx.owl",
     "homepage": "https://github.com/EBISPOT/amphx_ontology",
     "name": "Amphioxus Development and Anatomy Ontology (AMPHX)",
     "prefix": "amphx",
@@ -60,7 +59,7 @@
   },
   "apo": {
     "description": "A structured controlled vocabulary for the phenotypes of Ascomycete fungi.",
-    "download": "http://purl.obolibrary.org/obo/apo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/apo.owl",
     "homepage": "http://www.yeastgenome.org/",
     "name": "Ascomycete Phenotype Ontology (APO)",
     "prefix": "apo",
@@ -69,7 +68,7 @@
   },
   "apollo_sv": {
     "description": "An OWL2 ontology of phenomena in infectious disease epidemiology and population biology for use in epidemic simulation.",
-    "download": "http://purl.obolibrary.org/obo/apollo_sv.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/apollo_sv.owl",
     "homepage": "https://github.com/ApolloDev/apollo-sv",
     "name": "Apollo Structured Vocabulary (Apollo-SV)",
     "prefix": "apollo_sv",
@@ -78,14 +77,13 @@
   },
   "aro": {
     "description": "Antibiotic resistance genes and mutations",
-    "download": "http://purl.obolibrary.org/obo/aro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/aro.owl",
     "homepage": "https://github.com/arpcard/aro",
     "name": "Antibiotic Resistance Ontology",
     "prefix": "aro"
   },
   "bao": {
     "description": "The BioAssay Ontology (BAO) describes biological screening assays and their results including high-throughput screening (HTS) data for the purpose of categorizing assays and data analysis. BAO is an extensible, knowledge-based, highly expressive (currently SHOIQ(D)) description of biological assays making use of descriptive logic based features of the Web Ontology Language (OWL). BAO currently has over 700 classes and also makes use of several other ontologies. It describes several concepts related to biological screening, including Perturbagen, Format, Meta Target, Design, Detection Technology, and Endpoint. Perturbagens are perturbing agents that are screened in an assay; they are mostly small molecules. Assay Meta Target describes what is known about the biological system and / or its components interrogated in the assay (and influenced by the Perturbagen). Meta target can be directly described as a molecular entity (e.g. a purified protein or a protein complex), or indirectly by a biological process or event (e.g. phosphorylation). Format describes the biological or chemical features common to each test condition in the assay and includes biochemical, cell-based, organism-based, and variations thereof. The assay Design describes the assay methodology and implementation of how the perturbation of the biological system is translated into a detectable signal. Detection Technology relates to the physical method and technical details to detect and record a signal. Endpoints are the final HTS results as they are usually published (such as IC50, percent inhibition, etc). BAO has been designed to accommodate multiplexed assays. All main BAO components include multiple levels of sub-categories and specification classes, which are linked via object property relationships forming an expressive knowledge-based representation.",
-    "download": "http://www.bioassayontology.org/bao/",
     "homepage": "http://bioassayontology.org",
     "name": "BioAssay Ontology",
     "prefix": "bao",
@@ -102,7 +100,7 @@
   },
   "bcio": {
     "description": "The Behaviour Change Intervention Ontology is an ontology for all aspects of human behaviour change interventions and their evaluation.",
-    "download": "http://humanbehaviourchange.org/ontology/bcio.owl",
+    "download_owl": "http://humanbehaviourchange.org/ontology/bcio.owl",
     "homepage": "https://www.humanbehaviourchange.org/",
     "name": "The Behaviour Change Intervention Ontology",
     "prefix": "bcio",
@@ -111,7 +109,7 @@
   },
   "bco": {
     "description": "An ontology to support the interoperability of biodiversity data, including data on museum collections, environmental/metagenomic samples, and ecological surveys.",
-    "download": "http://purl.obolibrary.org/obo/bco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/bco.owl",
     "homepage": "https://github.com/BiodiversityOntologies/bco",
     "name": "Biological Collections Ontology",
     "prefix": "bco",
@@ -120,7 +118,7 @@
   },
   "bfo": {
     "description": "The upper level ontology upon which OBO Foundry ontologies are built.",
-    "download": "http://purl.obolibrary.org/obo/bfo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/bfo.owl",
     "homepage": "http://ifomis.org/bfo/",
     "name": "Basic Formal Ontology",
     "prefix": "bfo",
@@ -136,7 +134,7 @@
   },
   "bspo": {
     "description": "An ontology for respresenting spatial concepts, anatomical axes, gradients, regions, planes, sides and surfaces. These concepts can be used at multiple biological scales and in a diversity of taxa, including plants, animals and fungi. The BSPO is used to provide a source of anatomical location descriptors for logically defining anatomical entity classes in anatomy ontologies.",
-    "download": "http://purl.obolibrary.org/obo/bspo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/bspo.owl",
     "homepage": "https://github.com/obophenotype/biological-spatial-ontology",
     "name": "Biological Spatial Ontology",
     "prefix": "bspo",
@@ -145,7 +143,7 @@
   },
   "bto": {
     "description": "A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures.",
-    "download": "http://purl.obolibrary.org/obo/bto.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/bto.owl",
     "homepage": "http://www.brenda-enzymes.org",
     "name": "The BRENDA Tissue Ontology (BTO)",
     "prefix": "bto",
@@ -155,7 +153,7 @@
   "cao": {
     "contact": "schalk@unf.edu",
     "description": "The Chemical Analysis Ontology (CAO) is an ontology developed as part of the Chemical Analaysis Metadata Project (ChAMP) as a resource to semantically annotate standards developed using the ChAMP platform.  For more information go to http://champ-project.org.",
-    "download": "https://champ.stuchalk.domains.unf.edu/images/ontology/cao.owl",
+    "download_owl": "https://champ.stuchalk.domains.unf.edu/images/ontology/cao.owl",
     "homepage": "https://champ.stuchalk.domains.unf.edu/cao",
     "name": "Chemical Analysis Metadata Platform (ChAMP) Ontology version 0.2",
     "prefix": "cao",
@@ -163,7 +161,7 @@
   },
   "caro": {
     "description": "The Common Anatomy Reference Ontology (CARO) is being developed to facilitate interoperability between existing anatomy ontologies for different species, and will provide a template for building new anatomy ontologies.",
-    "download": "http://purl.obolibrary.org/obo/caro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/caro.owl",
     "homepage": "https://github.com/obophenotype/caro/",
     "name": "Common Anatomy Reference Ontology",
     "prefix": "caro",
@@ -173,7 +171,7 @@
   "ccf": {
     "contact": "infoccf@indiana.edu",
     "description": "The Common Coordinate Framework (CCF) Ontology is an application ontology built to support the development of the Human Reference Atlas (HRA).  It unifies vocabulary for HRA construction and usage\u2014making it possible to ingest external data sources; supporting uniform tissue sample registration that includes the spatial positioning and semantic annotations within 3D reference organs; and supporting user-formulated cross-domain queries over tissue donor properties, anatomical structures, cell types, biomarkers, and 3D space. The CCF Ontology consists of three major ontologies. The Biological Structure Ontology records anatomical structures, cell types, and biomarkers (ASCT+B) and the relationships between them.  The ASCT+B tables are authored by human experts using templated Google Sheets. The biomarkers, cell types, and anatomical structures are mapped to existing ontologies (Uberon/FMA, CL, HGNC) whenever possible.  All relationships between anatomical structures and from cell types to anatomical structures are valid Uberon and CL relationships. The Spatial Ontology defines the shape, size, location, and rotation of experimental tissue and data major anatomical structures in the 3D Reference Object Library. The Specimen Ontology captures the sex, age, and other information on donors that provided tissue data used in the construction of the HRA.",
-    "download": "https://purl.org/ccf/2.0/ccf.owl",
+    "download_owl": "https://purl.org/ccf/2.0/ccf.owl",
     "homepage": "https://hubmapconsortium.github.io/ccf/pages/ccf-ontology.html",
     "name": "Human Reference Atlas Common Coordinate Framework Ontology",
     "prefix": "ccf",
@@ -183,14 +181,14 @@
   "cco": {
     "contact": "vladimir.n.mironov@gmail.com",
     "description": "The Cell Cycle Ontology extends existing ontologies for cell cycle knowledge building a resource that integrates and manages knowledge about the cell cycle components and regulatory aspects.",
-    "download": "http://www.bio.ntnu.no/ontology/CCO/cco.owl",
+    "download_owl": "http://www.bio.ntnu.no/ontology/CCO/cco.owl",
     "homepage": "http://www.semantic-systems-biology.org/apo",
     "name": "Cell Cycle Ontology",
     "prefix": "cco"
   },
   "cdao": {
     "description": "The Comparative Data Analysis Ontology (CDAO) provides a framework for understanding data in the context of evolutionary-comparative analysis.  This comparative approach is used commonly in bioinformatics and other areas of biology to draw inferences from a comparison of differently evolved versions of something, such as differently evolved versions of a protein.  In this kind of analysis, the things-to-be-compared typically are classes called 'OTUs' (Operational Taxonomic Units).  The OTUs can represent biological species, but also may be drawn from higher or lower in a biological hierarchy, anywhere from molecules to communities.  The features to be compared among OTUs are rendered in an entity-attribute-value model sometimes referred to as the 'character-state data model'.  For a given character, such as 'beak length', each OTU has a state, such as 'short' or 'long'.  The differences between states are understood to emerge by a historical process of evolutionary transitions in state, represented by a model (or rules) of transitions along with a phylogenetic tree.  CDAO provides the framework for representing OTUs, trees, transformations, and characters.  The representation of characters and transformations may depend on imported ontologies for a specific type of character.",
-    "download": "http://purl.obolibrary.org/obo/cdao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cdao.owl",
     "homepage": "https://github.com/evoinfo/cdao",
     "name": "Comparative Data Analysis Ontology",
     "prefix": "cdao",
@@ -199,7 +197,7 @@
   },
   "cdno": {
     "description": "None",
-    "download": "http://purl.obolibrary.org/obo/cdno.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cdno.owl",
     "homepage": "https://cdno.info/",
     "name": "Compositional Dietary Nutrition Ontology",
     "prefix": "cdno",
@@ -208,7 +206,7 @@
   },
   "ceph": {
     "description": "An anatomical and developmental ontology for cephalopods",
-    "download": "http://purl.obolibrary.org/obo/ceph.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ceph.owl",
     "homepage": "https://github.com/obophenotype/cephalopod-ontology",
     "name": "Cephalopod Ontology",
     "prefix": "ceph",
@@ -217,7 +215,7 @@
   },
   "chebi": {
     "description": "A structured classification of molecular entities of biological interest focusing on 'small' chemical compounds.",
-    "download": "http://purl.obolibrary.org/obo/chebi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/chebi.owl",
     "homepage": "http://www.ebi.ac.uk/chebi",
     "name": "Chemical Entities of Biological Interest",
     "prefix": "chebi",
@@ -226,7 +224,7 @@
   },
   "cheminf": {
     "description": "Includes terms for the descriptors commonly used in cheminformatics software applications and the algorithms which generate them.",
-    "download": "http://purl.obolibrary.org/obo/cheminf.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cheminf.owl",
     "homepage": "https://github.com/semanticchemistry/semanticchemistry",
     "name": "chemical information ontology (cheminf) - information entities about chemical entities",
     "prefix": "cheminf",
@@ -234,7 +232,7 @@
   },
   "chiro": {
     "description": "CHEBI provides a distinct role hierarchy. Chemicals in the structural hierarchy are connected via a 'has role' relation. CHIRO provides links from these roles to useful other classes in other ontologies. This will allow direct connection between chemical structures (small molecules, drugs) and what they do. This could be formalized using 'capable of', in the same way Uberon and the Cell Ontology link structures to processes.",
-    "download": "http://purl.obolibrary.org/obo/chiro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/chiro.owl",
     "homepage": "https://github.com/obophenotype/chiro",
     "name": "CHEBI Integrated Role Ontology",
     "prefix": "chiro",
@@ -244,7 +242,7 @@
   "chmo": {
     "contact": "chemistry-ontologies@googlegroups.com",
     "description": "CHMO, the chemical methods ontology, describes methods used to collect data in chemical experiments, such as mass spectrometry and electron microscopy prepare and separate material for further analysis, such as sample ionisation, chromatography, and electrophoresis synthesise materials, such as epitaxy and continuous vapour deposition It also describes the instruments used in these experiments, such as mass spectrometers and chromatography columns. It is intended to be complementary to the Ontology for Biomedical Investigations (OBI).",
-    "download": "http://purl.obolibrary.org/obo/chmo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/chmo.owl",
     "homepage": "https://github.com/rsc-ontologies/rsc-cmo",
     "name": "Chemical Methods Ontology",
     "prefix": "chmo",
@@ -254,7 +252,7 @@
   "cido": {
     "contact": "cido-discuss@googlegroups.com",
     "description": "The Ontology of Coronavirus Infectious Disease (CIDO) is a community-driven open-source biomedical ontology in the area of coronavirus infectious disease. The CIDO is developed to provide standardized human- and computer-interpretable annotation and representation of various coronavirus infectious diseases, including their etiology, transmission, pathogenesis, diagnosis, prevention, and treatment.",
-    "download": "http://purl.obolibrary.org/obo/cido.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cido.owl",
     "homepage": "https://github.com/cido-ontology/cido",
     "name": "CIDO: Ontology of Coronavirus Infectious Disease",
     "prefix": "cido",
@@ -262,7 +260,7 @@
   },
   "cio": {
     "description": "An ontology to capture confidence information about annotations.",
-    "download": "http://purl.obolibrary.org/obo/cio.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cio.owl",
     "homepage": "https://github.com/BgeeDB/confidence-information-ontology",
     "name": "Confidence Information Ontology",
     "prefix": "cio",
@@ -271,7 +269,7 @@
   },
   "cl": {
     "description": "An ontology of cell types.",
-    "download": "http://purl.obolibrary.org/obo/cl.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cl.owl",
     "homepage": "https://obophenotype.github.io/cell-ontology/",
     "name": "Cell Ontology",
     "prefix": "cl",
@@ -280,7 +278,7 @@
   },
   "clao": {
     "description": "CLAO is an ontology of anatomical terms employed in morphological descriptions for the Class Collembola (Arthropoda: Hexapoda).",
-    "download": "http://purl.obolibrary.org/obo/clao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/clao.owl",
     "homepage": "https://github.com/luis-gonzalez-m/Collembola",
     "name": "Collembola Anatomy Ontology",
     "prefix": "clao",
@@ -289,7 +287,7 @@
   },
   "clo": {
     "description": "The Cell Line Ontology (CLO) is a community-based ontology of cell lines. The CLO is developed to unify publicly available cell line entry data from multiple sources to a standardized logically defined format based on consensus design patterns.",
-    "download": "http://purl.obolibrary.org/obo/clo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/clo.owl",
     "homepage": "http://www.clo-ontology.org",
     "name": "CLO: Cell Line Ontology",
     "prefix": "clo",
@@ -297,7 +295,7 @@
   },
   "clyh": {
     "description": "Anatomy, development and life cycle stages - planula, polyp, medusa/jellyfish - of the cnidarian hydrozoan species, Clytia hemiphaerica.",
-    "download": "http://purl.obolibrary.org/obo/clyh.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/clyh.owl",
     "homepage": "https://github.com/EBISPOT/clyh_ontology",
     "name": "Clytia hemisphaerica Development and Anatomy Ontology (CLYH)",
     "prefix": "clyh",
@@ -306,7 +304,7 @@
   },
   "cmo": {
     "description": "Morphological and physiological measurement records generated from clinical and model organism research and health programs.",
-    "download": "http://purl.obolibrary.org/obo/cmo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cmo.owl",
     "homepage": "http://rgd.mcw.edu/rgdweb/ontology/search.html",
     "name": "Clinical measurement ontology",
     "prefix": "cmo",
@@ -316,7 +314,7 @@
   "cmpo": {
     "contact": "jupp@ebi.ac.uk",
     "description": "CMPO is a species neutral ontology for describing general phenotypic observations relating to the whole cell, cellular components, cellular processes and cell populations.",
-    "download": "http://www.ebi.ac.uk/cmpo/cmpo.owl",
+    "download_owl": "http://www.ebi.ac.uk/cmpo/cmpo.owl",
     "homepage": "http://www.ebi.ac.uk/cmpo",
     "name": "Cellular Microscopy Phenotype Ontology",
     "prefix": "cmpo",
@@ -325,7 +323,7 @@
   },
   "cob": {
     "description": "COB brings together key terms from a wide range of OBO projects to improve interoperability.",
-    "download": "http://purl.obolibrary.org/obo/cob.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cob.owl",
     "homepage": "https://obofoundry.org/COB/",
     "name": "Core Ontology for Biology and Biomedicine",
     "prefix": "cob",
@@ -334,7 +332,7 @@
   },
   "colao": {
     "description": "The Coleoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of beetles in biodiversity research.",
-    "download": "http://purl.obolibrary.org/obo/colao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/colao.owl",
     "homepage": "https://github.com/insect-morphology/colao",
     "name": "Coleoptera Anatomy Ontology",
     "prefix": "colao",
@@ -343,7 +341,7 @@
   },
   "covoc": {
     "description": "The COVID-19 Vocabulary (COVoc) is an ontology containing terms related to the research of the COVID-19 pandemic. This includes host organisms, pathogenicity, gene and gene products, barrier gestures, treatments and more.",
-    "download": "https://github.com/EBISPOT/covoc/releases/download/current/covoc.owl",
+    "download_owl": "https://github.com/EBISPOT/covoc/releases/download/current/covoc.owl",
     "homepage": "https://github.com/EBISPOT/covoc",
     "name": "CoVoc Coronavirus Vocabulary",
     "prefix": "covoc",
@@ -352,7 +350,7 @@
   },
   "cro": {
     "description": "A classification of the diverse roles performed in the work leading to a published research output in the sciences. Its purpose to provide transparency in contributions to scholarly published work, to enable improved systems of attribution, credit, and accountability.",
-    "download": "http://purl.obolibrary.org/obo/cro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cro.owl",
     "homepage": "https://github.com/data2health/contributor-role-ontology",
     "name": "Contributor Role Ontology",
     "prefix": "cro",
@@ -362,7 +360,7 @@
   "cryoem": {
     "contact": "isanchez@cnb.csic.es",
     "description": "Ontology that describes data types and image processing operations in Cryo Electron Microscopy of Single Particles",
-    "download": "http://scipion.i2pc.es/ontology/cryoem.owl",
+    "download_owl": "http://scipion.i2pc.es/ontology/cryoem.owl",
     "homepage": "http://scipion.i2pc.es/ontology/cryoem",
     "name": "Cryo Electron Microscopy ontology",
     "prefix": "cryoem",
@@ -371,7 +369,7 @@
   },
   "cteno": {
     "description": "An anatomical and developmental ontology for ctenophores (Comb Jellies)",
-    "download": "http://purl.obolibrary.org/obo/cteno.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/cteno.owl",
     "homepage": "https://github.com/obophenotype/ctenophore-ontology",
     "name": "Ctenophore Ontology",
     "prefix": "cteno",
@@ -379,23 +377,23 @@
     "version.iri": "http://purl.obolibrary.org/obo/cteno/releases/2016-10-19/cteno.owl"
   },
   "dc": {
-    "download": "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_elements.rdf",
+    "download_rdf": "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_elements.rdf",
     "prefix": "dc"
   },
   "dcterms": {
-    "download": "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.rdf",
+    "download_rdf": "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.rdf",
     "prefix": "dcterms"
   },
   "ddanat": {
     "description": "A structured controlled vocabulary of anatomies of the slime-mold Dictyostelium discoideum.",
-    "download": "http://purl.obolibrary.org/obo/ddanat.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ddanat.owl",
     "homepage": "http://dictybase.org/",
     "name": "Dicty Anatomy Ontology (DDANAT)",
     "prefix": "ddanat"
   },
   "ddpheno": {
     "description": "A structured controlled vocabulary of phenotypes of the slime-mould Dictyostelium discoideum.",
-    "download": "http://purl.obolibrary.org/obo/ddpheno.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ddpheno.owl",
     "homepage": "http://dictybase.org/",
     "name": "Dicty Phenotype Ontology (DDPHENO)",
     "prefix": "ddpheno",
@@ -405,7 +403,7 @@
   "dicom": {
     "contact": "dclunie@dclunie.com",
     "description": "DICOM Controlled Terminology",
-    "download": "ftp://medical.nema.org/MEDICAL/Dicom/Resources/Ontology/DCM/dcm.owl",
+    "download_owl": "ftp://medical.nema.org/MEDICAL/Dicom/Resources/Ontology/DCM/dcm.owl",
     "homepage": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html",
     "name": "DICOM Controlled Terminology",
     "prefix": "dicom",
@@ -413,7 +411,7 @@
   },
   "dideo": {
     "description": "The Potential Drug-drug Interaction and Potential Drug-drug Interaction Evidence Ontology",
-    "download": "http://purl.obolibrary.org/obo/dideo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/dideo.owl",
     "homepage": "https://github.com/DIDEO/DIDEO",
     "name": "Drug-drug Interaction and Drug-drug Interaction Evidence Ontology",
     "prefix": "dideo",
@@ -422,14 +420,14 @@
   },
   "disdriv": {
     "description": "Drivers of human diseases including environmental, maternal and social exposures.",
-    "download": "http://purl.obolibrary.org/obo/disdriv.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/disdriv.owl",
     "homepage": "http://www.disease-ontology.org",
     "name": "Disease Drivers",
     "prefix": "disdriv"
   },
   "doid": {
     "description": "The Disease Ontology has been developed as a standardized ontology for human disease with the purpose of providing the biomedical community with consistent, reusable and sustainable descriptions of human disease terms, phenotype characteristics and related medical vocabulary disease concepts.",
-    "download": "http://purl.obolibrary.org/obo/doid.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/doid.owl",
     "homepage": "http://www.disease-ontology.org",
     "name": "Human Disease Ontology",
     "prefix": "doid",
@@ -438,7 +436,7 @@
   },
   "dpo": {
     "description": "An ontology for the description of Drosophila melanogaster phenotypes.",
-    "download": "http://purl.obolibrary.org/obo/dpo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/dpo.owl",
     "homepage": "http://purl.obolibrary.org/obo/fbcv",
     "name": "Drosophila Phenotype Ontology (DPO)",
     "prefix": "dpo",
@@ -447,7 +445,7 @@
   },
   "dron": {
     "description": "We built this ontology primarily to support comparative effectiveness researchers studying claims data. They need to be able to query U.S. National Drug Codes (NDCs) by ingredient, mechanism of action (beta-adrenergic blockade), physiological effect (diuresis), and therapeutic intent (anti-hypertensive).",
-    "download": "http://purl.obolibrary.org/obo/dron.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/dron.owl",
     "homepage": "https://github.com/ufbmi/dron",
     "name": "The Drug Ontology",
     "prefix": "dron",
@@ -456,7 +454,7 @@
   },
   "duo": {
     "description": "DUO is an ontology which represent data use conditions.",
-    "download": "http://purl.obolibrary.org/obo/duo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/duo.owl",
     "homepage": "https://github.com/EBISPOT/DUO",
     "name": "Data Use Ontology",
     "prefix": "duo",
@@ -465,7 +463,7 @@
   },
   "ecao": {
     "description": "None",
-    "download": "http://purl.obolibrary.org/obo/ecao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ecao.owl",
     "homepage": "https://github.com/echinoderm-ontology/ecao_ontology",
     "name": "Echinoderm Anatomy and Development Ontology",
     "prefix": "ecao",
@@ -474,7 +472,7 @@
   },
   "eco": {
     "description": "The Evidence & Conclusion Ontology (ECO) describes types of scientific evidence within the biological research domain that arise from laboratory experiments, computational methods, literature curation, or other means.",
-    "download": "http://purl.obolibrary.org/obo/eco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/eco.owl",
     "homepage": "https://www.evidenceontology.org",
     "name": "Evidence & Conclusion Ontology (ECO)",
     "prefix": "eco",
@@ -483,7 +481,7 @@
   },
   "ecocore": {
     "description": "Ecocore is a community ontology for the concise and controlled description of ecological traits of organisms.",
-    "download": "http://purl.obolibrary.org/obo/ecocore.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ecocore.owl",
     "homepage": "https://github.com/EcologicalSemantics/ecocore",
     "name": "An ontology of core ecological entities",
     "prefix": "ecocore",
@@ -492,7 +490,7 @@
   },
   "ecto": {
     "description": "ECTO describes exposures to experimental treatments of plants and model organisms (e.g. exposures to modification of diet, lighting levels, temperature); exposures of humans or any other organisms to stressors through a variety of routes, for purposes of public health, environmental monitoring etc, stimuli, natural and experimental, any kind of environmental condition or change in condition that can be experienced by an organism or population of organisms on earth. The scope is very general and can include for example plant treatment regimens, as well as human clinical exposures (although these may better be handled by a more specialized ontology).",
-    "download": "http://purl.obolibrary.org/obo/ecto.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ecto.owl",
     "homepage": "https://github.com/EnvironmentOntology/environmental-exposure-ontology",
     "name": "Environment Exposure Ontology",
     "prefix": "ecto",
@@ -502,7 +500,7 @@
   "edam": {
     "contact": "edam@elixir-dk.org",
     "description": "EDAM is a simple ontology of well established, familiar concepts that are prevalent within bioinformatics, including types of data and data identifiers, data formats, operations and topics. EDAM provides a set of terms with synonyms and definitions - organised into an intuitive hierarchy for convenient use.",
-    "download": "https://raw.githubusercontent.com/edamontology/edamontology/master/releases/EDAM.owl",
+    "download_owl": "https://raw.githubusercontent.com/edamontology/edamontology/master/releases/EDAM.owl",
     "homepage": "http://edamontology.org",
     "name": "Bioinformatics operations, data types, formats, identifiers and topics",
     "prefix": "edam"
@@ -510,7 +508,7 @@
   "efo": {
     "contact": "efo-users@lists.sourceforge.net",
     "description": "The Experimental Factor Ontology (EFO) provides a systematic description of many experimental variables available in EBI databases, and for external projects such as the NHGRI GWAS catalogue. It combines parts of several biological ontologies, such as anatomy, disease and chemical compounds. The scope of EFO is to support the annotation, analysis and visualization of data handled by many groups at the EBI and as the core ontology for OpenTargets.org",
-    "download": "http://www.ebi.ac.uk/efo/efo.owl",
+    "download_owl": "http://www.ebi.ac.uk/efo/efo.owl",
     "homepage": "http://www.ebi.ac.uk/efo",
     "name": "Experimental Factor Ontology",
     "prefix": "efo",
@@ -519,7 +517,7 @@
   },
   "ehdaa2": {
     "description": "A structured controlled vocabulary of stage-specific anatomical structures of the developing human.",
-    "download": "http://purl.obolibrary.org/obo/ehdaa2.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ehdaa2.owl",
     "homepage": "https://github.com/obophenotype/human-developmental-anatomy-ontology",
     "name": "Human developmental anatomy, abstract",
     "prefix": "ehdaa2",
@@ -536,7 +534,7 @@
   },
   "emapa": {
     "description": "An ontology for mouse anatomy covering embryonic development and postnatal stages.",
-    "download": "http://purl.obolibrary.org/obo/emapa.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/emapa.owl",
     "homepage": "http://www.informatics.jax.org/expression.shtml",
     "name": "Mouse Developmental Anatomy Ontology",
     "prefix": "emapa",
@@ -545,7 +543,7 @@
   },
   "enm": {
     "description": "The eNanoMapper project (https://www.enanomapper.net/), NanoCommons project (https://www.nanocommons.eu/) and ACEnano project (http://acenano-project.eu/) are creating a pan-European computational infrastructure for toxicological data management for ENMs, based on semantic web standards and ontologies. This ontology is an application ontology targeting the full domain of nanomaterial safety assessment. It re-uses several other ontologies including the NPO, CHEMINF, ChEBI, and ENVO.",
-    "download": "http://enanomapper.github.io/ontologies/enanomapper.owl",
+    "download_owl": "http://enanomapper.github.io/ontologies/enanomapper.owl",
     "homepage": "http://www.enanomapper.net/",
     "name": "eNanoMapper ontology",
     "prefix": "enm",
@@ -554,7 +552,7 @@
   },
   "ensemblglossary": {
     "description": "The Ensembl glossary lists the terms, data types and file types that are used in Ensembl and describes how they are used.",
-    "download": "https://raw.githubusercontent.com/Ensembl/ensembl-glossary/master/ensembl-glossary.owl",
+    "download_owl": "https://raw.githubusercontent.com/Ensembl/ensembl-glossary/master/ensembl-glossary.owl",
     "homepage": "http://ensembl.org/glossary",
     "name": "Ensembl Glossary",
     "prefix": "ensemblglossary",
@@ -563,7 +561,7 @@
   },
   "envo": {
     "description": "ENVO is an ontology which represents knowledge about environments,environmental processes, ecosystems, habitats, and related entities",
-    "download": "http://purl.obolibrary.org/obo/envo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/envo.owl",
     "homepage": "http://environmentontology.org/",
     "name": "The Environment Ontology",
     "prefix": "envo",
@@ -572,7 +570,7 @@
   },
   "eupath": {
     "description": "The VEuPathDB ontology is an application ontology developed to encode our understanding of what data is about in the public resources developed and maintained by the Eukaryotic Pathogen, Host and Vector Genomics Resource (VEuPathDB; https://veupathdb.org). The VEuPathDB ontology was previously named the EuPathDB ontology prior to EuPathDB joining with VectorBase.The ontology was built based on the Ontology of Biomedical Investigations (OBI) with integration of other OBO ontologies such as PATO, OGMS, DO, etc. as needed for coverage. Currently the VEuPath ontology is primarily intended to be used for support of the VEuPathDB sites. Terms with VEuPathDB ontology IDs that are not specific to VEuPathDB will be submitted to OBO Foundry ontologies for subsequent import and replacement of those terms when they are available.",
-    "download": "http://purl.obolibrary.org/obo/eupath.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/eupath.owl",
     "homepage": "https://github.com/VEuPathDB-ontology/VEuPathDB-ontology",
     "name": "VEuPathDB Ontology",
     "prefix": "eupath",
@@ -581,7 +579,7 @@
   },
   "exo": {
     "description": "ExO is intended to bridge the gap between exposure science and diverse environmental health disciplines including toxicology, epidemiology, disease surveillance, and epigenetics.",
-    "download": "http://purl.obolibrary.org/obo/exo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/exo.owl",
     "homepage": "https://github.com/CTDbase/exposure-ontology",
     "name": "Exposure ontology (ExO)",
     "prefix": "exo",
@@ -590,7 +588,7 @@
   },
   "fao": {
     "description": "A structured controlled vocabulary for the anatomy of fungi.",
-    "download": "http://purl.obolibrary.org/obo/fao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fao.owl",
     "homepage": "https://github.com/obophenotype/fungal-anatomy-ontology/",
     "name": "Fungal gross anatomy",
     "prefix": "fao",
@@ -599,7 +597,7 @@
   },
   "fbbi": {
     "description": "A structured controlled vocabulary of sample preparation, visualization and imaging methods used in biomedical research.",
-    "download": "http://purl.obolibrary.org/obo/fbbi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fbbi.owl",
     "homepage": "http://cellimagelibrary.org/",
     "name": "Biological Imaging Methods Ontology",
     "prefix": "fbbi",
@@ -608,7 +606,7 @@
   },
   "fbbt": {
     "description": "An ontology of Drosophila melanogaster anatomy.",
-    "download": "http://purl.obolibrary.org/obo/fbbt.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fbbt.owl",
     "homepage": "http://purl.obolibrary.org/obo/fbbt",
     "name": "Drosophila Anatomy Ontology (DAO)",
     "prefix": "fbbt",
@@ -617,7 +615,7 @@
   },
   "fbcv": {
     "description": "A miscellaneous ontology of terms used for curation in FlyBase, including the DPO.",
-    "download": "http://purl.obolibrary.org/obo/fbcv.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fbcv.owl",
     "homepage": "http://purl.obolibrary.org/obo/fbcv",
     "name": "FlyBase Controlled Vocabulary (FBcv)",
     "prefix": "fbcv",
@@ -626,7 +624,7 @@
   },
   "fbdv": {
     "description": "An ontology of Drosophila melanogaster developmental stages.",
-    "download": "http://purl.obolibrary.org/obo/fbdv.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fbdv.owl",
     "homepage": "http://purl.obolibrary.org/obo/fbdv",
     "name": "Drosophila Developmental Ontology",
     "prefix": "fbdv",
@@ -643,7 +641,7 @@
   },
   "fideo": {
     "description": "Food-Drug interactions automatically extracted from scientific literature",
-    "download": "http://purl.obolibrary.org/obo/fideo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fideo.owl",
     "homepage": "https://gitub.u-bordeaux.fr/erias/fideo",
     "name": "Food Interactions with Drugs Evidence Ontology",
     "prefix": "fideo",
@@ -652,7 +650,7 @@
   },
   "fix": {
     "description": "An ontology of physico-chemical methods and properties.",
-    "download": "http://purl.obolibrary.org/obo/fix.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fix.owl",
     "homepage": "http://www.ebi.ac.uk/chebi",
     "name": "Physico-chemical methods and properties",
     "prefix": "fix",
@@ -661,14 +659,14 @@
   },
   "flopo": {
     "description": "Traits and phenotypes of flowering plants occurring in digitized Floras",
-    "download": "http://purl.obolibrary.org/obo/flopo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/flopo.owl",
     "homepage": "https://github.com/flora-phenotype-ontology/flopoontology",
     "name": "Flora Phenotype Ontology",
     "prefix": "flopo"
   },
   "fma": {
     "description": "This is currently a slimmed down version of FMA",
-    "download": "http://purl.obolibrary.org/obo/fma.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fma.owl",
     "homepage": "http://si.washington.edu/projects/fma",
     "name": "Foundational Model of Anatomy Ontology (subset)",
     "prefix": "fma",
@@ -677,7 +675,7 @@
   },
   "fobi": {
     "description": "FOBI (Food-Biomarker Ontology) is an ontology to represent food intake data and associate it with metabolomic data",
-    "download": "http://purl.obolibrary.org/obo/fobi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fobi.owl",
     "homepage": "https://github.com/pcastellanoescuder/FoodBiomarkerOntology",
     "name": "Food-Biomarker Ontology",
     "prefix": "fobi",
@@ -685,7 +683,7 @@
   },
   "foodon": {
     "description": "A broadly scoped ontology representing entities which bear a \u201cfood role\u201d. It encompasses materials in natural ecosystems and agriculture that are consumed by humans and domesticated animals. This includes any generic (unbranded) raw or processed food material found in processing plants, markets, stores or food distribution points. FoodOn also imports nutritional component and dietary pattern terms from other OBO Foundry ontologies to support interoperability in diet and nutrition research",
-    "download": "http://purl.obolibrary.org/obo/foodon.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/foodon.owl",
     "homepage": "https://foodon.org/",
     "name": "Food Ontology",
     "prefix": "foodon",
@@ -694,7 +692,7 @@
   },
   "fovt": {
     "description": "These are the terms that are improted for FOVT to describe vertebrate traits.",
-    "download": "http://purl.obolibrary.org/obo/fovt.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fovt.owl",
     "homepage": "https://github.com/futres/fovt",
     "name": "FuTRES Ontology of Vertebrate Traits",
     "prefix": "fovt",
@@ -703,7 +701,7 @@
   },
   "fypo": {
     "description": "A formal ontology of phenotypes observed in fission yeast.",
-    "download": "http://purl.obolibrary.org/obo/fypo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/fypo.owl",
     "homepage": "https://github.com/pombase/fypo",
     "name": "Fission Yeast Phenotype Ontology (FYPO)",
     "prefix": "fypo",
@@ -712,14 +710,14 @@
   },
   "gaz": {
     "description": "A gazetteer constructed on ontological principles. The countries are actively maintained.",
-    "download": "http://purl.obolibrary.org/obo/gaz.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/gaz.owl",
     "homepage": "http://environmentontology.github.io/gaz/",
     "name": "Gazetteer",
     "prefix": "gaz"
   },
   "gecko": {
     "description": "An ontology to represent genomics cohort attributes.",
-    "download": "http://purl.obolibrary.org/obo/gecko.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/gecko.owl",
     "homepage": "https://github.com/IHCC-cohorts/GECKO",
     "name": "Genomics Cohorts Knowledge Ontology",
     "prefix": "gecko",
@@ -728,7 +726,7 @@
   },
   "genepio": {
     "description": "The Genomic Epidemiology Ontology (GenEpiO) covers vocabulary necessary to identify, document and research foodborne pathogens and associated outbreaks.",
-    "download": "http://purl.obolibrary.org/obo/genepio.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/genepio.owl",
     "homepage": "http://genepio.org/",
     "name": "Genomic Epidemiology Ontology",
     "prefix": "genepio",
@@ -737,7 +735,7 @@
   },
   "geno": {
     "description": "GENO is an OWL model of genotypes, their more fundamental sequence components, and links to related biological and experimental entities.  At present many parts of the model are exploratory and set to undergo refactoring.  In addition, many classes and properties have GENO URIs but are place holders for classes that will be imported from an external ontology (e.g. SO, ChEBI, OBI, etc).  Furthermore, ongoing work will implement a model of genotype-to-phenotype associations. This will support description of asserted and inferred relationships between a genotypes, phenotypes, and environments, and the evidence/provenance behind these associations. \n\nDocumentation is under development as well, and for now a slidedeck is available at http://www.slideshare.net/mhb120/brush-icbo-2013",
-    "download": "http://purl.obolibrary.org/obo/geno.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/geno.owl",
     "homepage": "https://github.com/monarch-initiative/GENO-ontology/",
     "name": "GENO ontology",
     "prefix": "geno",
@@ -746,7 +744,7 @@
   },
   "geo": {
     "description": "An ontology of geographical entities",
-    "download": "http://purl.obolibrary.org/obo/geo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/geo.owl",
     "homepage": "https://github.com/ufbmi/geographical-entity-ontology/wiki",
     "name": "Geographical Entity Ontology",
     "prefix": "geo",
@@ -755,14 +753,14 @@
   "gexo": {
     "contact": "vladimir.n.mironov@gmail.com",
     "description": "Gene Expression Ontology",
-    "download": "http://www.bio.ntnu.no/ontology/GeXO/gexo.rdf",
+    "download_rdf": "http://www.bio.ntnu.no/ontology/GeXO/gexo.rdf",
     "homepage": "http://www.semantic-systems-biology.org/apo",
     "name": "Gene Expression Ontology",
     "prefix": "gexo"
   },
   "gno": {
     "description": "An ontology for glycans based on GlyTouCan, but organized by subsumption.",
-    "download": "http://purl.obolibrary.org/obo/gno.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/gno.owl",
     "homepage": "https://gnome.glyomics.org/",
     "name": "Glycan Naming Ontology",
     "prefix": "gno",
@@ -771,7 +769,7 @@
   },
   "go": {
     "description": "The Gene Ontology (GO) provides a framework and set of concepts for describing the functions of gene products from all organisms.",
-    "download": "http://purl.obolibrary.org/obo/go/extensions/go-plus.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/go/extensions/go-plus.owl",
     "homepage": "http://geneontology.org/",
     "name": "Gene Ontology",
     "prefix": "go",
@@ -780,7 +778,7 @@
   },
   "gsso": {
     "description": "GSSO is the Gender, Sex, and Sex Orientation ontology, including terms related to gender identity and expression, sexual and romantic identity and orientation, and sexual and reproductive behavior.",
-    "download": "http://purl.obolibrary.org/obo/gsso.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/gsso.owl",
     "homepage": "https://gsso.research.cchmc.org/",
     "name": "GSSO - the Gender, Sex, and Sexual Orientation ontology",
     "prefix": "gsso",
@@ -789,7 +787,7 @@
   },
   "hancestro": {
     "description": "Human ancestry ontology for the NHGRI GWAS Catalog",
-    "download": "http://purl.obolibrary.org/obo/hancestro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/hancestro.owl",
     "homepage": "https://ebispot.github.io/hancestro/",
     "name": "Human Ancestry Ontology",
     "prefix": "hancestro",
@@ -798,7 +796,7 @@
   },
   "hao": {
     "description": "A structured controlled vocabulary of the anatomy of the Hymenoptera (bees, wasps, and ants)",
-    "download": "http://purl.obolibrary.org/obo/hao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/hao.owl",
     "homepage": "http://hymao.org",
     "name": "Hymenoptera Anatomy Ontology",
     "prefix": "hao",
@@ -807,14 +805,14 @@
   },
   "hcao": {
     "description": "Application ontology for human cell types, anatomy and development stages for the Human Cell Atlas.",
-    "download": "https://raw.githubusercontent.com/ebi-ait/ontology/master/hcao.owl",
+    "download_owl": "https://raw.githubusercontent.com/ebi-ait/ontology/master/hcao.owl",
     "name": "Human Cell Atlas Ontology",
     "prefix": "hcao",
     "version.iri": "http://ontology.data.humancellatlas.org/ontologies/hcao/releases/2023-05-16/hcao.owl"
   },
   "hom": {
     "description": "This ontology represents concepts related to homology, as well as other concepts used to describe similarity and non-homology.",
-    "download": "http://purl.obolibrary.org/obo/hom.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/hom.owl",
     "homepage": "https://github.com/BgeeDB/homology-ontology",
     "name": "Homology Ontology",
     "prefix": "hom",
@@ -823,7 +821,7 @@
   },
   "hp": {
     "description": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotypic abnormalities and clinical features encountered in human disease.",
-    "download": "http://purl.obolibrary.org/obo/hp/hp-international.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/hp/hp-international.owl",
     "homepage": "http://www.human-phenotype-ontology.org/",
     "name": "Human Phenotype Ontology",
     "prefix": "hp",
@@ -832,14 +830,14 @@
   },
   "hsapdv": {
     "description": "Life cycle stages for Human",
-    "download": "http://purl.obolibrary.org/obo/hsapdv.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/hsapdv.owl",
     "homepage": "https://github.com/obophenotype/developmental-stage-ontologies/wiki/HsapDv",
     "name": "Human Developmental Stages",
     "prefix": "hsapdv"
   },
   "hso": {
     "description": "The health Surveillance Ontology (HSO) focuses on \"surveillance system level data\", that is, data outputs from surveillance activities, such as number of samples collected, cases observed, etc. It aims to support One-Health surveillance, covering animal health, public health and food safety surveillance.",
-    "download": "http://purl.obolibrary.org/obo/hso.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/hso.owl",
     "homepage": "https://w3id.org/hso",
     "name": "Health Surveillance Ontology",
     "prefix": "hso",
@@ -848,14 +846,14 @@
   },
   "htn": {
     "description": "An ontology for representing clinical data about hypertension, intended to support classification of patients according to various diagnostic guidelines",
-    "download": "http://purl.obolibrary.org/obo/htn.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/htn.owl",
     "homepage": "https://github.com/aellenhicks/htn_owl",
     "name": "Hypertension Ontology For Clinical Data",
     "prefix": "htn"
   },
   "iao": {
     "description": "The Information Artifact Ontology (IAO) is an ontology of information entities, originally driven by work by the OBI digital entity and realizable information entity branch.",
-    "download": "http://purl.obolibrary.org/obo/iao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/iao.owl",
     "homepage": "https://github.com/information-artifact-ontology/IAO/",
     "name": "Information Artifact Ontology (IAO)",
     "prefix": "iao",
@@ -864,7 +862,7 @@
   },
   "iceo": {
     "description": "A biological ontology to standardize and integrate Integrative and Conjugative Element (ICE) information and to support computer-assisted reasoning.",
-    "download": "http://purl.obolibrary.org/obo/iceo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/iceo.owl",
     "homepage": "https://github.com/ontoice/ICEO",
     "name": "ICEO: Ontology of Integrative and Conjugative Elements",
     "prefix": "iceo",
@@ -872,7 +870,7 @@
   },
   "ico": {
     "description": "The Informed Consent Ontology (ICO) is an ontology for the informed consent and informed consent process in the medical field.",
-    "download": "http://purl.obolibrary.org/obo/ico.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ico.owl",
     "homepage": "https://github.com/ICO-ontology/ICO",
     "name": "Informed Consent Ontology (ICO)",
     "prefix": "ico",
@@ -880,7 +878,7 @@
   },
   "ido": {
     "description": "A set of interoperable ontologies that will together provide coverage of the infectious disease domain. IDO core is the upper-level ontology that hosts terms of general relevance across the domain, while extension ontologies host terms to specific to a particular part of the domain.",
-    "download": "http://purl.obolibrary.org/obo/ido.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ido.owl",
     "homepage": "http://www.bioontology.org/wiki/index.php/Infectious_Disease_Ontology",
     "name": "Infectious Disease Ontology",
     "prefix": "ido",
@@ -890,7 +888,6 @@
   "idocovid19": {
     "contact": "johnbeverley2021@u.northwestern.edu",
     "description": "The COVID-19 Infectious Disease Ontology (IDO-COVID-19) is an extension of the Infectious Disease Ontology (IDO) and the Virus Infectious Disease Ontology (VIDO). IDO-COVID-19 follows OBO Foundry guidelines, employs the Basic Formal Ontology as its starting point, and covers epidemiology, classification, pathogenesis, and treatment of terms used to represent infection by the SARS-CoV-2 virus strain, and the associated COVID-19 disease.",
-    "download": "https://raw.githubusercontent.com/infectious-disease-ontology-extensions/ido-covid-19/master/ontology/ido%20covid-19",
     "homepage": "https://github.com/infectious-disease-ontology-extensions/ido-covid-19",
     "name": "The COVID-19 Infectious Disease Ontology",
     "prefix": "idocovid19",
@@ -899,7 +896,7 @@
   },
   "idomal": {
     "description": "An application ontology to cover all aspects of malaria as well as the intervention attempts to control it.",
-    "download": "http://purl.obolibrary.org/obo/idomal.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/idomal.owl",
     "homepage": "https://www.vectorbase.org/ontology-browser",
     "name": "Malaria Ontology",
     "prefix": "idomal",
@@ -908,7 +905,7 @@
   },
   "ino": {
     "description": "he Interaction Network Ontology (INO) is an ontology in the domain of interactions and interaction networks. INO represents general and species-neutral types of interactions and interaction networks, and their related elements and relations. INO is a community-driven ontology, aligns with BFO, and is developed by following the OBO Foundry principles.",
-    "download": "http://purl.obolibrary.org/obo/ino.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ino.owl",
     "homepage": "https://github.com/INO-ontology/ino",
     "name": "INO: Interaction Network Ontology",
     "prefix": "ino",
@@ -916,7 +913,7 @@
   },
   "kisao": {
     "description": "A classification of algorithms for simulating biology, their parameters, and their outputs",
-    "download": "http://purl.obolibrary.org/obo/kisao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/kisao.owl",
     "homepage": "https://github.com/SED-ML/KiSAO",
     "name": "Kinetic Simulation Algorithm Ontology",
     "prefix": "kisao",
@@ -924,7 +921,7 @@
   },
   "labo": {
     "description": "LABO is an ontology of informational entities formalizing clinical laboratory tests prescriptions and reporting documents.",
-    "download": "http://purl.obolibrary.org/obo/labo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/labo.owl",
     "homepage": "https://github.com/OpenLHS/LABO",
     "name": "clinical LABoratory Ontology",
     "prefix": "labo",
@@ -933,7 +930,7 @@
   },
   "lepao": {
     "description": "The Lepidoptera Anatomy Ontology contains terms used for describing the anatomy and phenotype of moths and butterflies in biodiversity research.",
-    "download": "http://purl.obolibrary.org/obo/lepao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/lepao.owl",
     "homepage": "https://github.com/insect-morphology/lepao",
     "name": "Lepidoptera Anatomy Ontology",
     "prefix": "lepao",
@@ -942,7 +939,7 @@
   },
   "ma": {
     "description": "A structured controlled vocabulary of the adult anatomy of the mouse (Mus).",
-    "download": "http://purl.obolibrary.org/obo/ma.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ma.owl",
     "homepage": "https://github.com/obophenotype/mouse-anatomy-ontology",
     "name": "Mouse adult gross anatomy",
     "prefix": "ma",
@@ -951,7 +948,7 @@
   },
   "maxo": {
     "description": "An ontology to represent medically relevant actions, procedures, therapies, interventions, and recommendations.",
-    "download": "http://purl.obolibrary.org/obo/maxo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/maxo.owl",
     "homepage": "https://github.com/monarch-initiative/MAxO",
     "name": "Medical Action Ontology",
     "prefix": "maxo",
@@ -960,7 +957,7 @@
   },
   "mco": {
     "description": "Microbial Conditions Ontology is an ontology...",
-    "download": "http://purl.obolibrary.org/obo/mco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mco.owl",
     "homepage": "https://github.com/microbial-conditions-ontology/microbial-conditions-ontology",
     "name": "Microbial Conditions Ontology",
     "prefix": "mco",
@@ -969,7 +966,7 @@
   },
   "mf": {
     "description": "The Mental Functioning Ontology is an overarching ontology for all aspects of mental functioning.",
-    "download": "http://purl.obolibrary.org/obo/mf.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mf.owl",
     "homepage": "https://github.com/jannahastings/mental-functioning-ontology",
     "name": "Mental Functioning Ontology",
     "prefix": "mf",
@@ -978,7 +975,7 @@
   },
   "mfmo": {
     "description": "The Mammalian Feeding Muscle Ontology is an antomy ontology for the muscles of the head and neck that participate in feeding, swallowing, and other oral-pharyngeal behaviors.",
-    "download": "http://purl.obolibrary.org/obo/mfmo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mfmo.owl",
     "homepage": "https://github.com/rdruzinsky/feedontology",
     "name": "Mammalian Feeding Muscle Ontology",
     "prefix": "mfmo",
@@ -987,7 +984,7 @@
   },
   "mfoem": {
     "description": "An ontology of affective phenomena such as emotions, moods, appraisals and subjective feelings.",
-    "download": "http://purl.obolibrary.org/obo/mfoem.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mfoem.owl",
     "homepage": "https://github.com/jannahastings/emotion-ontology",
     "name": "Emotion Ontology",
     "prefix": "mfoem",
@@ -996,7 +993,7 @@
   },
   "mfomd": {
     "description": "The Mental Disease Ontology is developed to facilitate representation for all aspects of mental disease. It is an extension of the Ontology for General Medical Science (OGMS) and Mental Functioning Ontology (MF).",
-    "download": "http://purl.obolibrary.org/obo/mfomd.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mfomd.owl",
     "homepage": "https://github.com/jannahastings/mental-functioning-ontology",
     "name": "Mental Disease Ontology",
     "prefix": "mfomd",
@@ -1005,21 +1002,21 @@
   },
   "mi": {
     "description": "A structured controlled vocabulary for the annotation of experiments concerned with protein-protein interactions.",
-    "download": "http://purl.obolibrary.org/obo/mi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mi.owl",
     "homepage": "https://github.com/HUPO-PSI/psi-mi-CV",
     "name": "Molecular Interactions Controlled Vocabulary",
     "prefix": "mi"
   },
   "miapa": {
     "description": "The MIAPA ontology is intended to be an application ontology for the purpose of semantic annotation of phylogenetic data according to the requirements and recommendations of the Minimum Information for A Phylogenetic Analysis (MIAPA) metadata reporting standard. The ontology leverages (imports) primarily from the CDAO (Comparative Data Analysis Ontology), PROV (W3C Provenance Ontology), and SWO (Software Ontology, which includes the EDAM ontologies) ontologies. It adds some assertions of its own, as well as some classes and individuals that may eventually get pushed down into one of the respective source ontologies.\n\nThis ontology is maintained at http://github.com/miapa/miapa, and requests for changes or additions should be filed at the issue tracker there. The discussion list is at miapa-discuss@googlegroups.com. Further resources about MIAPA can be found at the project's main page at http://evoio.org/wiki/MIAPA.",
-    "download": "http://purl.obolibrary.org/obo/miapa.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/miapa.owl",
     "homepage": "http://www.evoio.org/wiki/MIAPA",
     "name": "Minimum Information for A Phylogenetic Analysis (MIAPA) Ontology",
     "prefix": "miapa"
   },
   "micro": {
     "description": "An ontology of prokaryotic phenotypic and metabolic characters",
-    "download": "http://purl.obolibrary.org/obo/micro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/micro.owl",
     "homepage": "https://github.com/carrineblank/MicrO",
     "name": "Ontology of Prokaryotic Phenotypic and Metabolic Characters",
     "prefix": "micro",
@@ -1027,7 +1024,7 @@
   },
   "miro": {
     "description": "Application ontology for entities related to insecticide resistance in mosquitos",
-    "download": "http://purl.obolibrary.org/obo/miro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/miro.owl",
     "name": "Mosquito insecticide resistance",
     "prefix": "miro",
     "version": "2014-05-14",
@@ -1035,7 +1032,7 @@
   },
   "mmo": {
     "description": "A representation of the variety of methods used to make clinical and phenotype measurements.",
-    "download": "http://purl.obolibrary.org/obo/mmo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mmo.owl",
     "homepage": "https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=MMO:0000000",
     "name": "Measurement method ontology",
     "prefix": "mmo",
@@ -1044,14 +1041,14 @@
   },
   "mmusdv": {
     "description": "Life cycle stages for Mus Musculus",
-    "download": "http://purl.obolibrary.org/obo/mmusdv.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mmusdv.owl",
     "homepage": "https://github.com/obophenotype/developmental-stage-ontologies/wiki/MmusDv",
     "name": "Mouse Developmental Stages",
     "prefix": "mmusdv"
   },
   "mod": {
     "description": "PSI-MOD is an ontology consisting of terms that describe protein chemical modifications",
-    "download": "http://purl.obolibrary.org/obo/mod.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mod.owl",
     "homepage": "http://www.psidev.info/MOD",
     "name": "Protein modification",
     "prefix": "mod",
@@ -1060,7 +1057,7 @@
   },
   "mondo": {
     "description": "A semi-automatically constructed ontology that merges in multiple disease resources to yield a coherent merged ontology.",
-    "download": "http://purl.obolibrary.org/obo/mondo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mondo.owl",
     "homepage": "https://monarch-initiative.github.io/mondo",
     "name": "Mondo Disease Ontology",
     "prefix": "mondo",
@@ -1070,7 +1067,7 @@
   "mop": {
     "contact": "chemistry-ontologies@googlegroups.com",
     "description": "MOP is the molecular process ontology. It contains the molecular processes that underlie the name reaction ontology RXNO, for example cyclization, methylation and demethylation.",
-    "download": "http://purl.obolibrary.org/obo/mop.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mop.owl",
     "homepage": "https://github.com/rsc-ontologies/rxno",
     "name": "MOP",
     "prefix": "mop",
@@ -1079,7 +1076,7 @@
   },
   "mp": {
     "description": "The Mammalian Phenotype Ontology is being developed by Cynthia L. Smith, Susan M. Bello, Anna, Anagnostopoulos, Carroll W. Goldsmith and Janan T. Eppig, as part of the Mouse Genome Database (MGD) Project, Mouse Genome Informatics (MGI), The Jackson Laboratory, Bar Harbor, ME. This file contains pre-coordinated phenotype terms, definitions and synonyms that can be used to describe mammalian phenotypes. The ontology is represented as a directed acyclic graph (DAG). It organizes phenotype terms into major biological system headers such as nervous system and respiratory system.  This ontology is currently under development. Weekly updates are available at the Mouse Genome Informatics (MGI) ftp site (ftp://ftp.informatics.jax.org/pub/reports/index.html#pheno) as well as the OBO Foundry site (http://obofoundry.org/). Questions, comments and suggestions are welcome, and should be directed to pheno@jax.org, Susan.Bello@jax.org or to GitHub tracker (https://github.com/mgijax/mammalian-phenotype-ontology/issues) MGD is funded by NIH/NHGRI grant HG000330.",
-    "download": "http://purl.obolibrary.org/obo/mp.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mp.owl",
     "homepage": "http://www.informatics.jax.org/searches/MP_form.shtml",
     "name": "The Mammalian Phenotype Ontology",
     "prefix": "mp",
@@ -1088,7 +1085,7 @@
   },
   "mpath": {
     "description": "A structured controlled vocabulary of mutant and transgenic mouse pathology phenotypes",
-    "download": "http://purl.obolibrary.org/obo/mpath.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mpath.owl",
     "homepage": "http://www.pathbase.net",
     "name": "Mouse pathology ontology",
     "prefix": "mpath",
@@ -1097,7 +1094,7 @@
   },
   "mpio": {
     "description": "An ontology of minimum information regarding potential drug-drug interaction information.",
-    "download": "http://purl.obolibrary.org/obo/mpio.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mpio.owl",
     "homepage": "https://github.com/MPIO-Developers/MPIO",
     "name": "Minimum PDDI Information Ontology",
     "prefix": "mpio",
@@ -1106,7 +1103,7 @@
   },
   "mro": {
     "description": "The MHC Restriction Ontology is an application ontology capturing how Major Histocompatibility Complex (MHC) restriction is defined in experiments, spanning exact protein complexes, individual protein chains, serotypes, haplotypes and mutant molecules, as well as evidence for MHC restrictions.",
-    "download": "http://purl.obolibrary.org/obo/mro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/mro.owl",
     "homepage": "https://github.com/IEDB/MRO",
     "name": "MHC Restriction Ontology",
     "prefix": "mro",
@@ -1116,7 +1113,7 @@
   "ms": {
     "contact": "psidev-ms-vocab@lists.sourceforge.net",
     "description": "A structured controlled vocabulary for the annotation of experiments concerned with proteomics mass spectrometry.",
-    "download": "http://purl.obolibrary.org/obo/ms.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ms.owl",
     "homepage": "http://www.psidev.info/groups/controlled-vocabularies",
     "name": "Mass spectrometry ontology",
     "prefix": "ms",
@@ -1125,7 +1122,7 @@
   },
   "msio": {
     "description": "an application ontology for supporting description and annotation of mass-spectrometry and nmr-spectroscopy based metabolomics experiments and fluxomics studies.",
-    "download": "https://raw.githubusercontent.com/MSI-Metabolomics-Standards-Initiative/MSIO/master/releases/latest_release/MSIO-merged-reasoned.owl",
+    "download_owl": "https://raw.githubusercontent.com/MSI-Metabolomics-Standards-Initiative/MSIO/master/releases/latest_release/MSIO-merged-reasoned.owl",
     "homepage": "https://github.com/MSI-Metabolomics-Standards-Initiative/MSIO",
     "name": "Metabolomics Standards Initiative Ontology (MSIO)",
     "prefix": "msio",
@@ -1133,7 +1130,7 @@
   },
   "nbo": {
     "description": "An ontology of human and animal behaviours and behavioural phenotypes",
-    "download": "http://purl.obolibrary.org/obo/nbo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/nbo.owl",
     "homepage": "https://github.com/obo-behavior/behavior-ontology/",
     "name": "Neuro Behavior Ontology",
     "prefix": "nbo",
@@ -1142,7 +1139,7 @@
   },
   "ncbitaxon": {
     "description": "An ontology representation of the NCBI organismal taxonomy",
-    "download": "http://purl.obolibrary.org/obo/ncbitaxon.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ncbitaxon.owl",
     "homepage": "https://github.com/obophenotype/ncbitaxon",
     "name": "NCBI organismal classification",
     "prefix": "ncbitaxon",
@@ -1151,7 +1148,7 @@
   },
   "ncit": {
     "description": "NCI Thesaurus (NCIt)is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases, findings and abnormalities. The NCIt OBO Edition aims to increase integration of the NCIt with OBO Library ontologies. NCIt OBO Edition releases should be considered experimental.",
-    "download": "http://purl.obolibrary.org/obo/ncit.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ncit.owl",
     "homepage": "https://github.com/NCI-Thesaurus/thesaurus-obo-edition",
     "name": "NCI Thesaurus OBO Edition",
     "prefix": "ncit",
@@ -1161,7 +1158,7 @@
   "ncro": {
     "contact": "ncro-devel@googlegroups.com",
     "description": "An ontology for non-coding RNA, both of biological origin, and engineered.",
-    "download": "http://purl.obolibrary.org/obo/ncro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ncro.owl",
     "homepage": "http://omnisearch.soc.southalabama.edu/w/index.php/Ontology",
     "name": "Non-Coding RNA Ontology",
     "prefix": "ncro",
@@ -1169,7 +1166,7 @@
   },
   "ngbo": {
     "description": "Next Generation Biobanking Ontology (NGBO) is an open application ontology representing contextual data about omics digital assets in biobank. The ontology focuses on capturing the information about three main activities: wet bench analysis used to generate omics data, bioinformatics analysis used to analyze and interpret data, and data management.",
-    "download": "http://purl.obolibrary.org/obo/ngbo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ngbo.owl",
     "homepage": "https://github.com/Dalalghamdi/NGBO",
     "name": "Next generation biobanking ontology(NGBO).",
     "prefix": "ngbo",
@@ -1178,7 +1175,7 @@
   },
   "nmrcv": {
     "description": "This artefact is an MSI-approved controlled vocabulary primarily developed under COSMOS EU and PhenoMeNal EU governance. The nmrCV is supporting the nmrML XML format with standardized terms. nmrML is a vendor agnostic open access NMR raw data standard. Its primaly role is analogous to the mzCV for the PSI-approved mzML XML format. It uses BFO2.0 as its Top level. This CV was derived from two predecessors (The NMR CV from the David Wishart Group, developed by Joseph Cruz) and the MSI nmr CV developed by Daniel Schober at the EBI.  This simple taxonomy of terms (no DL semantics used) serves the nuclear magnetic resonance markup language (nmrML) with meaningful descriptors to amend the nmrML xml file with CV terms. Metabolomics scientists are encouraged to use this CV to annotrate their raw and experimental context data, i.e. within nmrML. The approach to have an exchange syntax mixed of an xsd and CV stems from the PSI mzML effort. The reason to branch out from an xsd into a CV is, that in areas where the terminology is likely to change faster than the nmrML xsd could be updated and aligned, an externally and decentrallised maintained CV can accompensate for such dynamics in a more flexible way. A second reason for this set-up is that semantic validity of CV terms used in an nmrML XML instance (allowed CV terms, position/relation to each other, cardinality) can be validated by rule-based proprietary validators:  By means of cardinality specifications and XPath expressions defined in an XML mapping file (an instances of the CvMappingRules.xsd ), one can define what ontology terms are allowed in a specific location of the data model.",
-    "download": "http://nmrml.org/cv/stable/nmrCV.owl",
+    "download_owl": "http://nmrml.org/cv/stable/nmrCV.owl",
     "homepage": "http://nmrml.org/cv/",
     "name": "nuclear magnetic resonance CV",
     "prefix": "nmrcv",
@@ -1186,14 +1183,14 @@
   },
   "nomen": {
     "description": "NOMEN is a nomenclatural ontology for biological names (not concepts).  It encodes the goverened rules of nomenclature.",
-    "download": "http://purl.obolibrary.org/obo/nomen.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/nomen.owl",
     "homepage": "https://github.com/SpeciesFileGroup/nomen",
     "name": "NOMEN - A nomenclatural ontology for biological names",
     "prefix": "nomen"
   },
   "oae": {
     "description": "The Ontology of Adverse Eventsy (OAE) is a biomedical ontology in the domain of adverse events. OAE aims to standardize adverse event annotation, integrate various adverse event data, and support computer-assisted reasoning.  OAE is a community-based ontology. Its development follows the OBO Foundry principles. Vaccine adverse events have been used as an initial testing use case. OAE also studies adverse events associated with the administration of drug and nutritional products, the operation of surgeries, and the usage of medical devices, etc.",
-    "download": "http://purl.obolibrary.org/obo/oae.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/oae.owl",
     "homepage": "https://github.com/OAE-ontology/OAE/",
     "name": "OAE: Ontology of Adverse Events",
     "prefix": "oae",
@@ -1201,7 +1198,7 @@
   },
   "oarcs": {
     "description": "OArCS is an ontology describing the Arthropod ciruclatory system.",
-    "download": "http://purl.obolibrary.org/obo/oarcs.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/oarcs.owl",
     "homepage": "https://github.com/aszool/oarcs",
     "name": "Ontology of Arthropod Circulatory Systems",
     "prefix": "oarcs",
@@ -1210,7 +1207,7 @@
   },
   "oba": {
     "description": "A collection of biological attributes (traits) covering all kingdoms of life. Interoperable with VT (vertebrate trait ontology) and TO (plant trait ontology). Extends PATO.",
-    "download": "http://purl.obolibrary.org/obo/oba.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/oba.owl",
     "homepage": "https://github.com/obophenotype/bio-attribute-ontology",
     "name": "Ontology of Biological Attributes (OBA)",
     "prefix": "oba",
@@ -1219,7 +1216,7 @@
   },
   "obcs": {
     "description": "OBCS stands for the Ontology of Biological and Clinical Statistics. OBCS is an ontology in the domain of biological and clinical statistics. It is aligned with the Basic Formal Ontology (BFO) and the Ontology for Biomedical Investigations (OBI). OBCS imports all possible biostatistics terms in OBI and includes many additional biostatistics terms, some of which were proposed and discussed in the OBI face-to-face workshop in Ann Arbor in 2012.",
-    "download": "http://purl.obolibrary.org/obo/obcs.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/obcs.owl",
     "homepage": "https://github.com/obcs/obcs",
     "name": "Ontology of Biological and Clinical Statistics",
     "prefix": "obcs",
@@ -1228,7 +1225,7 @@
   },
   "obi": {
     "description": "An ontology for representing biomedical investigations, including study designs, the collection and preparation of the targets of investigation, assays, instrumentation and reagents used, as well as the data generated and the types of analysis performed on the data to reach conclusions, and their documentation.",
-    "download": "http://purl.obolibrary.org/obo/obi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/obi.owl",
     "homepage": "http://obi-ontology.org",
     "name": "Ontology for Biomedical Investigations",
     "prefix": "obi",
@@ -1237,7 +1234,7 @@
   },
   "obib": {
     "description": "The Ontology for Biobanking (OBIB) is an ontology for the annotation and modeling of the activities, contents, and administration of a biobank. Biobanks are facilities that store specimens, such as bodily fluids and tissues, typically along with specimen annotation and clinical data. OBIB is based on a subset of the Ontology for Biomedical Investigation (OBI), has the Basic Formal Ontology (BFO) as its upper ontology, and is developed following OBO Foundry principles. The first version of OBIB resulted from the merging of two existing biobank-related ontologies, OMIABIS and biobank ontology.",
-    "download": "http://purl.obolibrary.org/obo/obib.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/obib.owl",
     "homepage": "https://github.com/biobanking/biobanking",
     "name": "Ontology for BIoBanking (OBIB)",
     "prefix": "obib",
@@ -1246,7 +1243,7 @@
   },
   "ogg": {
     "description": "OGG is a biological ontology in the area of genes and genomes. OGG uses the Basic Formal Ontology (BFO) as its upper level ontology. This OGG document contains the genes and genomes of a list of selected organisms, including human, two viruses (HIV and influenza virus), and bacteria (B. melitensis strain 16M, E. coli strain K-12 substrain MG1655, M. tuberculosis strain H37Rv, and P. aeruginosa strain PAO1). More OGG information for other organisms (e.g., mouse, zebrafish, fruit fly, yeast, etc.) may be found in other OGG subsets.",
-    "download": "http://purl.obolibrary.org/obo/ogg.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ogg.owl",
     "homepage": "https://bitbucket.org/hegroup/ogg",
     "name": "OGG: Ontology of Genes and Genomes",
     "prefix": "ogg",
@@ -1254,7 +1251,7 @@
   },
   "ogms": {
     "description": "The Ontology for General Medical Science (OGMS) is an ontology of entities involved in a clinical encounter. OGMS includes very general terms that are used across medical disciplines, including: 'disease', 'disorder', 'disease course', 'diagnosis', 'patient', and 'healthcare provider'. OGMS uses the Basic Formal Ontology (BFO) as an upper-level ontology. The scope of OGMS is restricted to humans, but many terms can be applied to a variety of organisms. OGMS provides a formal theory of disease that can be further elaborated by specific disease ontologies. This theory is implemented using OWL-DL and OBO Relation Ontology relations and is available in OWL and OBO formats.\n\nOGMS is based on the papers Toward an Ontological Treatment of Disease and Diagnosis and On Carcinomas and Other Pathological Entities. The ontology attempts to address some of the issues raised at the Workshop on Ontology of Diseases (Dallas, TX) and the Signs, Symptoms, and Findings Workshop(Milan, Italy). OGMS was formerly called the clinical phenotype ontology. Terms from OGMS hang from the Basic Formal Ontology.",
-    "download": "http://purl.obolibrary.org/obo/ogms.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ogms.owl",
     "homepage": "https://github.com/OGMS/ogms",
     "name": "Ontology for General Medical Science",
     "prefix": "ogms",
@@ -1263,7 +1260,7 @@
   },
   "ogsf": {
     "description": "An application ontology to represent genetic susceptibility to a specific disease, adverse event, or a pathological process.",
-    "download": "http://purl.obolibrary.org/obo/ogsf.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ogsf.owl",
     "homepage": "https://github.com/linikujp/OGSF",
     "name": "Ontology of Genetic Susceptibility Factor",
     "prefix": "ogsf",
@@ -1271,7 +1268,7 @@
   },
   "ohd": {
     "description": "The Oral Health and Disease Ontology is used for representing the diagnosis and treatment of dental maladies.",
-    "download": "http://purl.obolibrary.org/obo/ohd.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ohd.owl",
     "homepage": "https://purl.obolibrary.org/obo/ohd/home",
     "name": "Oral Health and Disease Ontology",
     "prefix": "ohd",
@@ -1280,7 +1277,7 @@
   },
   "ohmi": {
     "description": "OHMI is a biomedical ontology that represents the entities and relations in the domain of host-microbiome interactions.",
-    "download": "http://purl.obolibrary.org/obo/ohmi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ohmi.owl",
     "homepage": "https://github.com/ohmi-ontology/ohmi",
     "name": "OHMI: Ontology of Host-Microbiome Interactions",
     "prefix": "ohmi",
@@ -1289,7 +1286,7 @@
   },
   "ohpi": {
     "description": "OHPI is a biomedical ontology in the area of host-pathogen interactions. OHPI is developed by following the OBO Foundry Principles (e.g., openness and collaboration).",
-    "download": "http://purl.obolibrary.org/obo/ohpi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ohpi.owl",
     "homepage": "https://github.com/OHPI/ohpi",
     "name": "OHPI: Ontology of Host-Pathogen Interactions",
     "prefix": "ohpi",
@@ -1299,7 +1296,7 @@
   "om": {
     "contact": "hajo.rijgersberg@wur.nl",
     "description": "The OM ontology provides classes, instances, and properties that represent the different concepts used for defining and using measures and units. It includes, for instance, common units such as the SI units meter and kilogram, but also units from other systems of units such as the mile or nautical mile. For many application areas it includes more specific units and quantities, such as the unit of the Hubble constant: km/s/Mpc, or the quantity vaselife.  OM defines the complete set of concepts in the domain as distinguished in the textual standards. As a result the ontology can answer a wider range of competency questions than the existing approaches do. The following application areas are supported by OM:  Geometry; Mechanics; Thermodynamics; Electromagnetism; Fluid mechanics; Chemical physics; Photometry; Radiometry and Radiobiology; Nuclear physics; Astronomy and Astrophysics; Cosmology; Earth science; Meteorology; Material science; Microbiology; Economics; Information technology; Typography; Shipping; Food engineering; Post-harvest; technology; Dynamics of texture and taste; Packaging",
-    "download": "https://raw.githubusercontent.com/HajoRijgersberg/OM/master/om-2.0.rdf",
+    "download_rdf": "https://raw.githubusercontent.com/HajoRijgersberg/OM/master/om-2.0.rdf",
     "homepage": "https://github.com/HajoRijgersberg/OM",
     "name": "Ontology of units of Measure (OM)",
     "prefix": "om",
@@ -1314,7 +1311,7 @@
   },
   "omit": {
     "description": "Ontology to establish data exchange standards and common data elements in the microRNA (miR) domain",
-    "download": "http://purl.obolibrary.org/obo/omit.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/omit.owl",
     "homepage": "http://omit.cis.usouthal.edu/",
     "name": "Ontology for MIRNA Target",
     "prefix": "omit",
@@ -1323,7 +1320,7 @@
   },
   "omo": {
     "description": "An ontology specifies terms that are used to annotate ontology terms for all OBO ontologies. The ontology was developed as part of Information Artifact Ontology (IAO).",
-    "download": "http://purl.obolibrary.org/obo/omo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/omo.owl",
     "homepage": "https://github.com/information-artifact-ontology/ontology-metadata",
     "name": "OBO Metadata Ontology",
     "prefix": "omo",
@@ -1332,7 +1329,7 @@
   },
   "omp": {
     "description": "An ontology of phenotypes covering microbes",
-    "download": "http://purl.obolibrary.org/obo/omp.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/omp.owl",
     "homepage": "http://microbialphenotypes.org",
     "name": "Ontology of Microbial Phenotypes",
     "prefix": "omp",
@@ -1341,7 +1338,7 @@
   },
   "omrse": {
     "description": "The Ontology for Modeling and Representation of Social Entities (OMRSE) is an OBO Foundry ontology that represents the various entities that arise from human social interactions, such as social acts, social roles, social groups, and organizations.",
-    "download": "http://purl.obolibrary.org/obo/omrse.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/omrse.owl",
     "homepage": "https://github.com/mcwdsi/OMRSE/wiki/OMRSE-Overview",
     "name": "Ontology for Modeling and Representation of Social Entities",
     "prefix": "omrse",
@@ -1350,14 +1347,14 @@
   },
   "one": {
     "description": "An ontology to standardize research output of nutritional epidemiologic studies.",
-    "download": "http://purl.obolibrary.org/obo/one.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/one.owl",
     "homepage": "https://github.com/cyang0128/Nutritional-epidemiologic-ontologies",
     "name": "Ontology for Nutritional Epidemiology",
     "prefix": "one"
   },
   "ons": {
     "description": "The Ontology for Nutritional Studies (ONS) has been developed as part of the ENPADASI European project (http://www.enpadasi.eu/) with the aim to define a common language and building ontologies for nutritional studies.",
-    "download": "http://purl.obolibrary.org/obo/ons.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ons.owl",
     "homepage": "https://github.com/enpadasi/Ontology-for-Nutritional-Studies",
     "name": "Ontology for Nutritional Studies",
     "prefix": "ons",
@@ -1365,7 +1362,7 @@
   },
   "ontoavida": {
     "description": "The Ontology for Avida (OntoAvida) project aims to develop an integrated vocabulary for the description of the most widely used computational approach for performing experimental evolution using digital organisms (i.e., self-replicating computer programs that evolve within a user-defined computational environment).\n\nThe lack of a clearly defined vocabulary makes biologists feel reluctant to embrace the field of digital evolution. This unique ontology has the potential to change this picture overnight.\n\nOntoAvida was initially developed by https://fortunalab.org, the computational biology lab at the Do\u00f1ana Biological Station (a research institute of the Spanish National Research Council based at Seville, Spain). Contributors to OntoAvida are expected to include members of the Digital Evolution Laboratory (https://devolab.org/) at Michigan State University (USA).\n\nMore information can be found at https://obofoundry.org/ontology/ontoavida.html",
-    "download": "http://purl.obolibrary.org/obo/ontoavida.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ontoavida.owl",
     "homepage": "https://gitlab.com/fortunalab/ontoavida",
     "name": "OntoAvida: ontology for Avida digital evolution platform.",
     "prefix": "ontoavida",
@@ -1374,7 +1371,7 @@
   },
   "ontoneo": {
     "description": "The Obstetric and Neonatal Ontology is a structured controlled vocabulary to provide a representation of the data from electronic health records (EHRs) involved in the care of the pregnant woman, and of her baby.",
-    "download": "http://purl.obolibrary.org/obo/ontoneo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ontoneo.owl",
     "homepage": "ontoneo.com",
     "name": "Obstetric and Neonatal Ontology",
     "prefix": "ontoneo",
@@ -1383,7 +1380,7 @@
   },
   "oostt": {
     "description": "The Ontology of Organizational Structures of Trauma centers and Trauma systems (OOSTT) is a representation of the components of trauma centers and trauma systems coded in Web Ontology Language (OWL2).",
-    "download": "http://purl.obolibrary.org/obo/oostt.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/oostt.owl",
     "homepage": "https://github.com/OOSTT/OOSTT",
     "name": "Ontology of Organizational Structures of Trauma centers and Trauma Systems",
     "prefix": "oostt",
@@ -1392,7 +1389,7 @@
   },
   "opl": {
     "description": "The Ontology for Parasite Lifecycle (OPL) models the life cycle stage details of various parasites, including Trypanosoma sp., Leishmania major, and Plasmodium sp., etc. In addition to life cycle stages, the ontology also models necessary contextual details, such as host information, vector information, and anatomical location. OPL is based on the Basic Formal Ontology (BFO) and follows the rules set by the OBO Foundry consortium.",
-    "download": "http://purl.obolibrary.org/obo/opl.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/opl.owl",
     "homepage": "https://github.com/OPL-ontology/OPL",
     "name": "Ontology for Parasite Lifecycle",
     "prefix": "opl",
@@ -1401,7 +1398,7 @@
   },
   "opmi": {
     "description": "OPMI is a biomedical ontology in the area of precision medicine and its related investigations. It is community-driven and developed by following the OBO Foundry ontology development principles.",
-    "download": "http://purl.obolibrary.org/obo/opmi.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/opmi.owl",
     "homepage": "https://github.com/OPMI/opmi",
     "name": "OPMI: Ontology of Precision Medicine and Investigation",
     "prefix": "opmi",
@@ -1409,7 +1406,7 @@
   },
   "ordo": {
     "description": "The Orphanet Rare Disease ontology (ORDO) is jointly developed by Orphanet and the EBI to provide a structured vocabulary for rare diseases capturing relationships between diseases, genes and other relevant features which will form a useful resource for the computational analysis of rare diseases. It derived from the Orphanet database (www.orpha.net ) , a multilingual database dedicated to rare diseases populated from literature and validated by international experts. It integrates a nosology (classification of rare diseases), relationships (gene-disease relations, epiemological data) and connections with other terminologies (MeSH, UMLS, MedDRA),databases (OMIM, UniProtKB, HGNC, ensembl, Reactome, IUPHAR, Geantlas) or classifications (ICD10).",
-    "download": "http://www.orphadata.org/data/ORDO/ordo_orphanet.owl",
+    "download_owl": "http://www.orphadata.org/data/ORDO/ordo_orphanet.owl",
     "name": "Orphanet Rare Disease Ontology",
     "prefix": "ordo",
     "version": "4.3",
@@ -1417,7 +1414,7 @@
   },
   "ornaseq": {
     "description": "An application ontology designed to annotate next-generation sequencing experiments performed on RNA.",
-    "download": "http://purl.obolibrary.org/obo/ornaseq.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ornaseq.owl",
     "homepage": "http://kim.bio.upenn.edu/software/ornaseq.shtml",
     "name": "Ontology for RNA sequencing (ORNASEQ)",
     "prefix": "ornaseq",
@@ -1426,7 +1423,6 @@
   },
   "orth": {
     "description": "The need of a common ontology for describing orthology information in biological research communities has led to the creation of the Orthology Ontology (ORTH). ORTH ontology is designed to describe sequence homology data available in multiple orthology databases on the Web (e.g.: OMA, OrthoDB, HieranoiDB, and etc.). By sequence homology data, we mostly mean gene region, gene and protein centric orthology, paralogy, and xenology information. Depending on the database, the homology information is structured in different ways. ORTH ontology accommodates these disparate data structures namely Hierarchical Orthologous Group (HOG), cluster of homologous sequences and homologous-pairwise relations between sequences. In addition to the specific ORTH terms, this specification includes terms of the imported ontologies (e.g. Semanticscience Integrated Ontology, SIO) which are pertinents to represent the information from various orthology databases in a homogeneous way.",
-    "download": "http://purl.org/net/orth",
     "homepage": "http://purl.org/net/orth",
     "name": "Orthology Ontology",
     "prefix": "orth",
@@ -1435,14 +1431,13 @@
   },
   "ovae": {
     "description": "OVAE is a biomedical ontology in the area of vaccine adverse events. OVAE is an extension of the community-based Ontology of Adverse Events (OAE).",
-    "download": "http://purl.obolibrary.org/obo/ovae.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ovae.owl",
     "homepage": "http://www.violinet.org/ovae/",
     "name": "OVAE: Ontology of Vaccine Adverse Events",
     "prefix": "ovae",
     "version": "1.0.34"
   },
   "owl": {
-    "download": "https://www.w3.org/2002/07/owl",
     "name": "The OWL 2 Schema vocabulary (OWL 2)",
     "prefix": "owl",
     "version": "$Date: 2009/11/15 10:54:12 $",
@@ -1450,7 +1445,7 @@
   },
   "pato": {
     "description": "An ontology of phenotypic qualities (properties, attributes or characteristics).",
-    "download": "http://purl.obolibrary.org/obo/pato.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/pato.owl",
     "homepage": "https://github.com/pato-ontology/pato/",
     "name": "PATO - the Phenotype And Trait Ontology",
     "prefix": "pato",
@@ -1459,7 +1454,7 @@
   },
   "pcl": {
     "description": "Cell types that are provisionally defined by experimental techniques such as single cell transcriptomics rather than a straightforward & coherent set of properties.",
-    "download": "https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-full.owl",
+    "download_owl": "https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-full.owl",
     "homepage": "https://github.com/obophenotype/provisional_cell_ontology",
     "name": "Provisional Cell Ontology",
     "prefix": "pcl",
@@ -1468,7 +1463,7 @@
   },
   "pco": {
     "description": "The Population and Community Ontology (PCO) describes material entities, qualities, and processes related to collections of interacting organisms such as populations and communities. It is taxon neutral, and can be used for any species, including humans. The classes in the PCO are useful for describing evolutionary processes, organismal interactions, and ecological experiments. Practical applications of the PCO include community health care, plant pathology, behavioral studies, sociology, and ecology.",
-    "download": "http://purl.obolibrary.org/obo/pco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/pco.owl",
     "homepage": "https://github.com/PopulationAndCommunityOntology/pco",
     "name": "Population and Community Ontology",
     "prefix": "pco",
@@ -1477,7 +1472,7 @@
   },
   "pdro": {
     "description": "An ontology to describe entities related to prescription of drugs",
-    "download": "http://purl.obolibrary.org/obo/pdro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/pdro.owl",
     "homepage": "https://github.com/OpenLHS/PDRO",
     "name": "The Prescription of Drugs Ontology",
     "prefix": "pdro",
@@ -1486,7 +1481,7 @@
   },
   "phipo": {
     "description": "Ontology of species-neutral phenotypes observed in pathogen-host interactions.",
-    "download": "http://purl.obolibrary.org/obo/phipo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/phipo.owl",
     "homepage": "https://github.com/PHI-base/phipo",
     "name": "Pathogen Host Interactions Phenotype Ontology",
     "prefix": "phipo",
@@ -1495,7 +1490,7 @@
   },
   "plana": {
     "description": "PLANA, the PLANarian Anatomy Ontology, encompasses the anatomy of developmental stages and adult biotypes of Schmidtea mediterranea.",
-    "download": "http://purl.obolibrary.org/obo/plana.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/plana.owl",
     "homepage": "https://github.com/obophenotype/planaria-ontology",
     "name": "Planarian Anatomy Ontology (PLANA)",
     "prefix": "plana",
@@ -1504,7 +1499,7 @@
   },
   "planp": {
     "description": "Planarian Phenotype Ontology is an ontology of phenotypes observed in the planarian Schmidtea mediterranea.",
-    "download": "http://purl.obolibrary.org/obo/planp.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/planp.owl",
     "homepage": "https://github.com/obophenotype/planarian-phenotype-ontology",
     "name": "Planarian Phenotype Ontology (PLANP)",
     "prefix": "planp",
@@ -1513,7 +1508,7 @@
   },
   "po": {
     "description": "The Plant Ontology is a structured vocabulary and database resource that links plant anatomy, morphology and growth and development to plant genomics data.",
-    "download": "http://purl.obolibrary.org/obo/po.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/po.owl",
     "homepage": "http://browser.planteome.org/amigo",
     "name": "Plant Ontology",
     "prefix": "po",
@@ -1522,7 +1517,7 @@
   },
   "poro": {
     "description": "An ontology describing the anatomical structures and characteristics of Porifera (sponges)",
-    "download": "http://purl.obolibrary.org/obo/poro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/poro.owl",
     "homepage": "https://github.com/obophenotype/porifera-ontology",
     "name": "Porifera (sponge) ontology",
     "prefix": "poro",
@@ -1532,7 +1527,7 @@
   "ppo": {
     "contact": "ppo-discuss@googlegroups.com",
     "description": "An ontology for describing the phenology of individual plants and populations of plants, and for integrating plant phenological data across sources and scales.",
-    "download": "http://purl.obolibrary.org/obo/ppo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ppo.owl",
     "homepage": "https://github.com/PlantPhenoOntology/PPO",
     "name": "Plant Phenology Ontology",
     "prefix": "ppo",
@@ -1541,7 +1536,7 @@
   },
   "pr": {
     "description": "An ontological representation of protein-related entities",
-    "download": "http://purl.obolibrary.org/obo/pr.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/pr.owl",
     "homepage": "http://proconsortium.org",
     "name": "PRotein Ontology (PRO)",
     "prefix": "pr",
@@ -1550,7 +1545,7 @@
   },
   "pride": {
     "description": "The PRIDE PRoteomics IDEntifications (PRIDE) database is a centralized, standards compliant, public data repository for proteomics data, including protein and peptide identifications, post-translational modifications and supporting spectral evidence.",
-    "download": "https://raw.githubusercontent.com/PRIDE-Utilities/pride-ontology/master/pride_cv.owl",
+    "download_owl": "https://raw.githubusercontent.com/PRIDE-Utilities/pride-ontology/master/pride_cv.owl",
     "homepage": "https://github.com/PRIDE-Utilities/pride-ontology",
     "name": "PRIDE Controlled Vocabulary",
     "prefix": "pride"
@@ -1558,7 +1553,7 @@
   "probonto": {
     "contact": "probonto.dev@gmail.com",
     "description": "ProbOnto, is an ontology-based knowledge base of probability distributions, featuring more than eighty uni- and multivariate distributions with their defining functions, characteristics, relationships and reparameterisation formulas.",
-    "download": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/probonto.ttl",
+    "download_rdf": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/probonto.ttl",
     "homepage": "http://probonto.org",
     "name": "Probability Distribution Ontology",
     "prefix": "probonto",
@@ -1566,7 +1561,7 @@
   },
   "proco": {
     "description": "PROCO (PROcess Chemistry Ontology) is a formal ontology that aims to standardly represent entities and relations among entities in the domain of process chemistry.",
-    "download": "http://purl.obolibrary.org/obo/proco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/proco.owl",
     "homepage": "https://github.com/proco-ontology/PROCO",
     "name": "PROCO: PROcess Chemistry Ontology",
     "prefix": "proco",
@@ -1574,14 +1569,13 @@
     "version.iri": "http://purl.obolibrary.org/obo/proco/releases/2022-04-11/proco.owl"
   },
   "prov": {
-    "download": "https://www.w3.org/ns/prov-o",
     "homepage": "https://www.w3.org/TR/prov-o/",
     "name": "Provenance Ontology (PROV-O)",
     "prefix": "prov"
   },
   "psdo": {
     "description": "Performance Summary Display Ontology (PSDO) is an application ontology about motivating information in performance summaries and the visual and textual entities that are used to communicate about performance. Motivating information includes performance comparisons and changes that motivate improvement or sustainment, such as improvement towards a goal, loss of high performer status, or the presence of a performance gap. Visual and textual entities include charts, tables, and graphs that display performance information. PSDO's domain focus is healthcare organizations that use clinical quality dashboards and feedback interventions for healthcare professionals and teams. Performance information is commonly about the quality of care and health outcomes that have been derived from clinical data using performance measures (aka metrics, process indicators, quality measures, etc). PSDO uses Basic Formal Ontology as its upper level ontology. This work is supported by the NIH, National Library of Medicine (1K01LM012528-01, 1R01LM013894-01).\n\nLandis-Lewis Z, Stansbury C, Rinc\u00f3n J, Gross C. Performance Summary Display Ontology: Feedback intervention content, delivery, and interpreted information. International Conference on Biomedical Ontology 2022 (ICBO 2022). https://icbo-conference.github.io/icbo2022/papers/ICBO-2022_paper_2172.pdf",
-    "download": "http://purl.obolibrary.org/obo/psdo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/psdo.owl",
     "homepage": "https://github.com/Display-Lab/psdo",
     "name": "Performance Summary Display Ontology",
     "prefix": "psdo",
@@ -1590,7 +1584,7 @@
   },
   "pso": {
     "description": "The Plant Stress Ontology describes biotic and abiotic stresses that a plant may encounter.",
-    "download": "http://purl.obolibrary.org/obo/pso.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/pso.owl",
     "homepage": "https://github.com/Planteome/plant-stress-ontology",
     "name": "Plant Stress Ontology",
     "prefix": "pso",
@@ -1599,7 +1593,7 @@
   },
   "pw": {
     "description": "A controlled vocabulary for annotating gene products to pathways.",
-    "download": "http://purl.obolibrary.org/obo/pw.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/pw.owl",
     "homepage": "http://rgd.mcw.edu/rgdweb/ontology/search.html",
     "name": "Pathway ontology",
     "prefix": "pw",
@@ -1608,7 +1602,7 @@
   },
   "rbo": {
     "description": "RBO is an ontology for the effects of radiation on biota in terrestrial and space environments.",
-    "download": "http://purl.obolibrary.org/obo/rbo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/rbo.owl",
     "homepage": "https://github.com/Radiobiology-Informatics-Consortium/RBO",
     "name": "Radiation Biology Ontology",
     "prefix": "rbo",
@@ -1616,14 +1610,12 @@
     "version.iri": "http://purl.obolibrary.org/obo/rbo/releases/2023-09-05/rbo.owl"
   },
   "rdfs": {
-    "download": "https://www.w3.org/2000/01/rdf-schema",
     "name": "The RDF Schema vocabulary (RDFS)",
     "prefix": "rdfs"
   },
   "reproduceme": {
     "contact": "sheeba.samuel@uni-jena.de",
     "description": "The REPRODUCE-ME ontology is an extension of the PROV-O and the P-Plan ontology to describe a complete path of a scientific experiment. It expresses the REPRODUCE-ME Data Model using the OWL2 Web Ontology Language (OWL2). It provides a set of classes and properties to represent a scientific experiment including its computational and non-computational steps to track the provenance of results. It describes a complete path of a scientific experiment considering the use-case of biological imaging and microscopy experiments, computational experiments, including Jupyter notebooks and scripts. It describes an experiment and its data, agents, activities, plans, steps, variables, instruments, materials, and settings required for its reproducibility.",
-    "download": "https://sheeba-samuel.github.io/REPRODUCE-ME/doc/reproduce-me.xml",
     "homepage": "https://w3id.org/reproduceme/research",
     "name": "REPRODUCE-ME Ontology",
     "prefix": "reproduceme",
@@ -1632,14 +1624,14 @@
   "reto": {
     "contact": "vladimir.n.mironov@gmail.com",
     "description": "Regulation of Transcription",
-    "download": "http://www.bio.ntnu.no/ontology/ReTO/reto.rdf",
+    "download_rdf": "http://www.bio.ntnu.no/ontology/ReTO/reto.rdf",
     "homepage": "http://www.semantic-systems-biology.org/apo",
     "name": "Regulation of Transcription Ontology",
     "prefix": "reto"
   },
   "rex": {
     "description": "An ontology of physico-chemical processes, i.e. physico-chemical changes occurring in course of time.",
-    "download": "http://purl.obolibrary.org/obo/rex.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/rex.owl",
     "name": "Physico-chemical process",
     "prefix": "rex",
     "version": "2017-11-19",
@@ -1648,14 +1640,14 @@
   "rexo": {
     "contact": "vladimir.n.mironov@gmail.com",
     "description": "Regulation of Gene Expression",
-    "download": "http://www.bio.ntnu.no/ontology/ReXO/rexo.rdf",
+    "download_rdf": "http://www.bio.ntnu.no/ontology/ReXO/rexo.rdf",
     "homepage": "http://www.semantic-systems-biology.org/apo",
     "name": "Regulation of Gene Expression Ontology",
     "prefix": "rexo"
   },
   "ro": {
     "description": "Relationship types shared across multiple ontologies",
-    "download": "http://purl.obolibrary.org/obo/ro.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/ro.owl",
     "homepage": "https://oborel.github.io/",
     "name": "Relation Ontology",
     "prefix": "ro",
@@ -1664,7 +1656,7 @@
   },
   "rs": {
     "description": "Ontology of rat strains",
-    "download": "http://purl.obolibrary.org/obo/rs.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/rs.owl",
     "homepage": "http://rgd.mcw.edu/rgdweb/search/strains.html",
     "name": "Rat Strain Ontology",
     "prefix": "rs",
@@ -1674,7 +1666,7 @@
   "rxno": {
     "contact": "chemistry-ontologies@googlegroups.com",
     "description": "RXNO is the name reaction ontology. It contains more than 500 classes representing organic reactions such as the Diels\u2013Alder cyclization.",
-    "download": "http://purl.obolibrary.org/obo/rxno.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/rxno.owl",
     "homepage": "https://github.com/rsc-ontologies/rxno",
     "name": "RXNO",
     "prefix": "rxno",
@@ -1683,7 +1675,7 @@
   },
   "sbo": {
     "description": "Terms commonly used in Systems Biology, and in particular in computational modeling.",
-    "download": "http://purl.obolibrary.org/obo/sbo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/sbo.owl",
     "homepage": "http://www.ebi.ac.uk/sbo/",
     "name": "Systems Biology Ontology",
     "prefix": "sbo",
@@ -1691,7 +1683,7 @@
   },
   "scdo": {
     "description": "An ontology for the standardization of terminology and integration of knowledge about Sickle Cell Disease.",
-    "download": "http://purl.obolibrary.org/obo/scdo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/scdo.owl",
     "homepage": "https://scdontology.h3abionet.org/",
     "name": "Sickle Cell Disease Ontology",
     "prefix": "scdo",
@@ -1699,12 +1691,12 @@
     "version.iri": "http://purl.obolibrary.org/obo/scdo/releases/2021-04-15/scdo.owl"
   },
   "schemaorg_http": {
-    "download": "https://schema.org/version/latest/schemaorg-all-http.rdf",
+    "download_rdf": "https://schema.org/version/latest/schemaorg-all-http.rdf",
     "prefix": "schemaorg_http"
   },
   "sdgio": {
     "description": "An OBO-compliant ontology representing the entities referenced by the SDGs, their targets, and indicators.",
-    "download": "http://purl.unep.org/sdg/sdgio.owl",
+    "download_owl": "http://purl.unep.org/sdg/sdgio.owl",
     "homepage": "https://github.com/SDG-InterfaceOntology/sdgio",
     "name": "Sustainable Development Goals Interface Ontology",
     "prefix": "sdgio",
@@ -1712,7 +1704,7 @@
   },
   "sepio": {
     "description": "An ontology for representing the provenance of scientific claims and the evidence that supports them.",
-    "download": "http://purl.obolibrary.org/obo/sepio.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/sepio.owl",
     "homepage": "https://github.com/monarch-initiative/SEPIO-ontology",
     "name": "Ontology for Scientific Evidence and Provenance Information",
     "prefix": "sepio",
@@ -1721,13 +1713,13 @@
   },
   "shareloc": {
     "description": "ShareLoc defines terms to annotate data sets from single molecule localization microscopy, including but not limited to: imaging technique, biological structures or molecules of interest, cell types, experimental condition, labeling method, fixation protocol, etc.",
-    "download": "https://raw.githubusercontent.com/imodpasteur/ShareLoc.XYZ/ontology/shareloc.owl",
+    "download_owl": "https://raw.githubusercontent.com/imodpasteur/ShareLoc.XYZ/ontology/shareloc.owl",
     "name": "ShareLoc",
     "prefix": "shareloc"
   },
   "sibo": {
     "description": "Social Behavior in insects",
-    "download": "http://purl.obolibrary.org/obo/sibo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/sibo.owl",
     "homepage": "https://github.com/obophenotype/sibo",
     "name": "Social Insect Behavior Ontology",
     "prefix": "sibo",
@@ -1737,7 +1729,7 @@
   "sio": {
     "contact": "sio-ontology@googlegroups.com",
     "description": "The Semanticscience Integrated Ontology (SIO) provides a simple, integrated ontology of types and relations for rich description of objects, processes and their attributes.",
-    "download": "https://raw.githubusercontent.com/micheldumontier/semanticscience/master/ontology/sio/release/sio-release.owl",
+    "download_owl": "https://raw.githubusercontent.com/micheldumontier/semanticscience/master/ontology/sio/release/sio-release.owl",
     "homepage": "https://github.com/micheldumontier/semanticscience",
     "name": "Semanticscience Integrated Ontology",
     "prefix": "sio",
@@ -1745,18 +1737,18 @@
     "version.iri": "http://semanticscience.org/ontology/sio/v1.59/sio-release.owl"
   },
   "skos": {
-    "download": "http://www.w3.org/TR/skos-reference/skos.rdf",
+    "download_rdf": "http://www.w3.org/TR/skos-reference/skos.rdf",
     "prefix": "skos"
   },
   "slm": {
     "description": "SwissLipids is a curated resource that provides information about known lipids, including lipid structure, metabolism, interactions, and subcellular and tissue localization. Information is curated from peer-reviewed literature and referenced using established ontologies, and provided with full provenance and evidence codes for curated assertions.",
-    "download": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/swisslipids.ttl",
+    "download_rdf": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/swisslipids.ttl",
     "name": "SwissLipids",
     "prefix": "slm"
   },
   "snomed": {
     "description": "SNOMED CT or SNOMED Clinical Terms is a systematically organized computer processable collection of medical terms providing codes, terms, synonyms and definitions used in clinical documentation and reporting.",
-    "download": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/snomed.owl",
+    "download_owl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/snomed.owl",
     "name": "SNOMED CT (International Edition)",
     "prefix": "snomed",
     "version": "2020-01-31",
@@ -1764,7 +1756,7 @@
   },
   "so": {
     "description": "A structured controlled vocabulary for sequence annotation, for the exchange of annotation data and for the description of sequence objects in databases.",
-    "download": "http://purl.obolibrary.org/obo/so.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/so.owl",
     "homepage": "http://www.sequenceontology.org/",
     "name": "Sequence types and features ontology",
     "prefix": "so",
@@ -1773,7 +1765,7 @@
   },
   "spd": {
     "description": "An ontology for spider comparative biology including anatomical parts (e.g. leg, claw), behavior (e.g. courtship, combing) and products (i.g. silk, web, borrow).",
-    "download": "http://purl.obolibrary.org/obo/spd.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/spd.owl",
     "homepage": "http://research.amnh.org/atol/files/",
     "name": "Spider Ontology",
     "prefix": "spd"
@@ -1781,7 +1773,7 @@
   "srao": {
     "contact": "contact@fairsharing.org",
     "description": "The FAIRsharing Subject Ontology (SRAO) is an application ontology for the categorization of research disciplines across all research domains, from the humanities to the natural sciences. It utilizes multiple external vocabularies.",
-    "download": "https://github.com/FAIRsharing/subject-ontology/raw/master/SRAO.owl",
+    "download_owl": "https://github.com/FAIRsharing/subject-ontology/raw/master/SRAO.owl",
     "homepage": "https://github.com/FAIRsharing/subject-ontology",
     "name": "FAIRsharing Subject Ontology (SRAO)",
     "prefix": "srao",
@@ -1790,7 +1782,7 @@
   },
   "stato": {
     "description": "STATO is the statistical methods ontology. It contains concepts and properties related to statistical methods, probability distributions and other concepts related to statistical analysis, including relationships to study designs and plots.",
-    "download": "http://purl.obolibrary.org/obo/stato.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/stato.owl",
     "homepage": "http://stato-ontology.org/",
     "name": "STATO: the statistical methods ontology",
     "prefix": "stato",
@@ -1798,7 +1790,7 @@
   },
   "swo": {
     "description": "The Software Ontology (SWO) is a resource for describing software tools, their types, tasks, versions, provenance and associated data. It contains detailed information on licensing and formats as well as software applications themselves, mainly (but not limited) to the bioinformatics community.",
-    "download": "http://purl.obolibrary.org/obo/swo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/swo.owl",
     "homepage": "https://github.com/allysonlister/swo",
     "name": "Software ontology",
     "prefix": "swo",
@@ -1807,7 +1799,7 @@
   },
   "symp": {
     "description": "The Symptom Ontology has been developed as a standardized ontology for symptoms of human diseases.",
-    "download": "http://purl.obolibrary.org/obo/symp.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/symp.owl",
     "homepage": "http://symptomontologywiki.igs.umaryland.edu/mediawiki/index.php/Main_Page",
     "name": "Symptom Ontology",
     "prefix": "symp",
@@ -1816,7 +1808,7 @@
   },
   "t4fs": {
     "description": "A terminology for the skills necessary to make data FAIR and to keep it FAIR.",
-    "download": "http://purl.obolibrary.org/obo/t4fs.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/t4fs.owl",
     "homepage": "https://github.com/terms4fairskills/FAIRterminology",
     "name": "terms4FAIRskills",
     "prefix": "t4fs",
@@ -1825,7 +1817,7 @@
   },
   "tads": {
     "description": "The anatomy of the Tick, <i>Families: Ixodidae, Argassidae</i>",
-    "download": "http://purl.obolibrary.org/obo/tads.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/tads.owl",
     "homepage": "https://www.vectorbase.org/ontology-browser",
     "name": "Tick Anatomy Ontology",
     "prefix": "tads",
@@ -1842,7 +1834,7 @@
   },
   "taxrank": {
     "description": "A vocabulary of taxonomic ranks (species, family, phylum, etc)",
-    "download": "http://purl.obolibrary.org/obo/taxrank.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/taxrank.owl",
     "homepage": "https://github.com/phenoscape/taxrank",
     "name": "Taxonomic rank vocabulary",
     "prefix": "taxrank",
@@ -1851,7 +1843,7 @@
   },
   "teddy": {
     "description": "TEDDY is an ontology for dynamical behaviours, observable dynamical phenomena, and control elements of bio-models and biological systems in Systems and Synthetic Biology.",
-    "download": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/teddy-inferred-fixed.owl",
+    "download_owl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/teddy-inferred-fixed.owl",
     "name": "Terminology for Description of Dynamics",
     "prefix": "teddy",
     "version": "2014-04-24",
@@ -1859,7 +1851,7 @@
   },
   "tgma": {
     "description": "A structured controlled vocabulary of the anatomy of mosquitoes.",
-    "download": "http://purl.obolibrary.org/obo/tgma.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/tgma.owl",
     "homepage": "https://www.vectorbase.org/ontology-browser",
     "name": "Mosquito gross anatomy ontology",
     "prefix": "tgma",
@@ -1868,7 +1860,7 @@
   },
   "to": {
     "description": "A controlled vocabulary to describe phenotypic traits in plants.",
-    "download": "http://purl.obolibrary.org/obo/to.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/to.owl",
     "homepage": "http://browser.planteome.org/amigo",
     "name": "Plant Trait Ontology",
     "prefix": "to",
@@ -1877,7 +1869,7 @@
   },
   "trans": {
     "description": "The Pathogen Transmission Ontology describes the tranmission methods of human disease pathogens describing how a pathogen is transmitted from one host, reservoir, or source to another host. The pathogen transmission may occur either directly or indirectly and may involve animate vectors or inanimate vehicles.",
-    "download": "http://purl.obolibrary.org/obo/trans.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/trans.owl",
     "homepage": "https://github.com/DiseaseOntology/PathogenTransmissionOntology",
     "name": "Pathogen Transmission Ontology",
     "prefix": "trans",
@@ -1886,14 +1878,14 @@
   },
   "tto": {
     "description": "An ontology covering the taxonomy of teleosts (bony fish)",
-    "download": "http://purl.obolibrary.org/obo/tto.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/tto.owl",
     "homepage": "https://github.com/phenoscape/teleost-taxonomy-ontology",
     "name": "Teleost taxonomy ontology",
     "prefix": "tto"
   },
   "txpo": {
     "description": "Elucidating the mechanism of toxicity is crucial in drug safety evaluations. TOXic Process Ontology (TXPO) systematizes a wide variety of terms involving toxicity courses and processes. The first version of TXPO focuses on liver toxicity.\n\nThe TXPO contains an is-a hierarchy that is organized into three layers: the top layer contains general terms, mostly derived from the Basic Formal Ontology. The intermediate layer contains biomedical terms in OBO foundry from UBERON, Cell Ontology, NCBI Taxon, ChEBI, Gene Ontology, PATO, OGG, INOH, HINO, NCIT, DOID and Relational ontology (RO). The lower layer contains toxicological terms.\n\nIn applied work, we have developed a prototype of TOXPILOT, a TOXic Process InterpretabLe knOwledge sysTem. TOXPILOT provides visualization maps of the toxic course, which facilitates capturing the comprehensive picture for understanding toxicity mechanisms. A prototype of TOXPILOT is available: https://toxpilot.nibiohn.go.jp",
-    "download": "http://purl.obolibrary.org/obo/txpo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/txpo.owl",
     "homepage": "https://toxpilot.nibiohn.go.jp/",
     "name": "TOXic Process Ontology (TXPO)",
     "prefix": "txpo",
@@ -1902,7 +1894,7 @@
   },
   "uberon": {
     "description": "Uberon is an integrated cross-species anatomy ontology representing a variety of entities classified according to traditional anatomical criteria such as structure, function and developmental lineage. The ontology includes comprehensive relationships to taxon-specific anatomical ontologies, allowing integration of functional, phenotype and expression data.",
-    "download": "http://purl.obolibrary.org/obo/uberon.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/uberon.owl",
     "homepage": "http://uberon.org",
     "name": "Uber-anatomy ontology",
     "prefix": "uberon",
@@ -1912,14 +1904,14 @@
   "unimod": {
     "contact": "psidev-ms-vocab@lists.sourceforge.net",
     "description": "Unimod is a community supported, comprehensive database of protein modifications for mass spectrometry applications. That is, accurate and verifiable values, derived from elemental compositions, for the mass differences introduced by all types of natural and artificial modifications. Other important information includes any mass change, (neutral loss), that occurs during MS/MS analysis, an d site specificity, (which residues are susceptible to modification and any constraints on the position of the modification within the protein or peptide).",
-    "download": "https://raw.githubusercontent.com/PRIDE-Utilities/pride-ontology/master/unimod.owl",
+    "download_owl": "https://raw.githubusercontent.com/PRIDE-Utilities/pride-ontology/master/unimod.owl",
     "homepage": "http://www.unimod.org/",
     "name": "Unimod protein modification database for mass spectrometry",
     "prefix": "unimod"
   },
   "uo": {
     "description": "Metrical units for use in conjunction with PATO",
-    "download": "http://purl.obolibrary.org/obo/uo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/uo.owl",
     "homepage": "https://github.com/bio-ontology-research-group/unit-ontology",
     "name": "Units of measurement ontology",
     "prefix": "uo",
@@ -1928,7 +1920,7 @@
   },
   "upa": {
     "description": "A manually curated resource for the representation and annotation of metabolic pathways",
-    "download": "http://purl.obolibrary.org/obo/upa.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/upa.owl",
     "homepage": "https://github.com/geneontology/unipathway",
     "name": "Unipathway",
     "prefix": "upa",
@@ -1937,7 +1929,7 @@
   },
   "vbo": {
     "description": "Vertebrate Breed Ontology is an ontology created to serve as a single computable resource for vertebrate breed names.",
-    "download": "http://purl.obolibrary.org/obo/vbo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/vbo.owl",
     "homepage": "https://github.com/monarch-initiative/vertebrate-breed-ontology",
     "name": "Vertebrate Breed Ontology",
     "prefix": "vbo",
@@ -1946,7 +1938,7 @@
   },
   "vo": {
     "description": "The Vaccine Ontology (VO) is a community-based biomedical ontology in the domain of vaccine and vaccination. VO aims to standardize vaccine types and annotations, integrate various vaccine data, and support computer-assisted reasoning. The VO supports basic vaccine R&D and clincal vaccine usage. VO is being developed as a community-based ontology with support and collaborations from the vaccine and bio-ontology communities.",
-    "download": "http://purl.obolibrary.org/obo/vo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/vo.owl",
     "homepage": "http://www.violinet.org/vaccineontology",
     "name": "Vaccine Ontology",
     "prefix": "vo",
@@ -1962,14 +1954,14 @@
   },
   "vt": {
     "description": "The Vertebrate Trait Ontology is a controlled vocabulary for the description of traits (measurable or observable characteristics) pertaining to the morphology, physiology, or development of vertebrate organisms.",
-    "download": "http://purl.obolibrary.org/obo/vt.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/vt.owl",
     "homepage": "https://github.com/AnimalGenome/vertebrate-trait-ontology",
     "name": "The Vertebrate Trait Ontology",
     "prefix": "vt"
   },
   "vto": {
     "description": "Comprehensive hierarchy of extinct and extant vertebrate taxa.",
-    "download": "http://purl.obolibrary.org/obo/vto.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/vto.owl",
     "homepage": "https://github.com/phenoscape/vertebrate-taxonomy-ontology",
     "name": "Vertebrate Taxonomy Ontology",
     "prefix": "vto",
@@ -1978,7 +1970,7 @@
   },
   "wbbt": {
     "description": "Ontology about the gross anatomy of the C. elegans",
-    "download": "http://purl.obolibrary.org/obo/wbbt.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/wbbt.owl",
     "homepage": "https://github.com/obophenotype/c-elegans-gross-anatomy-ontology",
     "name": "C. elegans Gross Anatomy Ontology",
     "prefix": "wbbt",
@@ -1987,7 +1979,7 @@
   },
   "wbls": {
     "description": "Ontology about the development and life stages of the C. elegans",
-    "download": "http://purl.obolibrary.org/obo/wbls.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/wbls.owl",
     "homepage": "https://github.com/obophenotype/c-elegans-development-ontology",
     "name": "C. elegans Development Ontology",
     "prefix": "wbls",
@@ -1996,7 +1988,7 @@
   },
   "wbphenotype": {
     "description": "Ontology about C. elegans and other nematode phenotypes",
-    "download": "http://purl.obolibrary.org/obo/wbphenotype.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/wbphenotype.owl",
     "homepage": "https://github.com/obophenotype/c-elegans-phenotype-ontology",
     "name": "C elegans Phenotype Ontology",
     "prefix": "wbphenotype",
@@ -2005,7 +1997,7 @@
   },
   "xao": {
     "description": "XAO represents the anatomy and development of the African frogs Xenopus laevis and tropicalis.",
-    "download": "http://purl.obolibrary.org/obo/xao.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/xao.owl",
     "homepage": "http://www.xenbase.org/anatomy/xao.do?method=display",
     "name": "Xenopus Anatomy Ontology",
     "prefix": "xao",
@@ -2014,7 +2006,7 @@
   },
   "xco": {
     "description": "Conditions under which physiological and morphological measurements are made both in the clinic and in studies involving humans or model organisms.",
-    "download": "http://purl.obolibrary.org/obo/xco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/xco.owl",
     "homepage": "https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=XCO:0000000",
     "name": "Experimental condition ontology",
     "prefix": "xco",
@@ -2024,7 +2016,7 @@
   "xlmod": {
     "contact": "psidev-ms-vocab@lists.sourceforge.net",
     "description": "A structured controlled vocabulary for cross-linking reagents used with proteomics mass spectrometry.",
-    "download": "http://purl.obolibrary.org/obo/xlmod.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/xlmod.owl",
     "homepage": "http://www.psidev.info/groups/controlled-vocabularies",
     "name": "HUPO-PSI cross-linking and derivatization reagents controlled vocabulary",
     "prefix": "xlmod",
@@ -2033,7 +2025,7 @@
   },
   "xpo": {
     "description": "XPO represents anatomical, cellular, and gene function phenotypes occurring throughout the development of the African frogs Xenopus laevis and tropicalis.",
-    "download": "http://purl.obolibrary.org/obo/xpo.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/xpo.owl",
     "homepage": "https://github.com/obophenotype/xenopus-phenotype-ontology",
     "name": "Xenopus Phenotype Ontology",
     "prefix": "xpo",
@@ -2042,7 +2034,7 @@
   },
   "zeco": {
     "description": "Ontology of Zebrafish Experimental Conditions",
-    "download": "http://purl.obolibrary.org/obo/zeco.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/zeco.owl",
     "homepage": "https://github.com/ybradford/zebrafish-experimental-conditions-ontology",
     "name": "Zebrafish Experimental Conditions Ontology",
     "prefix": "zeco",
@@ -2051,7 +2043,7 @@
   },
   "zfa": {
     "description": "ZFA description.",
-    "download": "http://purl.obolibrary.org/obo/zfa.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/zfa.owl",
     "homepage": "https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources",
     "name": "Zebrafish Anatomy Ontology (ZFA)",
     "prefix": "zfa",
@@ -2060,7 +2052,7 @@
   },
   "zfs": {
     "description": "Developmental stages of the Zebrafish",
-    "download": "http://purl.obolibrary.org/obo/zfs.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/zfs.owl",
     "homepage": "https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources",
     "name": "Zebrafish developmental stages ontology",
     "prefix": "zfs",
@@ -2069,7 +2061,7 @@
   },
   "zp": {
     "description": "The Zebrafish Phenotype Ontology formally defines all phenotypes of the Zebrafish model organism.",
-    "download": "http://purl.obolibrary.org/obo/zp.owl",
+    "download_owl": "http://purl.obolibrary.org/obo/zp.owl",
     "homepage": "https://github.com/obophenotype/zebrafish-phenotype-ontology",
     "name": "Zebrafish Phenotype Ontology (ZP)",
     "prefix": "zp",

--- a/src/bioregistry/data/mismatch.json
+++ b/src/bioregistry/data/mismatch.json
@@ -71,6 +71,9 @@
     "miriam": "gro",
     "obofoundry": "gro"
   },
+  "hpath": {
+    "fairsharing": "FAIRsharing.kj336a"
+  },
   "icdo": {
     "bioportal": "ICDO",
     "ontobee": "ICDO"

--- a/src/bioregistry/external/ols.py
+++ b/src/bioregistry/external/ols.py
@@ -71,7 +71,7 @@ def get_ols(force_download: bool = False):
         config = get_ols_processing().get(ols_id)
         if config is None:
             if ols_id not in OLS_SKIP:
-                logger.warning("need to curate processing file for OLS prefix %s", ols_id)
+                logger.warning("[%s] need to curate processing file", ols_id)
             continue
         processed[ols_id] = _process(ontology, config)
 
@@ -212,7 +212,6 @@ def _process(  # noqa:C901
         "prefix": ols_id,
         # "preferred_prefix": config["preferredPrefix"],
         "name": title,
-        "download": _clean_url(config["fileLocation"]),
         "version.iri": _clean_url(version_iri),
         "version": _get_version(ols_id, config, processing),
         "description": description,
@@ -221,6 +220,17 @@ def _process(  # noqa:C901
         "contact": _get_email(ols_id, config),
         "license": _get_license(ols_id, config),
     }
+    download = _clean_url(config["fileLocation"])
+    if download is None:
+        pass
+    elif download.endswith(".obo"):
+        rv["download_obo"] = download
+    elif download.endswith(".owl"):
+        rv["download_owl"] = download
+    elif download.endswith(".rdf") or download.endswith(".ttl"):
+        rv["download_rdf"] = download
+    else:
+        logger.warning(f"[%s] unknown download type %s", ols_id, download)
     rv = {k: v.strip() for k, v in rv.items() if v}
     return rv
 

--- a/src/bioregistry/external/ols.py
+++ b/src/bioregistry/external/ols.py
@@ -230,7 +230,7 @@ def _process(  # noqa:C901
     elif download.endswith(".rdf") or download.endswith(".ttl"):
         rv["download_rdf"] = download
     else:
-        logger.warning(f"[%s] unknown download type %s", ols_id, download)
+        logger.warning("[%s] unknown download type %s", ols_id, download)
     rv = {k: v.strip() for k, v in rv.items() if v}
     return rv
 

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -255,6 +255,11 @@
           "description": "The URI format string, which must have at least one ``$1`` in it. Note that this field is generic enough to accept IRIs. See the URI specification (https://www.rfc-editor.org/rfc/rfc3986) and IRI specification (https://www.ietf.org/rfc/rfc3987.txt) for more information.",
           "type": "string"
         },
+        "uri_format_resolvable": {
+          "title": "URI format string resolvable",
+          "description": "If false, denotes if the URI format string is known to be not resolvable",
+          "type": "boolean"
+        },
         "rdf_uri_format": {
           "title": "RDF URI format string",
           "description": "The RDF URI format string, which must have at least one ``$1`` in it. Note that this field is generic enough to accept IRIs. See the URI specification (https://www.rfc-editor.org/rfc/rfc3986) and IRI specification (https://www.ietf.org/rfc/rfc3987.txt) for more information.",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -300,7 +300,7 @@ class Resource(BaseModel):
     uri_format_resolvable: Optional[bool] = Field(
         default=None,
         title="URI format string resolvable",
-        description=f"If false, denotes if the URI format string is known to be not resolvable",
+        description="If false, denotes if the URI format string is known to be not resolvable",
     )
     rdf_uri_format: Optional[str] = Field(
         default=None,
@@ -1983,9 +1983,9 @@ class Resource(BaseModel):
         if self.download_obo:
             return self.download_obo
         return (
-                self.get_external("obofoundry").get("download.obo")
-                or self.get_external("ols").get("download_obo")
-                or self.get_external("aberowl").get("download_obo")
+            self.get_external("obofoundry").get("download.obo")
+            or self.get_external("ols").get("download_obo")
+            or self.get_external("aberowl").get("download_obo")
         )
 
     def get_download_obograph(self) -> Optional[str]:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1996,7 +1996,7 @@ class Resource(BaseModel):
 
     def get_download_rdf(self) -> Optional[str]:
         """Get the download link for the latest RDF file."""
-        return self.download_rdf
+        return self.download_rdf or self.get_external("ols").get("download_rdf")
 
     def get_download_owl(self) -> Optional[str]:
         """Get the download link for the latest OWL file.

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -297,6 +297,11 @@ class Resource(BaseModel):
         title="URI format string",
         description=f"The URI format string, which must have at least one ``$1`` in it. {URI_IRI_INFO}",
     )
+    uri_format_resolvable: Optional[bool] = Field(
+        default=None,
+        title="URI format string resolvable",
+        description=f"If false, denotes if the URI format string is known to be not resolvable",
+    )
     rdf_uri_format: Optional[str] = Field(
         default=None,
         title="RDF URI format string",
@@ -1964,6 +1969,10 @@ class Resource(BaseModel):
         >>> get_resource("bfo").get_download_obo()
         'http://purl.obolibrary.org/obo/bfo.obo'
 
+        Get ontology download link from OLS where OWL isn't available
+        >>> get_resource("hpath").get_download_obo()
+        'https://raw.githubusercontent.com/Novartis/hpath/master/src/hpath.obo'
+
         Get ontology download link in AberOWL but not OBO Foundry
         (note this might change over time so the exact value isn't
         used in the doctest):
@@ -1973,9 +1982,11 @@ class Resource(BaseModel):
         """
         if self.download_obo:
             return self.download_obo
-        return self.get_external("obofoundry").get("download.obo") or self.get_external(
-            "aberowl"
-        ).get("download_obo")
+        return (
+                self.get_external("obofoundry").get("download.obo")
+                or self.get_external("ols").get("download_obo")
+                or self.get_external("aberowl").get("download_obo")
+        )
 
     def get_download_obograph(self) -> Optional[str]:
         """Get the download link for the latest OBOGraph JSON file."""
@@ -2017,7 +2028,7 @@ class Resource(BaseModel):
         return (
             self.get_external("obofoundry").get("download.owl")
             or self.get_external("ols").get("version.iri")
-            or self.get_external("ols").get("download")
+            or self.get_external("ols").get("download_owl")
             or self.get_external("aberowl").get("download_owl")
         )
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -963,7 +963,8 @@ class TestRegistry(unittest.TestCase):
         for prefix, resource in self.registry.items():
             if resource.uri_format_resolvable is not False:
                 continue
-            self.assertIsNotNone(
-                resource.comment,
-                msg="Any resource with a non-resolvable URI format needs a comment as to why",
-            )
+            with self.subTest(prefix=prefix):
+                self.assertIsNotNone(
+                    resource.comment,
+                    msg="Any resource with a non-resolvable URI format needs a comment as to why",
+                )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -957,3 +957,13 @@ class TestRegistry(unittest.TestCase):
                     self.assert_contact_metadata(resource.contact)
                 for owner in resource.owners:
                     self.assertTrue(owner.ror is not None or owner.wikidata is not None)
+
+    def test_resolvable_annotation(self):
+        """Test resolvability annotations."""
+        for prefix, resource in self.registry.items():
+            if resource.uri_format_resolvable is not False:
+                continue
+            self.assertIsNotNone(
+                resource.comment,
+                msg="Any resource with a non-resolvable URI format needs a comment as to why",
+            )


### PR DESCRIPTION
Closes #927

This PR does the following:

- [x] Adds a new boolean field `uri_format_resolvable` so we can explicitly annotate when URI format strings are known to not be resolvable
- [x] Adds a note on to the page for a resource when this flag is set to true
- [x] Updates OLS download processing to more carefully annotate if the download is OWL, OBO, RDF, or other