### PR TITLE
Fix new prefix action code, add missing publications key

### DIFF
--- a/src/bioregistry/gh/new_prefix.py
+++ b/src/bioregistry/gh/new_prefix.py
@@ -50,6 +50,7 @@ MAPPING = {
     "License": "license",
     "Repository": "repository",  # old
     "Source Code Repository": "repository",
+    "Publications": "publications",
 }
 
 ORCID_HTTP_PREFIX = "http://orcid.org/"


### PR DESCRIPTION
This PR adds a mapping from the issue template yaml to an internal data key allowing to process publications submitted as part of the new prefix request form (which was enabled in https://github.com/biopragmatics/bioregistry/pull/1000). This should fix the error in  https://github.com/biopragmatics/bioregistry/actions/runs/7633346253/job/20795375392.