### PR TITLE
Proactively update Prefix.cc

### DIFF
--- a/.github/workflows/update_prefix_cc.yml
+++ b/.github/workflows/update_prefix_cc.yml
@@ -1,0 +1,22 @@
+name: Send data to Prefix.cc
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: pip install tox tox-uv
+
+      - name: Send a prefix to Prefix.cc
+        run: tox -e send-prefixcc

--- a/.github/workflows/update_prefix_cc.yml
+++ b/.github/workflows/update_prefix_cc.yml
@@ -2,7 +2,7 @@ name: Send data to Prefix.cc
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "5 4 * * *"  # run at 4:05 in the morning (cron format is minute hour day month day, check https://crontab.guru)
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/bioregistry/export/prefixcc.py
+++ b/src/bioregistry/export/prefixcc.py
@@ -3,7 +3,9 @@
 .. seealso:: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1038
 """
 
+import click
 import requests
+
 import bioregistry
 
 
@@ -29,9 +31,9 @@ def main():
             # both available and correct wrt Bioregistry/OBO
             continue
 
-        print("Attempting to create a record for", record.prefix, uri_prefix)
+        click.echo(f"Attempting to create a record for {record.prefix} {uri_prefix}")
         res = create(record.prefix, uri_prefix)
-        print(res.text)
+        click.echo(res.text)
 
         # We're breaking here since we can only make one
         # update per day

--- a/src/bioregistry/export/prefixcc.py
+++ b/src/bioregistry/export/prefixcc.py
@@ -1,0 +1,42 @@
+"""Update Prefix.cc to reflect the content of the Bioregistry.
+
+.. seealso:: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1038
+"""
+
+import requests
+import bioregistry
+
+
+def create(curie_prefix: str, uri_prefix: str) -> requests.Response:
+    """Send a CURIE prefix/URI prefix to the Prefix.cc "create" endpoint."""
+    return requests.post(
+        f"https://prefix.cc/{curie_prefix}",
+        data={"create": uri_prefix},
+    )
+
+
+def main():
+    """Add an OBO Foundry prefix to Prefix.cc."""
+    prefix_cc_map = requests.get("https://prefix.cc/context").json()["@context"]
+    for record in bioregistry.resources():
+        if not record.get_obofoundry_prefix():
+            continue
+        uri_prefix = record.get_uri_prefix()
+        if not uri_prefix:
+            continue
+        if uri_prefix == prefix_cc_map.get(record.prefix):
+            # No need to re-create something that's already
+            # both available and correct wrt Bioregistry/OBO
+            continue
+
+        print("Attempting to create a record for", record.prefix, uri_prefix)
+        res = create(record.prefix, uri_prefix)
+        print(res.text)
+
+        # We're breaking here since we can only make one
+        # update per day
+        break
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -197,6 +197,12 @@ commands =
     erdantic bioregistry.Registry bioregistry.Resource -o docs/img/datamodel_umls.svg
     erdantic bioregistry.Registry bioregistry.Resource -o docs/img/datamodel_umls.png
 
+[testenv:send-prefixcc]
+usedevelop = true
+commands =
+    python -m bioregistry.export.prefixcc
+description = Send a Bioregistry CURIE prefix/URI prefix pair to Prefix.cc via its "create" API endpoint. Note that only one request to this endpoint can be sent per day.
+
 ####################
 # Deployment tools #
 ####################

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,10 @@ description = Lint the Bioregistry data
 deps =
     mypy
     pydantic
+    types-PyYAML
+    types-Markdown
+    types-tabulate
+    types-requests
 skip_install = true
 commands = mypy --install-types --non-interactive --ignore-missing-imports src/bioregistry/
 description = Run the mypy tool to check static typing on the project.


### PR DESCRIPTION
References https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1038

Prefix.cc is a website that allows for public curation of CURIE prefix/URI prefix pairs that are useful in semantic web applications. Users can submit new CURIE prefixes, add additional URI prefixes to existing CURIE prefixes, and up- or down-vote URI prefixes for a given CURIE prefix. This can all be done from the website at https://prefix.cc or by its secret API.

To protect from abuse, these actions are limited both on the website and API to one creation and one vote per day. Interestingly, Prefix.cc has an [RSS feed](https://prefix.cc/latest.rss) of when new content is added. It shows that there isn't typically more than one interaction with the underlying database per day. However, Prefix.cc nevertheless has vandalism, including URI prefixes that link to elicit websites.

Though it is a generic system, its content mostly reflects semantic web and information science, with a few life and natural sciences prefixes included. This falls within scope for the Bioregistry, but so far, we don't automatically ingest Prefix.cc because 1) it doesn't include any context to go with CURIE prefix/URI prefix pairs, 2) its scope isn't generally overlapping enough, 3) it includes a lot of vandalism, and since the Bioregistry copies data wholesale, this skeeves me out (e.g., I don't want the Bioregistry to include explicitly references to pornographic sites in its cached data). That all being said, Prefix.cc does include a lot of interesting prefixes that could supplement the Bioregistry, and we could incrementally identify parts of Prefix.cc to curate more carefully.

For now, this PR automates updating Prefix.cc with content from the Bioregistry on a nightly basis in GitHub Actions, to better include life science content in it. Unfortunately, because of the rate limit of one request to Prefix.cc's creation endpoint per day, this is going to take a while!


