### PR TITLE
Fix Pydantic models for health report

### DIFF
--- a/docs/health.md
+++ b/docs/health.md
@@ -7,7 +7,7 @@ permalink: /health/
 
 Of the {{ run.summary.total_measured }} prefixes in the Bioregistry that have
 both an example local unique identifiers and at least one URI format string,
-{{ run.summary.total_success }} 
+{{ run.summary.total_success }} ({{ run.summary.success_percent }}%)
 were able to resolve (with a HTTP 200 status code) and {{ run.summary.total_failed }}
 ({{ run.summary.failure_percent }}%) were not.
 

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -29,10 +29,10 @@ class ProviderStatus(BaseModel):
     """A container for provider information."""
 
     prefix: str = Field(...)
-    example: str= Field(...)
-    url: str= Field(...)
+    example: str = Field(...)
+    url: str = Field(...)
     status_code: Optional[int] = Field(None)
-    failed: bool= Field(...)
+    failed: bool = Field(...)
     exception: Optional[str] = Field(None)
     context: Optional[str] = Field(None)
 
@@ -84,7 +84,9 @@ class Run(BaseModel):
     date: str = Field(default_factory=lambda: datetime.datetime.now().strftime("%Y-%m-%d"))
     results: List[ProviderStatus]
     summary: Summary
-    delta: Optional[Delta] = Field(None, description="Information about the changes since the last run")
+    delta: Optional[Delta] = Field(
+        None, description="Information about the changes since the last run"
+    )
 
 
 class Database(BaseModel):

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -28,13 +28,13 @@ HEALTH_YAML_PATH = DOCS_DATA.joinpath("health.yaml")
 class ProviderStatus(BaseModel):
     """A container for provider information."""
 
-    prefix: str
-    example: str
-    url: str
-    status_code: Optional[int]
-    failed: bool
-    exception: Optional[str]
-    context: Optional[str]
+    prefix: str = Field(...)
+    example: str= Field(...)
+    url: str= Field(...)
+    status_code: Optional[int] = Field(None)
+    failed: bool= Field(...)
+    exception: Optional[str] = Field(None)
+    context: Optional[str] = Field(None)
 
 
 class Summary(BaseModel):
@@ -84,7 +84,7 @@ class Run(BaseModel):
     date: str = Field(default_factory=lambda: datetime.datetime.now().strftime("%Y-%m-%d"))
     results: List[ProviderStatus]
     summary: Summary
-    delta: Optional[Delta] = Field(description="Information about the changes since the last run")
+    delta: Optional[Delta] = Field(None, description="Information about the changes since the last run")
 
 
 class Database(BaseModel):


### PR DESCRIPTION
This PR fixes an issue where old runs in the Bioregistry health report didn't validate against the current pydantic model. I wrote a script that calculated the missing data and also made "delta" optional since the first item on the list will never have a delta. It also re-runs the health report