### PR TITLE
Fix Integbio downloader

### DIFF
--- a/src/bioregistry/data/external/integbio/processed.json
+++ b/src/bioregistry/data/external/integbio/processed.json
@@ -9820,7 +9820,7 @@
   "maintainer": "Osaka University Institute for Protein Research",
   "name": "Mouse Basement Membrane Bodymap",
   "prefix": "NBDC00574",
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Protein"
   ]
@@ -13838,7 +13838,7 @@
   "maintainer": "NARO (National Agriculture and Food Research Organization)",
   "name": "NIAS Genebank : Illustrations of Plant",
   "prefix": "NBDC00893",
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Organism"
   ]
@@ -15824,7 +15824,7 @@
    "18266924",
    "24949426"
   ],
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Metabolite"
   ]
@@ -22126,7 +22126,7 @@
   "maintainer": "BC Cancer Agency's Genome Sciences Centre||McGill University",
   "name": "CEEHRC NETWORK",
   "prefix": "NBDC01657",
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Genome/Gene",
    "Epigenetics",
@@ -22348,7 +22348,7 @@
   "pubmeds": [
    "20833631"
   ],
-  "status": "Inactive",
+  "status": "Active",
   "target_keywords": [
    "Genome/Gene"
   ]
@@ -27577,7 +27577,7 @@
   "pubmeds": [
    "25352549"
   ],
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Genetic variation",
    "Genome/Gene",
@@ -29454,7 +29454,7 @@
    "16964256",
    "16381918"
   ],
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "RNA",
    "Genome/Gene",
@@ -36376,7 +36376,7 @@
   "pubmeds": [
    "25428362"
   ],
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Genome/Gene",
    "cDNA/EST"
@@ -37181,7 +37181,7 @@
   "pubmeds": [
    "30202990"
   ],
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Genome/Gene",
    "DNA",
@@ -37247,7 +37247,7 @@
   "pubmeds": [
    "30285246"
   ],
-  "status": "Active",
+  "status": "Inactive",
   "target_keywords": [
    "Genome/Gene",
    "RNA"


### PR DESCRIPTION
It turns out that they delete their old dumps and post new ones with a different file name on each release, so this PR adds scraping functionality to get the current download URL.