### PR TITLE
Add license for ORDO and update OBO Foundry patterns/examples

### DIFF
--- a/src/bioregistry/data/external/miriam/processed.json
+++ b/src/bioregistry/data/external/miriam/processed.json
@@ -1512,6 +1512,18 @@
     "sampleId": "57-27-2",
     "uri_format": "https://chem.nlm.nih.gov/chemidplus/rn/$1"
   },
+  "cheminf": {
+    "deprecated": false,
+    "description": "The chemical information ontology (cheminf) describes information entities about chemical entities. It provides qualitative and quantitative attributes to richly describe chemicals.",
+    "homepage": "https://www.ebi.ac.uk/ols4/ontologies/cheminf",
+    "id": "00001045",
+    "name": "Chemical Information Ontology",
+    "namespaceEmbeddedInLui": true,
+    "pattern": "^CHEMINF:\\d+$",
+    "prefix": "cheminf",
+    "sampleId": "000306",
+    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/cheminf/classes?obo_id=CHEMINF:$1"
+  },
   "chemspider": {
     "deprecated": false,
     "description": "ChemSpider is a collection of compound data from across the web, which aggregates chemical structures and their associated information into a single searchable repository entry. These entries are supplemented with additional properties, related information and links back to original data sources.",
@@ -5682,6 +5694,18 @@
     "sampleId": "0001073",
     "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/maxo/terms?obo_id=MAXO:$1"
   },
+  "mcro": {
+    "deprecated": false,
+    "description": "An ontology representing the model card structure, he aim of this work is to describe machine learning models to communicate information about specific details about the model (trade offs, intended users, licensing, etc.). ",
+    "homepage": "https://www.ebi.ac.uk/ols4/ontologies/mcro",
+    "id": "00001049",
+    "name": "Model Card Ontology",
+    "namespaceEmbeddedInLui": true,
+    "pattern": "^MCRO:\\d+$",
+    "prefix": "mcro",
+    "sampleId": "0000027",
+    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/mcro/classes?obo_id=MCRO:$1"
+  },
   "mdm": {
     "deprecated": false,
     "description": "The MDM (Medical Data Models) Portal is a meta-data registry for creating, analysing, sharing and reusing medical forms. Electronic forms are central in numerous processes involving data, including the collection of data through electronic health records (EHRs), Electronic Data Capture (EDC), and as case report forms (CRFs) for clinical trials. The MDM Portal provides medical forms in numerous export formats, facilitating the sharing and reuse of medical data models and exchange between information systems.",
@@ -7003,6 +7027,18 @@
     "sampleId": "880798137",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nuccore/$1"
   },
+  "obcs": {
+    "deprecated": false,
+    "description": "OBCS stands for the Ontology of Biological and Clinical Statistics. OBCS is an ontology in the domain of biological and clinical statistics. It is aligned with the Basic Formal Ontology (BFO) and the Ontology for Biomedical Investigations (OBI)",
+    "homepage": "https://www.ebi.ac.uk/ols4/ontologies/obcs",
+    "id": "00001053",
+    "name": " Ontology of Biological and Clinical Statistics",
+    "namespaceEmbeddedInLui": true,
+    "pattern": "^OBCS:\\d+$",
+    "prefix": "obcs",
+    "sampleId": "0000086",
+    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/obcs/classes?obo_id=OBCS:$1"
+  },
   "obi": {
     "deprecated": false,
     "description": "The Ontology for Biomedical Investigations (OBI) project is developing an integrated ontology for the description of biological and clinical investigations. The ontology will represent the design of an investigation, the protocols and instrumentation used, the material used, the data generated and the type analysis performed on it. Currently OBI is being built under the Basic Formal Ontology (BFO).",
@@ -7218,6 +7254,18 @@
     "prefix": "opb",
     "sampleId": "OPB_00573",
     "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1"
+  },
+  "opl": {
+    "deprecated": false,
+    "description": "The Ontology for Parasite Lifecycle (OPL) models the life cycle stage details of various parasites, including Trypanosoma sp., Leishmania major, and Plasmodium sp., etc.",
+    "homepage": "https://www.ebi.ac.uk/ols4/ontologies/opl",
+    "id": "00001047",
+    "name": "Ontology for Parasite Lifecycle",
+    "namespaceEmbeddedInLui": true,
+    "pattern": "^OPL:\\d+$",
+    "prefix": "opl",
+    "sampleId": "0000134",
+    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/opl/classes?obo_id=OPL:$1"
   },
   "opm": {
     "deprecated": false,
@@ -9314,6 +9362,18 @@
     "sampleId": "1a24",
     "uri_format": "http://psb.kobic.re.kr/STAP/refinement1/result.php?search=$1"
   },
+  "stato": {
+    "deprecated": false,
+    "description": "STATO is the statistical methods ontology. It contains concepts and properties related to statistical methods, probability distributions and other concepts related to statistical analysis, including relationships to study designs and plots.",
+    "homepage": "https://www.ebi.ac.uk",
+    "id": "00001051",
+    "name": "Statistical Ontology",
+    "namespaceEmbeddedInLui": true,
+    "pattern": "^STATO:\\d+$",
+    "prefix": "stato",
+    "sampleId": "0000138",
+    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/stato/classes?obo_id=STATO:$1"
+  },
   "stitch": {
     "deprecated": false,
     "description": "STITCH is a resource to explore known and predicted interactions of chemicals and proteins. Chemicals are linked to other chemicals and proteins by evidence derived from experiments, databases and the literature.",
@@ -9442,6 +9502,18 @@
     "prefix": "swissregulon",
     "sampleId": "AHR",
     "uri_format": "http://swissregulon.unibas.ch/query/$1"
+  },
+  "synapse": {
+    "deprecated": false,
+    "description": "Synapse is a collaborative, open-source research platform that allows teams to share data, track analyses, and collaborate.",
+    "homepage": "https://sagebionetworks.org",
+    "id": "00001043",
+    "name": "Synapse Data Repository",
+    "namespaceEmbeddedInLui": false,
+    "pattern": "[0-9]*\\.*[0-9]*",
+    "prefix": "synapse",
+    "sampleId": "41455251.1",
+    "uri_format": "https://repo-prod.prod.sagebase.org/ga4gh/drs/v1/objects/syn$1"
   },
   "t3db": {
     "deprecated": false,

--- a/src/bioregistry/data/external/miriam/raw.json
+++ b/src/bioregistry/data/external/miriam/raw.json
@@ -4,16 +4,16 @@
   "payload": {
     "namespaces": [
       {
-        "created": "2019-06-11T14:15:50.652+00:00",
+        "created": "2019-06-11T14:15:50.652+0000",
         "deprecated": true,
-        "deprecationDate": "2024-02-12T09:35:45.473+00:00",
+        "deprecationDate": "2024-02-12T09:35:45.473+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "3DMET is a database collecting three-dimensional structures of natural metabolites.",
         "id": 230,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000066",
-        "modified": "2024-02-12T09:37:02.753+00:00",
+        "modified": "2024-02-12T09:37:02.753+0000",
         "name": "3DMET",
         "namespaceEmbeddedInLui": false,
         "pattern": "^B\\d{5}$",
@@ -60,7 +60,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:31:54.933+00:00",
+        "created": "2022-02-27T20:31:54.933+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -69,7 +69,7 @@
         "id": 3152,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001020",
-        "modified": "2022-02-27T20:31:54.933+00:00",
+        "modified": "2022-02-27T20:31:54.933+0000",
         "name": "BioData Catalyst",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -116,7 +116,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-05T19:25:24.806+00:00",
+        "created": "2021-08-05T19:25:24.806+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -125,7 +125,7 @@
         "id": 2746,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000833",
-        "modified": "2021-08-05T19:25:24.806+00:00",
+        "modified": "2021-08-05T19:25:24.806+0000",
         "name": "4D Nucleome",
         "namespaceEmbeddedInLui": false,
         "pattern": "^4DN[A-Z]{2}[A-Z0-9]{7}$",
@@ -172,7 +172,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:34:03.581+00:00",
+        "created": "2022-02-27T20:34:03.581+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -181,7 +181,7 @@
         "id": 3174,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000934",
-        "modified": "2022-02-27T20:34:03.581+00:00",
+        "modified": "2022-02-27T20:34:03.581+0000",
         "name": "JCOIN Portal",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -228,7 +228,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:43.224+00:00",
+        "created": "2019-06-11T14:16:43.224+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -237,7 +237,7 @@
         "id": 814,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000277",
-        "modified": "2019-06-11T14:16:43.224+00:00",
+        "modified": "2019-06-11T14:16:43.224+0000",
         "name": "ABS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^A\\d+$",
@@ -284,7 +284,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:44.374+00:00",
+        "created": "2019-06-11T14:16:44.374+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -293,7 +293,7 @@
         "id": 829,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000282",
-        "modified": "2019-06-11T14:16:44.374+00:00",
+        "modified": "2019-06-11T14:16:44.374+0000",
         "name": "Aceview Worm",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z0-9-]+$",
@@ -340,7 +340,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:17.878+00:00",
+        "created": "2019-06-11T14:18:17.878+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -349,7 +349,7 @@
         "id": 1870,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000675",
-        "modified": "2019-06-11T14:18:17.878+00:00",
+        "modified": "2019-06-11T14:18:17.878+0000",
         "name": "Addgene Plasmid Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]{5}(-[a-zA-Z0-9-]{0,7})?$|^[0-9]{10}$",
@@ -396,7 +396,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:32.366+00:00",
+        "created": "2019-06-11T14:17:32.366+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -405,7 +405,7 @@
         "id": 1395,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000492",
-        "modified": "2019-06-11T14:17:32.366+00:00",
+        "modified": "2019-06-11T14:17:32.366+0000",
         "name": "Animal Diversity Web",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z_a-z]+$",
@@ -452,7 +452,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:10.647+00:00",
+        "created": "2019-06-11T14:17:10.647+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -461,7 +461,7 @@
         "id": 1142,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000394",
-        "modified": "2019-06-11T14:17:10.647+00:00",
+        "modified": "2019-06-11T14:17:10.647+0000",
         "name": "Affymetrix Probeset",
         "namespaceEmbeddedInLui": false,
         "pattern": "\\d{4,}((_[asx])?_at)?",
@@ -543,7 +543,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:14.756+00:00",
+        "created": "2019-06-11T14:17:14.756+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -552,7 +552,7 @@
         "id": 1192,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000411",
-        "modified": "2019-06-11T14:17:14.756+00:00",
+        "modified": "2019-06-11T14:17:14.756+0000",
         "name": "AFTOL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -599,7 +599,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:56.660+00:00",
+        "created": "2019-06-11T14:17:56.660+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -608,7 +608,7 @@
         "id": 1638,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000589",
-        "modified": "2019-06-11T14:17:56.660+00:00",
+        "modified": "2019-06-11T14:17:56.660+0000",
         "name": "AGRICOLA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -655,7 +655,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:55.214+00:00",
+        "created": "2019-06-11T14:16:55.214+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -664,7 +664,7 @@
         "id": 958,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000334",
-        "modified": "2019-06-11T14:16:55.214+00:00",
+        "modified": "2019-06-11T14:16:55.214+0000",
         "name": "Allergome",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -711,7 +711,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:12.793+00:00",
+        "created": "2019-06-11T14:16:12.793+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -720,7 +720,7 @@
         "id": 466,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000148",
-        "modified": "2019-06-11T14:16:12.793+00:00",
+        "modified": "2019-06-11T14:16:12.793+0000",
         "name": "AmoebaDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EDI_\\d+$",
@@ -767,7 +767,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:38.379+00:00",
+        "created": "2019-06-11T14:17:38.379+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -776,7 +776,7 @@
         "id": 1456,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000516",
-        "modified": "2019-06-11T14:17:38.379+00:00",
+        "modified": "2019-06-11T14:17:38.379+0000",
         "name": "Antibody Registry",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{6}$",
@@ -823,7 +823,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:12.204+00:00",
+        "created": "2019-06-11T14:16:12.204+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -832,7 +832,7 @@
         "id": 459,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000146",
-        "modified": "2019-06-11T14:16:12.204+00:00",
+        "modified": "2019-06-11T14:16:12.204+0000",
         "name": "AntWeb",
         "namespaceEmbeddedInLui": false,
         "pattern": "^casent\\d+(\\-D\\d+)?$",
@@ -879,7 +879,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:03.584+00:00",
+        "created": "2019-06-11T14:18:03.584+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -888,7 +888,7 @@
         "id": 1712,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000617",
-        "modified": "2019-06-11T14:18:03.584+00:00",
+        "modified": "2019-06-11T14:18:03.584+0000",
         "name": "AOPWiki",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -935,7 +935,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:12.154+00:00",
+        "created": "2019-06-11T14:18:12.154+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -944,7 +944,7 @@
         "id": 1811,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000652",
-        "modified": "2019-06-11T14:18:12.154+00:00",
+        "modified": "2019-06-11T14:18:12.154+0000",
         "name": "AOPWiki (Key Event)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -991,7 +991,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:12.357+00:00",
+        "created": "2019-06-11T14:18:12.357+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1000,7 +1000,7 @@
         "id": 1813,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000653",
-        "modified": "2019-06-11T14:18:12.357+00:00",
+        "modified": "2019-06-11T14:18:12.357+0000",
         "name": "AOPWiki (Key Event Relationship)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -1047,7 +1047,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:12.557+00:00",
+        "created": "2019-06-11T14:18:12.557+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1056,7 +1056,7 @@
         "id": 1815,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000654",
-        "modified": "2019-06-11T14:18:12.557+00:00",
+        "modified": "2019-06-11T14:18:12.557+0000",
         "name": "AOPWiki (Stressor)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -1103,7 +1103,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:43.451+00:00",
+        "created": "2019-06-11T14:16:43.451+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1112,7 +1112,7 @@
         "id": 817,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000278",
-        "modified": "2019-06-11T14:16:43.451+00:00",
+        "modified": "2019-06-11T14:16:43.451+0000",
         "name": "APD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{5}$",
@@ -1159,7 +1159,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:10.425+00:00",
+        "created": "2019-06-11T14:17:10.425+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1168,7 +1168,7 @@
         "id": 1139,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000393",
-        "modified": "2019-06-11T14:17:10.425+00:00",
+        "modified": "2019-06-11T14:17:10.425+0000",
         "name": "AphidBase Transcript",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ACYPI\\d{6}(-RA)?$",
@@ -1215,7 +1215,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:52.731+00:00",
+        "created": "2019-06-11T14:17:52.731+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1224,7 +1224,7 @@
         "id": 1603,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000576",
-        "modified": "2019-06-11T14:17:52.731+00:00",
+        "modified": "2019-06-11T14:17:52.731+0000",
         "name": "APID Interactomes",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\\.\\d+)?$",
@@ -1271,7 +1271,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:22.902+00:00",
+        "created": "2019-06-11T14:16:22.902+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1280,7 +1280,7 @@
         "id": 581,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000193",
-        "modified": "2019-06-11T14:16:22.902+00:00",
+        "modified": "2019-06-11T14:16:22.902+0000",
         "name": "ArachnoServer",
         "namespaceEmbeddedInLui": false,
         "pattern": "^AS\\d{6}$",
@@ -1327,7 +1327,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:40.104+00:00",
+        "created": "2019-06-11T14:17:40.104+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1336,7 +1336,7 @@
         "id": 1472,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000522",
-        "modified": "2019-06-11T14:17:40.104+00:00",
+        "modified": "2019-06-11T14:17:40.104+0000",
         "name": "Antibiotic Resistance Genes Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z_]{3}[0-9]{4,}$",
@@ -1383,7 +1383,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:57.583+00:00",
+        "created": "2019-06-11T14:17:57.583+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1392,7 +1392,7 @@
         "id": 1647,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000592",
-        "modified": "2023-01-31T08:16:22.071+00:00",
+        "modified": "2023-01-31T08:16:22.071+0000",
         "name": "Archival Resource Key (ARK)",
         "namespaceEmbeddedInLui": true,
         "pattern": "^(ark\\:)/*[0-9A-Za-z]+(?:/[\\w/.=*+@\\$-]*)?(?:\\?.*)?$",
@@ -1439,7 +1439,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:41.970+00:00",
+        "created": "2019-06-11T14:15:41.970+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1448,7 +1448,7 @@
         "id": 143,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000036",
-        "modified": "2019-06-11T14:15:41.970+00:00",
+        "modified": "2019-06-11T14:15:41.970+0000",
         "name": "ArrayExpress",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[AEP]-\\w{4}-\\d+$",
@@ -1530,7 +1530,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:46.944+00:00",
+        "created": "2019-06-11T14:16:46.944+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1539,7 +1539,7 @@
         "id": 861,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000294",
-        "modified": "2019-06-11T14:16:46.944+00:00",
+        "modified": "2019-06-11T14:16:46.944+0000",
         "name": "ArrayExpress Platform",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[AEP]-\\w{4}-\\d+$",
@@ -1586,7 +1586,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:04.557+00:00",
+        "created": "2019-06-11T14:18:04.557+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1595,7 +1595,7 @@
         "id": 1724,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000621",
-        "modified": "2019-06-11T14:18:04.557+00:00",
+        "modified": "2019-06-11T14:18:04.557+0000",
         "name": "ArrayMap",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[\\w\\-:,]{3,64}$",
@@ -1642,7 +1642,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:41.707+00:00",
+        "created": "2019-06-11T14:15:41.707+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1651,7 +1651,7 @@
         "id": 140,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000035",
-        "modified": "2019-06-11T14:15:41.707+00:00",
+        "modified": "2019-06-11T14:15:41.707+0000",
         "name": "arXiv",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(\\w+(\\-\\w+)?(\\.\\w+)?)?\\d{4,7}(\\.\\d+(v\\d+)?)?$",
@@ -1698,7 +1698,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:44.568+00:00",
+        "created": "2019-06-11T14:16:44.568+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1707,7 +1707,7 @@
         "id": 831,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000283",
-        "modified": "2019-06-11T14:16:44.568+00:00",
+        "modified": "2019-06-11T14:16:44.568+0000",
         "name": "ASAP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9-]+$",
@@ -1754,7 +1754,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:09.136+00:00",
+        "created": "2019-06-11T14:18:09.136+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1763,7 +1763,7 @@
         "id": 1777,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000641",
-        "modified": "2019-06-11T14:18:09.136+00:00",
+        "modified": "2019-06-11T14:18:09.136+0000",
         "name": "Astrophysics Source Code Library",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9\\.]+$",
@@ -1810,7 +1810,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:16.611+00:00",
+        "created": "2019-06-11T14:18:16.611+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1819,7 +1819,7 @@
         "id": 1856,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000670",
-        "modified": "2019-06-11T14:18:16.611+00:00",
+        "modified": "2019-06-11T14:18:16.611+0000",
         "name": "Amazon Standard Identification Number (ASIN)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]{10}$",
@@ -1866,7 +1866,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:14.975+00:00",
+        "created": "2019-06-11T14:17:14.975+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1875,7 +1875,7 @@
         "id": 1195,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000412",
-        "modified": "2019-06-11T14:17:14.975+00:00",
+        "modified": "2019-06-11T14:17:14.975+0000",
         "name": "AspGD Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z_0-9]+$",
@@ -1922,7 +1922,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:15.227+00:00",
+        "created": "2019-06-11T14:17:15.227+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1931,7 +1931,7 @@
         "id": 1198,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000413",
-        "modified": "2019-06-11T14:17:15.227+00:00",
+        "modified": "2019-06-11T14:17:15.227+0000",
         "name": "AspGD Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z_0-9]+$",
@@ -1978,7 +1978,7 @@
         "successor": null
       },
       {
-        "created": "2021-10-17T10:22:37.356+00:00",
+        "created": "2021-10-17T10:22:37.356+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -1987,7 +1987,7 @@
         "id": 2929,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000884",
-        "modified": "2021-10-17T10:22:37.356+00:00",
+        "modified": "2021-10-17T10:22:37.356+0000",
         "name": "Assembly",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9_\\.]+$",
@@ -2034,7 +2034,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:56.747+00:00",
+        "created": "2019-06-11T14:15:56.747+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2043,7 +2043,7 @@
         "id": 294,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000088",
-        "modified": "2019-06-11T14:15:56.747+00:00",
+        "modified": "2019-06-11T14:15:56.747+0000",
         "name": "Anatomical Therapeutic Chemical",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z](\\d+([A-Z]{1,2}(\\d+)?)?)?$",
@@ -2090,7 +2090,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:44.811+00:00",
+        "created": "2019-06-11T14:16:44.811+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2099,7 +2099,7 @@
         "id": 834,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000284",
-        "modified": "2019-06-11T14:16:44.811+00:00",
+        "modified": "2019-06-11T14:16:44.811+0000",
         "name": "ATCC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -2146,7 +2146,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:40.712+00:00",
+        "created": "2019-06-11T14:16:40.712+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2155,7 +2155,7 @@
         "id": 783,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000267",
-        "modified": "2019-06-11T14:16:40.712+00:00",
+        "modified": "2019-06-11T14:16:40.712+0000",
         "name": "Anatomical Therapeutic Chemical Vetinary",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Q[A-Z0-9]+$",
@@ -2202,7 +2202,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:51.241+00:00",
+        "created": "2019-06-11T14:16:51.241+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2211,7 +2211,7 @@
         "id": 911,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000316",
-        "modified": "2019-06-11T14:16:51.241+00:00",
+        "modified": "2019-06-11T14:16:51.241+0000",
         "name": "Animal TFDB Family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -2258,7 +2258,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:15.426+00:00",
+        "created": "2019-06-11T14:17:15.426+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2267,7 +2267,7 @@
         "id": 1200,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000415",
-        "modified": "2019-06-11T14:17:15.426+00:00",
+        "modified": "2019-06-11T14:17:15.426+0000",
         "name": "AutDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]+[A-Z-0-9]{2,}$",
@@ -2314,7 +2314,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:18.125+00:00",
+        "created": "2019-06-11T14:18:18.125+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2323,7 +2323,7 @@
         "id": 1873,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000676",
-        "modified": "2019-06-11T14:18:18.125+00:00",
+        "modified": "2019-06-11T14:18:18.125+0000",
         "name": "Bacterial Diversity Metadatabase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -2370,7 +2370,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:01.735+00:00",
+        "created": "2019-06-11T14:17:01.735+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2379,7 +2379,7 @@
         "id": 1036,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000361",
-        "modified": "2019-06-11T14:17:01.735+00:00",
+        "modified": "2019-06-11T14:17:01.735+0000",
         "name": "BacMap Biography",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -2426,7 +2426,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:15.634+00:00",
+        "created": "2019-06-11T14:17:15.634+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2435,7 +2435,7 @@
         "id": 1203,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000416",
-        "modified": "2019-06-11T14:17:15.634+00:00",
+        "modified": "2019-06-11T14:17:15.634+0000",
         "name": "BacMap Map",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\_)?\\d+(\\.\\d+)?$",
@@ -2482,7 +2482,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:58.671+00:00",
+        "created": "2019-06-11T14:17:58.671+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2491,7 +2491,7 @@
         "id": 1659,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000597",
-        "modified": "2019-06-11T14:17:58.671+00:00",
+        "modified": "2019-06-11T14:17:58.671+0000",
         "name": "BioAssay Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{7}$",
@@ -2573,7 +2573,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-10T18:54:31.118+00:00",
+        "created": "2022-01-10T18:54:31.118+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2582,7 +2582,7 @@
         "id": 3020,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000903",
-        "modified": "2022-01-10T18:54:31.118+00:00",
+        "modified": "2022-01-10T18:54:31.118+0000",
         "name": "Blue Brain Project Knowledge Graph",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[-\\w]+(?:\\/[-\\w]+)(?:\\/\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b)$",
@@ -2629,7 +2629,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-09T18:52:31.186+00:00",
+        "created": "2022-01-09T18:52:31.186+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2638,7 +2638,7 @@
         "id": 2986,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000889",
-        "modified": "2022-01-09T18:52:31.186+00:00",
+        "modified": "2022-01-09T18:52:31.186+0000",
         "name": "Blue Brain Project Topological sampling Knowledge Graph",
         "namespaceEmbeddedInLui": false,
         "pattern": "\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b",
@@ -2685,7 +2685,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:45.049+00:00",
+        "created": "2019-06-11T14:16:45.049+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2694,7 +2694,7 @@
         "id": 837,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000285",
-        "modified": "2019-06-11T14:16:45.049+00:00",
+        "modified": "2019-06-11T14:16:45.049+0000",
         "name": "BDGP EST",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\.)?(\\d+)?$",
@@ -2741,7 +2741,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:14.437+00:00",
+        "created": "2019-06-11T14:16:14.437+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2750,7 +2750,7 @@
         "id": 484,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000156",
-        "modified": "2019-06-11T14:16:14.437+00:00",
+        "modified": "2019-06-11T14:16:14.437+0000",
         "name": "BDGP insertion DB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -2797,7 +2797,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:54.741+00:00",
+        "created": "2019-06-11T14:16:54.741+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2806,7 +2806,7 @@
         "id": 952,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000332",
-        "modified": "2019-06-11T14:16:54.741+00:00",
+        "modified": "2019-06-11T14:16:54.741+0000",
         "name": "Bloomington Drosophila Stock Center",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -2853,7 +2853,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:14.695+00:00",
+        "created": "2019-06-11T14:16:14.695+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2862,7 +2862,7 @@
         "id": 487,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000157",
-        "modified": "2019-06-11T14:16:14.695+00:00",
+        "modified": "2019-06-11T14:16:14.695+0000",
         "name": "BeetleBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TC\\d+$",
@@ -2909,7 +2909,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:04.748+00:00",
+        "created": "2019-06-11T14:18:04.748+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -2918,7 +2918,7 @@
         "id": 1726,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000622",
-        "modified": "2019-06-11T14:18:04.748+00:00",
+        "modified": "2019-06-11T14:18:04.748+0000",
         "name": "Benchmark Energy & Geometry Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -2965,16 +2965,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:15.821+00:00",
+        "created": "2019-06-11T14:17:15.821+0000",
         "deprecated": true,
-        "deprecationDate": "2023-07-04T10:27:03.694+00:00",
+        "deprecationDate": "2023-07-04T10:27:03.694+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "Bgee is a database of gene expression patterns within particular anatomical structures within a species, and between different animal species. This collection refers to expression across species.",
         "id": 1205,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000417",
-        "modified": "2023-09-13T08:55:41.857+00:00",
+        "modified": "2023-09-13T08:55:41.857+0000",
         "name": "Bgee family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(ENSFM|ENSGTV:)\\d+$",
@@ -3021,7 +3021,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:16.067+00:00",
+        "created": "2019-06-11T14:17:16.067+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3030,7 +3030,7 @@
         "id": 1208,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000418",
-        "modified": "2023-06-21T08:14:55.477+00:00",
+        "modified": "2023-06-21T08:14:55.477+0000",
         "name": "Bgee gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -3077,16 +3077,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:16.514+00:00",
+        "created": "2019-06-11T14:17:16.514+0000",
         "deprecated": true,
-        "deprecationDate": "2023-07-04T10:26:56.707+00:00",
+        "deprecationDate": "2023-07-04T10:26:56.707+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "Bgee is a database of gene expression patterns within particular anatomical structures within a species, and between different animal species. This collection refers to anatomical structures.",
         "id": 1213,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000420",
-        "modified": "2023-09-13T08:53:52.558+00:00",
+        "modified": "2023-09-13T08:53:52.558+0000",
         "name": "Bgee organ",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(XAO|ZFA|EHDAA|EMAPA|EV|MA)\\:\\d+$",
@@ -3133,16 +3133,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:16.333+00:00",
+        "created": "2019-06-11T14:17:16.333+0000",
         "deprecated": true,
-        "deprecationDate": "2023-07-04T10:26:40.148+00:00",
+        "deprecationDate": "2023-07-04T10:26:40.148+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "Bgee is a database of gene expression patterns within particular anatomical structures within a species, and between different animal species. This collection refers to developmental stages.",
         "id": 1211,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000419",
-        "modified": "2023-09-13T08:52:47.196+00:00",
+        "modified": "2023-09-13T08:52:47.196+0000",
         "name": "Bgee stage",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(FBvd|XtroDO|HsapDO|MmusDO)\\:\\d+$",
@@ -3189,7 +3189,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:47.621+00:00",
+        "created": "2019-06-11T14:17:47.621+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3198,7 +3198,7 @@
         "id": 1553,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000555",
-        "modified": "2019-06-11T14:17:47.621+00:00",
+        "modified": "2019-06-11T14:17:47.621+0000",
         "name": "BiGG Compartment",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z_A-Z]+$",
@@ -3245,7 +3245,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:47.850+00:00",
+        "created": "2019-06-11T14:17:47.850+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3254,7 +3254,7 @@
         "id": 1555,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000556",
-        "modified": "2023-06-21T08:19:14.475+00:00",
+        "modified": "2023-06-21T08:19:14.475+0000",
         "name": "BiGG Metabolite",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z_A-Z0-9]+$",
@@ -3301,7 +3301,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:47.362+00:00",
+        "created": "2019-06-11T14:17:47.362+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3310,7 +3310,7 @@
         "id": 1550,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000554",
-        "modified": "2019-06-11T14:17:47.362+00:00",
+        "modified": "2019-06-11T14:17:47.362+0000",
         "name": "BiGG Model",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z_A-Z0-9]+$",
@@ -3357,7 +3357,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:48.059+00:00",
+        "created": "2019-06-11T14:17:48.059+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3366,7 +3366,7 @@
         "id": 1557,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000557",
-        "modified": "2019-06-11T14:17:48.059+00:00",
+        "modified": "2019-06-11T14:17:48.059+0000",
         "name": "BiGG Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z_A-Z0-9]+$",
@@ -3413,7 +3413,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:39.982+00:00",
+        "created": "2019-06-11T14:16:39.982+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3422,7 +3422,7 @@
         "id": 775,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000264",
-        "modified": "2019-06-11T14:16:39.982+00:00",
+        "modified": "2019-06-11T14:16:39.982+0000",
         "name": "BindingDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w\\d+$",
@@ -3469,7 +3469,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:16.688+00:00",
+        "created": "2019-06-11T14:17:16.688+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3478,7 +3478,7 @@
         "id": 1215,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000421",
-        "modified": "2019-06-11T14:17:16.688+00:00",
+        "modified": "2019-06-11T14:17:16.688+0000",
         "name": "BioCarta Pathway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([hm]\\_)?\\w+Pathway$",
@@ -3525,7 +3525,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:10.872+00:00",
+        "created": "2019-06-11T14:16:10.872+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3534,7 +3534,7 @@
         "id": 445,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000140",
-        "modified": "2019-06-11T14:16:10.872+00:00",
+        "modified": "2019-06-11T14:16:10.872+0000",
         "name": "BioCatalogue",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -3581,7 +3581,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:23.132+00:00",
+        "created": "2019-06-11T14:16:23.132+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3590,7 +3590,7 @@
         "id": 584,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000194",
-        "modified": "2019-06-11T14:16:23.132+00:00",
+        "modified": "2019-06-11T14:16:23.132+0000",
         "name": "BioCyc",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z-0-9]+(\\:)?[A-Za-z0-9+_.%-:]+$",
@@ -3637,7 +3637,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:48.429+00:00",
+        "created": "2019-06-11T14:15:48.429+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3646,7 +3646,7 @@
         "id": 206,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000058",
-        "modified": "2019-06-11T14:15:48.429+00:00",
+        "modified": "2019-06-11T14:15:48.429+0000",
         "name": "BioGRID",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -3693,7 +3693,7 @@
         "successor": null
       },
       {
-        "created": "2023-03-01T11:40:49.456+00:00",
+        "created": "2023-03-01T11:40:49.456+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3702,7 +3702,7 @@
         "id": 3472,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000995",
-        "modified": "2023-03-01T11:40:49.456+00:00",
+        "modified": "2023-03-01T11:40:49.456+0000",
         "name": "BioKC",
         "namespaceEmbeddedInLui": false,
         "pattern": "bkc[0-9]*",
@@ -3749,7 +3749,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-20T15:04:54.734+00:00",
+        "created": "2020-03-20T15:04:54.734+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3758,7 +3758,7 @@
         "id": 2160,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000782",
-        "modified": "2020-03-20T15:04:54.734+00:00",
+        "modified": "2020-03-20T15:04:54.734+0000",
         "name": "BioLink Model",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\S+$",
@@ -3805,7 +3805,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:07.548+00:00",
+        "created": "2019-06-11T14:18:07.548+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3814,7 +3814,7 @@
         "id": 1760,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000634",
-        "modified": "2019-06-11T14:18:07.548+00:00",
+        "modified": "2019-06-11T14:18:07.548+0000",
         "name": "Bio-MINDER Tissue Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z0-9\\-]+$",
@@ -3861,7 +3861,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:30.877+00:00",
+        "created": "2019-06-11T14:15:30.877+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3870,7 +3870,7 @@
         "id": 36,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000007",
-        "modified": "2019-06-11T14:15:30.877+00:00",
+        "modified": "2019-06-11T14:15:30.877+0000",
         "name": "BioModels Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((BIOMD|MODEL)\\d{10})|(BMID\\d{12})$",
@@ -3987,7 +3987,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:01.508+00:00",
+        "created": "2019-06-11T14:16:01.508+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -3996,7 +3996,7 @@
         "id": 347,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000108",
-        "modified": "2019-06-11T14:16:01.508+00:00",
+        "modified": "2019-06-11T14:16:01.508+0000",
         "name": "KiSAO",
         "namespaceEmbeddedInLui": false,
         "pattern": "^KISAO_\\d+$",
@@ -4078,7 +4078,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:01.178+00:00",
+        "created": "2019-06-11T14:16:01.178+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4087,7 +4087,7 @@
         "id": 344,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000107",
-        "modified": "2019-06-11T14:16:01.178+00:00",
+        "modified": "2019-06-11T14:16:01.178+0000",
         "name": "TEDDY",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TEDDY_\\d{7}$",
@@ -4169,7 +4169,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:37.784+00:00",
+        "created": "2019-06-11T14:17:37.784+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4178,7 +4178,7 @@
         "id": 1450,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000514",
-        "modified": "2019-06-11T14:17:37.784+00:00",
+        "modified": "2019-06-11T14:17:37.784+0000",
         "name": "SBML RDF Vocabulary",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z]+$",
@@ -4225,7 +4225,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:59.756+00:00",
+        "created": "2019-06-11T14:15:59.756+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4234,7 +4234,7 @@
         "id": 327,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000101",
-        "modified": "2019-06-11T14:15:59.756+00:00",
+        "modified": "2019-06-11T14:15:59.756+0000",
         "name": "BioNumbers",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -4281,7 +4281,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:21.882+00:00",
+        "created": "2019-06-11T14:16:21.882+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4290,7 +4290,7 @@
         "id": 570,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000187",
-        "modified": "2019-06-11T14:16:21.882+00:00",
+        "modified": "2019-06-11T14:16:21.882+0000",
         "name": "BioPortal",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -4337,7 +4337,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:58.543+00:00",
+        "created": "2019-06-11T14:16:58.543+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4346,7 +4346,7 @@
         "id": 999,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000349",
-        "modified": "2019-06-11T14:16:58.543+00:00",
+        "modified": "2019-06-11T14:16:58.543+0000",
         "name": "BioProject",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PRJ[DEN][A-Z]\\d+$",
@@ -4463,7 +4463,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:59.017+00:00",
+        "created": "2019-06-11T14:16:59.017+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4472,7 +4472,7 @@
         "id": 1004,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000350",
-        "modified": "2019-06-11T14:16:59.017+00:00",
+        "modified": "2019-06-11T14:16:59.017+0000",
         "name": "BioSample",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SAM[NED](\\w)?\\d+$",
@@ -4589,7 +4589,7 @@
         "successor": null
       },
       {
-        "created": "2021-10-11T12:50:59.916+00:00",
+        "created": "2021-10-11T12:50:59.916+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4598,7 +4598,7 @@
         "id": 2903,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000880",
-        "modified": "2021-10-11T12:50:59.916+00:00",
+        "modified": "2021-10-11T12:50:59.916+0000",
         "name": "biosimulations",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9_-]{3,}$",
@@ -4645,7 +4645,7 @@
         "successor": null
       },
       {
-        "created": "2020-10-22T01:16:20.744+00:00",
+        "created": "2020-10-22T01:16:20.744+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4654,7 +4654,7 @@
         "id": 2416,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000767",
-        "modified": "2020-10-22T01:16:20.744+00:00",
+        "modified": "2020-10-22T01:16:20.744+0000",
         "name": "BioSimulators",
         "namespaceEmbeddedInLui": false,
         "pattern": "[a-zA-Z0-9-_]+",
@@ -4701,7 +4701,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:22.448+00:00",
+        "created": "2019-06-11T14:18:22.448+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4710,7 +4710,7 @@
         "id": 1921,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000694",
-        "modified": "2023-01-12T08:36:02.758+00:00",
+        "modified": "2023-01-12T08:36:02.758+0000",
         "name": "BioStudies database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^S-[A-Z]{4}[\\-\\_A-Z\\d]+$",
@@ -4757,7 +4757,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:58.906+00:00",
+        "created": "2019-06-11T14:15:58.906+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4766,7 +4766,7 @@
         "id": 318,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000097",
-        "modified": "2019-06-11T14:15:58.906+00:00",
+        "modified": "2019-06-11T14:15:58.906+0000",
         "name": "BioSystems",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -4813,7 +4813,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:03.353+00:00",
+        "created": "2019-06-11T14:18:03.353+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4822,7 +4822,7 @@
         "id": 1709,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000616",
-        "modified": "2023-01-05T19:09:45.468+00:00",
+        "modified": "2023-01-05T19:09:45.468+0000",
         "name": "BioTools",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[-A-Za-z0-9\\_]*$",
@@ -4869,7 +4869,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-09T19:35:12.259+00:00",
+        "created": "2022-01-09T19:35:12.259+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4878,7 +4878,7 @@
         "id": 3009,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000899",
-        "modified": "2022-01-09T19:35:12.259+00:00",
+        "modified": "2022-01-09T19:35:12.259+0000",
         "name": "Bitbucket",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9A-Za-z-_\\.]+/[0-9A-Za-z-_\\.]+$",
@@ -4925,7 +4925,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:58.347+00:00",
+        "created": "2019-06-11T14:16:58.347+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4934,7 +4934,7 @@
         "id": 997,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000348",
-        "modified": "2019-06-11T14:16:58.347+00:00",
+        "modified": "2019-06-11T14:16:58.347+0000",
         "name": "BitterDB Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -4981,7 +4981,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:58.089+00:00",
+        "created": "2019-06-11T14:16:58.089+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -4990,7 +4990,7 @@
         "id": 994,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000347",
-        "modified": "2019-06-11T14:16:58.089+00:00",
+        "modified": "2019-06-11T14:16:58.089+0000",
         "name": "BitterDB Receptor",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -5037,7 +5037,7 @@
         "successor": null
       },
       {
-        "created": "2019-12-09T15:05:02.665+00:00",
+        "created": "2019-12-09T15:05:02.665+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5046,7 +5046,7 @@
         "id": 2055,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000716",
-        "modified": "2019-12-09T15:05:02.665+00:00",
+        "modified": "2019-12-09T15:05:02.665+0000",
         "name": "Biological Magnetic Resonance Data Bank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(bmr|bmse|bmst)?[0-9]{1,6}$",
@@ -5093,7 +5093,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:14.938+00:00",
+        "created": "2019-06-11T14:16:14.938+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5102,7 +5102,7 @@
         "id": 490,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000158",
-        "modified": "2019-06-11T14:16:14.938+00:00",
+        "modified": "2019-06-11T14:16:14.938+0000",
         "name": "BOLD Taxonomy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -5149,7 +5149,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:51.985+00:00",
+        "created": "2019-06-11T14:15:51.985+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5158,7 +5158,7 @@
         "id": 244,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000071",
-        "modified": "2019-06-11T14:15:51.985+00:00",
+        "modified": "2019-06-11T14:15:51.985+0000",
         "name": "BRENDA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((\\d+\\.-\\.-\\.-)|(\\d+\\.\\d+\\.-\\.-)|(\\d+\\.\\d+\\.\\d+\\.-)|(\\d+\\.\\d+\\.\\d+\\.\\d+))$",
@@ -5205,7 +5205,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:20.539+00:00",
+        "created": "2019-06-11T14:17:20.539+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5214,7 +5214,7 @@
         "id": 1258,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000438",
-        "modified": "2019-06-11T14:17:20.539+00:00",
+        "modified": "2019-06-11T14:17:20.539+0000",
         "name": "Broad Fungal Genome Initiative",
         "namespaceEmbeddedInLui": false,
         "pattern": "^S\\d+$",
@@ -5261,7 +5261,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:02.399+00:00",
+        "created": "2019-06-11T14:16:02.399+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5270,7 +5270,7 @@
         "id": 355,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000111",
-        "modified": "2019-06-11T14:16:02.399+00:00",
+        "modified": "2019-06-11T14:16:02.399+0000",
         "name": "Brenda Tissue Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^BTO:\\d{7}$",
@@ -5352,7 +5352,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:12.968+00:00",
+        "created": "2019-06-11T14:17:12.968+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5361,7 +5361,7 @@
         "id": 1172,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000404",
-        "modified": "2019-06-11T14:17:12.968+00:00",
+        "modified": "2019-06-11T14:17:12.968+0000",
         "name": "BugBase Expt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -5408,7 +5408,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:12.749+00:00",
+        "created": "2019-06-11T14:17:12.749+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5417,7 +5417,7 @@
         "id": 1169,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000403",
-        "modified": "2019-06-11T14:17:12.749+00:00",
+        "modified": "2019-06-11T14:17:12.749+0000",
         "name": "BugBase Protocol",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -5464,7 +5464,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:38.105+00:00",
+        "created": "2019-06-11T14:16:38.105+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5473,7 +5473,7 @@
         "id": 751,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000253",
-        "modified": "2019-06-11T14:16:38.105+00:00",
+        "modified": "2019-06-11T14:16:38.105+0000",
         "name": "BYKdb",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -5520,7 +5520,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:39.396+00:00",
+        "created": "2019-06-11T14:16:39.396+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5529,7 +5529,7 @@
         "id": 767,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000261",
-        "modified": "2019-06-11T14:16:39.396+00:00",
+        "modified": "2019-06-11T14:16:39.396+0000",
         "name": "CABRI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-Za-z]+)?(\\_)?([A-Za-z-]+)\\:([A-Za-z0-9 ]+)$",
@@ -5611,7 +5611,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:22.646+00:00",
+        "created": "2019-06-11T14:18:22.646+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5620,7 +5620,7 @@
         "id": 1923,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000695",
-        "modified": "2019-06-11T14:18:22.646+00:00",
+        "modified": "2019-06-11T14:18:22.646+0000",
         "name": "Cancer Data Standards Registry and Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]*$",
@@ -5667,7 +5667,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:04.976+00:00",
+        "created": "2019-06-11T14:18:04.976+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5676,7 +5676,7 @@
         "id": 1729,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000623",
-        "modified": "2019-10-01T11:46:06.302+00:00",
+        "modified": "2019-10-01T11:46:06.302+0000",
         "name": "CAMEO",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9\\-_]+$",
@@ -5723,7 +5723,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:11.199+00:00",
+        "created": "2019-06-11T14:17:11.199+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5732,7 +5732,7 @@
         "id": 1149,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000396",
-        "modified": "2019-06-11T14:17:11.199+00:00",
+        "modified": "2019-06-11T14:17:11.199+0000",
         "name": "CAPS-DB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -5779,7 +5779,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:33.869+00:00",
+        "created": "2019-06-11T14:16:33.869+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5788,7 +5788,7 @@
         "id": 701,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000237",
-        "modified": "2019-06-11T14:16:33.869+00:00",
+        "modified": "2019-06-11T14:16:33.869+0000",
         "name": "CAS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{1,7}\\-\\d{2}\\-\\d$",
@@ -5870,7 +5870,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:02.470+00:00",
+        "created": "2019-06-11T14:18:02.470+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5879,7 +5879,7 @@
         "id": 1699,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000612",
-        "modified": "2021-02-01T16:12:25.234+00:00",
+        "modified": "2021-02-01T16:12:25.234+0000",
         "name": "CATH Protein Structural Domain Superfamily",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[1-6]\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
@@ -5926,7 +5926,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:26.899+00:00",
+        "created": "2019-06-11T14:16:26.899+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5935,7 +5935,7 @@
         "id": 626,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000210",
-        "modified": "2019-06-11T14:16:26.899+00:00",
+        "modified": "2019-06-11T14:16:26.899+0000",
         "name": "CATH domain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -5982,7 +5982,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:26.635+00:00",
+        "created": "2019-06-11T14:16:26.635+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -5991,7 +5991,7 @@
         "id": 623,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000209",
-        "modified": "2019-06-11T14:16:26.635+00:00",
+        "modified": "2019-06-11T14:16:26.635+0000",
         "name": "CATH superfamily",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+(\\.\\d+(\\.\\d+(\\.\\d+)?)?)?$",
@@ -6038,7 +6038,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:35.485+00:00",
+        "created": "2019-06-11T14:17:35.485+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6047,7 +6047,7 @@
         "id": 1428,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000504",
-        "modified": "2019-06-11T14:17:35.485+00:00",
+        "modified": "2019-06-11T14:17:35.485+0000",
         "name": "Animal Genome Cattle QTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -6094,7 +6094,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:23.358+00:00",
+        "created": "2019-06-11T14:16:23.358+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6103,7 +6103,7 @@
         "id": 587,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000195",
-        "modified": "2019-06-11T14:16:23.358+00:00",
+        "modified": "2019-06-11T14:16:23.358+0000",
         "name": "CAZy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(GT|GH|PL|CE|CBM)\\d+(\\_\\d+)?$",
@@ -6150,7 +6150,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:18.874+00:00",
+        "created": "2019-06-11T14:18:18.874+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6159,7 +6159,7 @@
         "id": 1881,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000679",
-        "modified": "2019-06-11T14:18:18.874+00:00",
+        "modified": "2019-06-11T14:18:18.874+0000",
         "name": "The cBioPortal for Cancer Genomics",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z0-9\\_]+$",
@@ -6206,7 +6206,7 @@
         "successor": null
       },
       {
-        "created": "2021-05-30T10:05:35.955+00:00",
+        "created": "2021-05-30T10:05:35.955+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6215,7 +6215,7 @@
         "id": 2665,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000818",
-        "modified": "2021-05-30T10:05:35.955+00:00",
+        "modified": "2021-05-30T10:05:35.955+0000",
         "name": "CCDC Number",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{6,7}$",
@@ -6262,7 +6262,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:04.925+00:00",
+        "created": "2019-06-11T14:17:04.925+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6271,7 +6271,7 @@
         "id": 1076,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000375",
-        "modified": "2019-06-11T14:17:04.925+00:00",
+        "modified": "2019-06-11T14:17:04.925+0000",
         "name": "Consensus CDS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CCDS\\d+\\.\\d+$",
@@ -6318,7 +6318,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:33.213+00:00",
+        "created": "2019-06-11T14:16:33.213+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6327,7 +6327,7 @@
         "id": 694,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000234",
-        "modified": "2023-01-10T14:47:52.365+00:00",
+        "modified": "2023-01-10T14:47:52.365+0000",
         "name": "Cell Cycle Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^CCO:\\w+$",
@@ -6374,7 +6374,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:04.400+00:00",
+        "created": "2019-06-11T14:16:04.400+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6383,7 +6383,7 @@
         "id": 377,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000119",
-        "modified": "2019-06-11T14:16:04.400+00:00",
+        "modified": "2019-06-11T14:16:04.400+0000",
         "name": "Conserved Domain Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(cd)?\\d{5}$",
@@ -6430,7 +6430,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:41.852+00:00",
+        "created": "2019-06-11T14:16:41.852+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6439,7 +6439,7 @@
         "id": 797,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000272",
-        "modified": "2019-06-11T14:16:41.852+00:00",
+        "modified": "2019-06-11T14:16:41.852+0000",
         "name": "Canadian Drug Product Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -6486,7 +6486,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:38.984+00:00",
+        "created": "2019-06-11T14:16:38.984+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6495,7 +6495,7 @@
         "id": 762,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000257",
-        "modified": "2019-06-11T14:16:38.984+00:00",
+        "modified": "2019-06-11T14:16:38.984+0000",
         "name": "Cell Image Library",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -6542,7 +6542,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:59.000+00:00",
+        "created": "2019-06-11T14:17:59.000+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6551,7 +6551,7 @@
         "id": 1662,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000598",
-        "modified": "2023-01-09T15:31:03.506+00:00",
+        "modified": "2023-01-09T15:31:03.506+0000",
         "name": "Cellosaurus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CVCL_[A-Z0-9]{4}(\\.txt)?$",
@@ -6598,7 +6598,7 @@
         "successor": null
       },
       {
-        "created": "2021-06-24T15:54:23.109+00:00",
+        "created": "2021-06-24T15:54:23.109+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6607,7 +6607,7 @@
         "id": 2702,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000829",
-        "modified": "2021-06-24T15:54:23.109+00:00",
+        "modified": "2021-06-24T15:54:23.109+0000",
         "name": "Cell Version Control Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -6654,7 +6654,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:11.955+00:00",
+        "created": "2019-06-11T14:16:11.955+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6663,7 +6663,7 @@
         "id": 456,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000145",
-        "modified": "2019-06-11T14:16:11.955+00:00",
+        "modified": "2019-06-11T14:16:11.955+0000",
         "name": "Candida Genome Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CAL\\d{7}$",
@@ -6710,7 +6710,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:47.138+00:00",
+        "created": "2019-06-11T14:16:47.138+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6719,7 +6719,7 @@
         "id": 863,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000295",
-        "modified": "2019-06-11T14:16:47.138+00:00",
+        "modified": "2019-06-11T14:16:47.138+0000",
         "name": "CGSC Strain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -6766,7 +6766,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:56.827+00:00",
+        "created": "2019-06-11T14:16:56.827+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6775,7 +6775,7 @@
         "id": 979,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000341",
-        "modified": "2019-06-11T14:16:56.827+00:00",
+        "modified": "2019-06-11T14:16:56.827+0000",
         "name": "CharProt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CH_\\d+$",
@@ -6822,7 +6822,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:26.925+00:00",
+        "created": "2019-06-11T14:15:26.925+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6831,7 +6831,7 @@
         "id": 1,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000002",
-        "modified": "2019-06-11T14:15:26.925+00:00",
+        "modified": "2019-06-11T14:15:26.925+0000",
         "name": "ChEBI",
         "namespaceEmbeddedInLui": true,
         "pattern": "^CHEBI:\\d+$",
@@ -6948,7 +6948,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-28T16:13:04.331+00:00",
+        "created": "2021-02-28T16:13:04.331+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -6957,7 +6957,7 @@
         "id": 2571,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000799",
-        "modified": "2021-02-28T16:13:04.331+00:00",
+        "modified": "2021-02-28T16:13:04.331+0000",
         "name": "ChEMBL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CHEMBL\\d+$",
@@ -7004,7 +7004,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:55.368+00:00",
+        "created": "2019-06-11T14:15:55.368+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7013,7 +7013,7 @@
         "id": 281,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000084",
-        "modified": "2019-06-11T14:15:55.368+00:00",
+        "modified": "2019-06-11T14:15:55.368+0000",
         "name": "ChEMBL compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CHEMBL\\d+$",
@@ -7130,7 +7130,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:55.880+00:00",
+        "created": "2019-06-11T14:15:55.880+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7139,7 +7139,7 @@
         "id": 286,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000085",
-        "modified": "2019-06-11T14:15:55.880+00:00",
+        "modified": "2019-06-11T14:15:55.880+0000",
         "name": "ChEMBL target",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CHEMBL\\d+$",
@@ -7256,7 +7256,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:43.696+00:00",
+        "created": "2019-06-11T14:16:43.696+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7265,7 +7265,7 @@
         "id": 820,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000279",
-        "modified": "2019-06-11T14:16:43.696+00:00",
+        "modified": "2019-06-11T14:16:43.696+0000",
         "name": "ChemDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -7312,7 +7312,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:58.577+00:00",
+        "created": "2019-06-11T14:15:58.577+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7321,7 +7321,7 @@
         "id": 315,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000096",
-        "modified": "2019-06-11T14:15:58.577+00:00",
+        "modified": "2019-06-11T14:15:58.577+0000",
         "name": "ChemIDplus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+\\-\\d+\\-\\d+$",
@@ -7368,7 +7368,63 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:10.254+00:00",
+        "created": "2024-03-20T10:24:50.346+0000",
+        "deprecated": false,
+        "deprecationDate": null,
+        "deprecationOfflineDate": null,
+        "deprecationStatement": null,
+        "description": "The chemical information ontology (cheminf) describes information entities about chemical entities. It provides qualitative and quantitative attributes to richly describe chemicals.",
+        "id": 3819,
+        "infoOnPostmortemAccess": null,
+        "mirId": "MIR:00001045",
+        "modified": "2024-03-20T10:29:26.220+0000",
+        "name": "Chemical Information Ontology",
+        "namespaceEmbeddedInLui": true,
+        "pattern": "^CHEMINF:\\d+$",
+        "prefix": "cheminf",
+        "renderDeprecatedLanding": false,
+        "resources": [
+          {
+            "authHelpDescription": null,
+            "authHelpUrl": null,
+            "deprecated": false,
+            "deprecationDate": null,
+            "deprecationOfflineDate": null,
+            "deprecationStatement": null,
+            "description": "The chemical information ontology (cheminf) describes information entities about chemical entities. It provides qualitative and quantitative attributes to richly describe chemicals.",
+            "id": 3820,
+            "institution": {
+              "description": "At EMBL-EBI, we make the world’s public biological data freely available to the scientific community via a range of services and tools, perform basic research and provide professional training in bioinformatics. \nWe are part of the European Molecular Biology Laboratory (EMBL), an international, innovative and interdisciplinary research organisation funded by 26 member states and two associate member states.",
+              "homeUrl": "https://www.ebi.ac.uk",
+              "id": 2,
+              "location": {
+                "countryCode": "GB",
+                "countryName": "United Kingdom"
+              },
+              "name": "European Bioinformatics Institute",
+              "rorId": "https://ror.org/02catss52"
+            },
+            "location": {
+              "countryCode": "GB",
+              "countryName": "United Kingdom"
+            },
+            "mirId": "MIR:00001044",
+            "name": "CHEMINF via OLS",
+            "official": true,
+            "protectedUrls": false,
+            "providerCode": "ols",
+            "renderDeprecatedLanding": false,
+            "renderProtectedLanding": false,
+            "resourceHomeUrl": "https://www.ebi.ac.uk/ols4/ontologies/cheminf",
+            "sampleId": "000306",
+            "urlPattern": "https://www.ebi.ac.uk/ols4/ontologies/cheminf/classes?obo_id=CHEMINF:{$id}"
+          }
+        ],
+        "sampleId": "000306",
+        "successor": null
+      },
+      {
+        "created": "2019-06-11T14:16:10.254+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7377,7 +7433,7 @@
         "id": 438,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000138",
-        "modified": "2019-06-11T14:16:10.254+00:00",
+        "modified": "2019-06-11T14:16:10.254+0000",
         "name": "ChemSpider",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -7424,7 +7480,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:35.752+00:00",
+        "created": "2019-06-11T14:17:35.752+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7433,7 +7489,7 @@
         "id": 1431,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000505",
-        "modified": "2019-06-11T14:17:35.752+00:00",
+        "modified": "2019-06-11T14:17:35.752+0000",
         "name": "Animal Genome Chicken QTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -7480,7 +7536,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-05T19:47:08.870+00:00",
+        "created": "2021-08-05T19:47:08.870+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7489,7 +7545,7 @@
         "id": 2751,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000835",
-        "modified": "2021-08-05T19:47:08.870+00:00",
+        "modified": "2021-08-05T19:47:08.870+0000",
         "name": "CIViC Assertion",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7536,7 +7592,7 @@
         "successor": null
       },
       {
-        "created": "2022-08-08T18:34:15.882+00:00",
+        "created": "2022-08-08T18:34:15.882+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7545,7 +7601,7 @@
         "id": 3258,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000957",
-        "modified": "2022-08-08T18:34:15.882+00:00",
+        "modified": "2022-08-08T18:34:15.882+0000",
         "name": "CIViC Disease",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7592,7 +7648,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:28:56.816+00:00",
+        "created": "2021-08-08T09:28:56.816+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7601,7 +7657,7 @@
         "id": 2784,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000839",
-        "modified": "2021-08-08T09:28:56.816+00:00",
+        "modified": "2021-08-08T09:28:56.816+0000",
         "name": "CIViC Evidence",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7648,7 +7704,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-29T10:47:57.098+00:00",
+        "created": "2022-01-29T10:47:57.098+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7657,7 +7713,7 @@
         "id": 3039,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000907",
-        "modified": "2022-01-29T10:47:57.098+00:00",
+        "modified": "2022-01-29T10:47:57.098+0000",
         "name": "CIViC Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7704,7 +7760,7 @@
         "successor": null
       },
       {
-        "created": "2023-01-23T09:53:23.139+00:00",
+        "created": "2023-01-23T09:53:23.139+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7713,7 +7769,7 @@
         "id": 3383,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000981",
-        "modified": "2023-01-23T09:53:23.139+00:00",
+        "modified": "2023-01-23T09:53:23.139+0000",
         "name": "CIViC Molecular Profile",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7760,7 +7816,7 @@
         "successor": null
       },
       {
-        "created": "2022-08-08T18:32:17.171+00:00",
+        "created": "2022-08-08T18:32:17.171+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7769,7 +7825,7 @@
         "id": 3252,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000953",
-        "modified": "2022-08-08T18:32:17.171+00:00",
+        "modified": "2022-08-08T18:32:17.171+0000",
         "name": "CIViC Source",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7816,7 +7872,7 @@
         "successor": null
       },
       {
-        "created": "2022-08-08T18:33:25.710+00:00",
+        "created": "2022-08-08T18:33:25.710+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7825,7 +7881,7 @@
         "id": 3255,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000955",
-        "modified": "2022-08-08T18:33:25.710+00:00",
+        "modified": "2022-08-08T18:33:25.710+0000",
         "name": "CIViC Therapy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7872,7 +7928,7 @@
         "successor": null
       },
       {
-        "created": "2023-01-23T09:52:20.012+00:00",
+        "created": "2023-01-23T09:52:20.012+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7881,7 +7937,7 @@
         "id": 3380,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000979",
-        "modified": "2023-01-23T09:52:20.012+00:00",
+        "modified": "2023-01-23T09:52:20.012+0000",
         "name": "CIViC Variant Group",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7928,7 +7984,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-29T10:48:56.640+00:00",
+        "created": "2022-01-29T10:48:56.640+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7937,7 +7993,7 @@
         "id": 3042,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000909",
-        "modified": "2022-01-29T10:48:56.640+00:00",
+        "modified": "2022-01-29T10:48:56.640+0000",
         "name": "CIViC Variant",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -7984,7 +8040,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:02.066+00:00",
+        "created": "2019-06-11T14:16:02.066+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -7993,7 +8049,7 @@
         "id": 352,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000110",
-        "modified": "2019-06-11T14:16:02.066+00:00",
+        "modified": "2019-06-11T14:16:02.066+0000",
         "name": "Cell Type Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^CL:\\d{7}$",
@@ -8075,7 +8131,7 @@
         "successor": null
       },
       {
-        "created": "2019-09-05T11:46:36.162+00:00",
+        "created": "2019-09-05T11:46:36.162+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8084,7 +8140,7 @@
         "id": 1977,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000770",
-        "modified": "2019-09-05T11:46:36.162+00:00",
+        "modified": "2019-09-05T11:46:36.162+0000",
         "name": "ClassyFire",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C[0-9]{7}$",
@@ -8131,7 +8187,7 @@
         "successor": null
       },
       {
-        "created": "2022-11-03T14:17:05.019+00:00",
+        "created": "2022-11-03T14:17:05.019+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8140,7 +8196,7 @@
         "id": 3292,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000964",
-        "modified": "2022-11-03T14:17:05.019+00:00",
+        "modified": "2022-11-03T14:17:05.019+0000",
         "name": "ChecklistBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+(LR)?$",
@@ -8187,7 +8243,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:09.531+00:00",
+        "created": "2019-06-11T14:17:09.531+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8196,7 +8252,7 @@
         "id": 1129,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000390",
-        "modified": "2019-06-11T14:17:09.531+00:00",
+        "modified": "2019-06-11T14:17:09.531+0000",
         "name": "CLDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(cl|tum)\\d+$",
@@ -8243,7 +8299,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:09.937+00:00",
+        "created": "2019-06-11T14:16:09.937+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8252,7 +8308,7 @@
         "id": 435,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000137",
-        "modified": "2019-06-11T14:16:09.937+00:00",
+        "modified": "2019-06-11T14:16:09.937+0000",
         "name": "ClinicalTrials.gov",
         "namespaceEmbeddedInLui": false,
         "pattern": "^NCT\\d{8}$",
@@ -8299,7 +8355,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:58.490+00:00",
+        "created": "2019-06-11T14:17:58.490+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8308,7 +8364,7 @@
         "id": 1657,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000596",
-        "modified": "2019-06-11T14:17:58.490+00:00",
+        "modified": "2019-06-11T14:17:58.490+0000",
         "name": "ClinVar Variant",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -8355,7 +8411,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:42.685+00:00",
+        "created": "2019-06-11T14:17:42.685+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8364,7 +8420,7 @@
         "id": 1499,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000534",
-        "modified": "2019-06-11T14:17:42.685+00:00",
+        "modified": "2019-06-11T14:17:42.685+0000",
         "name": "ClinVar Record",
         "namespaceEmbeddedInLui": false,
         "pattern": "^RCV\\d+(\\.\\d+)?$",
@@ -8411,7 +8467,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:58.273+00:00",
+        "created": "2019-06-11T14:17:58.273+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8420,7 +8476,7 @@
         "id": 1655,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000595",
-        "modified": "2019-06-11T14:17:58.273+00:00",
+        "modified": "2019-06-11T14:17:58.273+0000",
         "name": "ClinVar Submission",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SCV\\d+(\\.\\d+)?$",
@@ -8467,7 +8523,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-17T17:56:14.329+00:00",
+        "created": "2021-02-17T17:56:14.329+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8476,7 +8532,7 @@
         "id": 2518,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000769",
-        "modified": "2021-02-17T17:56:14.329+00:00",
+        "modified": "2021-02-17T17:56:14.329+0000",
         "name": "ClinVar Submitter",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -8523,7 +8579,7 @@
         "successor": null
       },
       {
-        "created": "2023-01-23T10:14:16.128+00:00",
+        "created": "2023-01-23T10:14:16.128+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8532,7 +8588,7 @@
         "id": 3391,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000983",
-        "modified": "2023-01-23T10:14:16.128+00:00",
+        "modified": "2023-01-23T10:14:16.128+0000",
         "name": "Cell Line Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{7}$",
@@ -8614,7 +8670,7 @@
         "successor": null
       },
       {
-        "created": "2023-07-19T09:43:16.685+00:00",
+        "created": "2023-07-19T09:43:16.685+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8623,7 +8679,7 @@
         "id": 3609,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000930",
-        "modified": "2023-07-19T09:43:16.685+00:00",
+        "modified": "2023-07-19T09:43:16.685+0000",
         "name": "COG",
         "namespaceEmbeddedInLui": false,
         "pattern": "^COG[0-9]+$",
@@ -8670,7 +8726,7 @@
         "successor": null
       },
       {
-        "created": "2022-11-04T13:50:22.141+00:00",
+        "created": "2022-11-04T13:50:22.141+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8679,7 +8735,7 @@
         "id": 3311,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000969",
-        "modified": "2022-11-04T13:50:22.141+00:00",
+        "modified": "2022-11-04T13:50:22.141+0000",
         "name": "Catalogue of Life",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[23456789BCDFGHJKLMNPQRSTVWXYZ]{1,6}$",
@@ -8761,7 +8817,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:39.210+00:00",
+        "created": "2019-06-11T14:16:39.210+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8770,7 +8826,7 @@
         "id": 765,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000258",
-        "modified": "2023-01-04T15:31:16.641+00:00",
+        "modified": "2023-01-04T15:31:16.641+0000",
         "name": "COMBINE specifications",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\-|\\.|\\w)*$",
@@ -8817,7 +8873,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:13.254+00:00",
+        "created": "2019-06-11T14:18:13.254+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8826,7 +8882,7 @@
         "id": 1823,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000657",
-        "modified": "2019-06-11T14:18:13.254+00:00",
+        "modified": "2019-06-11T14:18:13.254+0000",
         "name": "Complex Portal",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CPX-[0-9]+$",
@@ -8873,7 +8929,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:13.452+00:00",
+        "created": "2019-06-11T14:18:13.452+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8882,7 +8938,7 @@
         "id": 1825,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000658",
-        "modified": "2019-06-11T14:18:13.452+00:00",
+        "modified": "2019-06-11T14:18:13.452+0000",
         "name": "CompTox Chemistry Dashboard",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DTXSID\\d+$",
@@ -8929,7 +8985,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:24.045+00:00",
+        "created": "2019-06-11T14:16:24.045+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8938,7 +8994,7 @@
         "id": 595,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000198",
-        "modified": "2019-06-11T14:16:24.045+00:00",
+        "modified": "2019-06-11T14:16:24.045+0000",
         "name": "Compulyeast",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])$",
@@ -8985,7 +9041,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:38.340+00:00",
+        "created": "2019-06-11T14:16:38.340+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -8994,7 +9050,7 @@
         "id": 754,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000254",
-        "modified": "2019-06-11T14:16:38.340+00:00",
+        "modified": "2019-06-11T14:16:38.340+0000",
         "name": "Conoserver",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -9041,7 +9097,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:20.763+00:00",
+        "created": "2019-06-11T14:17:20.763+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9050,7 +9106,7 @@
         "id": 1261,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000439",
-        "modified": "2019-06-11T14:17:20.763+00:00",
+        "modified": "2019-06-11T14:17:20.763+0000",
         "name": "Coriell Cell Repositories",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]{2}\\d+$",
@@ -9097,7 +9153,7 @@
         "successor": null
       },
       {
-        "created": "2021-07-06T14:35:18.469+00:00",
+        "created": "2021-07-06T14:35:18.469+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9106,7 +9162,7 @@
         "id": 2720,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000831",
-        "modified": "2021-07-06T14:35:18.469+00:00",
+        "modified": "2021-07-06T14:35:18.469+0000",
         "name": "CorrDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -9153,7 +9209,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:20.995+00:00",
+        "created": "2019-06-11T14:17:20.995+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9162,7 +9218,7 @@
         "id": 1264,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000440",
-        "modified": "2019-06-11T14:17:20.995+00:00",
+        "modified": "2019-06-11T14:17:20.995+0000",
         "name": "CORUM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -9209,7 +9265,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:59.699+00:00",
+        "created": "2019-06-11T14:17:59.699+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9218,7 +9274,7 @@
         "id": 1669,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000601",
-        "modified": "2019-06-11T14:17:59.699+00:00",
+        "modified": "2019-06-11T14:17:59.699+0000",
         "name": "COSMIC Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -9265,7 +9321,7 @@
         "successor": null
       },
       {
-        "created": "2020-12-14T12:49:56.333+00:00",
+        "created": "2020-12-14T12:49:56.333+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9274,7 +9330,7 @@
         "id": 2477,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000789",
-        "modified": "2020-12-14T12:49:56.333+00:00",
+        "modified": "2020-12-14T12:49:56.333+0000",
         "name": "SARS-CoV-2",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+_COVID19_[-\\w]+$",
@@ -9321,7 +9377,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:43.853+00:00",
+        "created": "2019-06-11T14:17:43.853+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9330,7 +9386,7 @@
         "id": 1513,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000539",
-        "modified": "2019-06-11T14:17:43.853+00:00",
+        "modified": "2019-06-11T14:17:43.853+0000",
         "name": "Cooperative Patent Classification",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-H,Y]|[A-H, Y]\\d{2}|[A-H, Y]\\d{2}[A-Z]|[A-H, Y]\\d{2}[A-Z]\\d{1,3}|[A-H, Y]\\d{2}[A-Z]\\d{1,3}(\\/)?\\d{2,})$",
@@ -9377,7 +9433,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:05.694+00:00",
+        "created": "2019-06-11T14:18:05.694+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9386,7 +9442,7 @@
         "id": 1738,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000626",
-        "modified": "2019-06-11T14:18:05.694+00:00",
+        "modified": "2019-06-11T14:18:05.694+0000",
         "name": "CRISPRdb",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -9433,7 +9489,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-01T17:20:51.953+00:00",
+        "created": "2022-02-01T17:20:51.953+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9442,7 +9498,7 @@
         "id": 3067,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001015",
-        "modified": "2022-02-01T17:20:51.953+00:00",
+        "modified": "2022-02-01T17:20:51.953+0000",
         "name": "CropMRepository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]{9}$",
@@ -9489,7 +9545,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:13.024+00:00",
+        "created": "2019-06-11T14:16:13.024+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9498,7 +9554,7 @@
         "id": 469,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000149",
-        "modified": "2019-06-11T14:16:13.024+00:00",
+        "modified": "2019-06-11T14:16:13.024+0000",
         "name": "CryptoDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+",
@@ -9545,7 +9601,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:11.769+00:00",
+        "created": "2019-06-11T14:16:11.769+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9554,7 +9610,7 @@
         "id": 454,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000144",
-        "modified": "2019-06-11T14:16:11.769+00:00",
+        "modified": "2019-06-11T14:16:11.769+0000",
         "name": "CSA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9][A-Za-z0-9]{3}$",
@@ -9601,7 +9657,7 @@
         "successor": null
       },
       {
-        "created": "2021-05-30T10:06:48.264+00:00",
+        "created": "2021-05-30T10:06:48.264+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9610,7 +9666,7 @@
         "id": 2668,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000820",
-        "modified": "2021-05-30T10:06:48.264+00:00",
+        "modified": "2021-05-30T10:06:48.264+0000",
         "name": "Cambridge Structural Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]{6}(\\d{2})?$",
@@ -9657,7 +9713,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:18.324+00:00",
+        "created": "2019-06-11T14:17:18.324+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9666,7 +9722,7 @@
         "id": 1232,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000429",
-        "modified": "2019-06-11T14:17:18.324+00:00",
+        "modified": "2019-06-11T14:17:18.324+0000",
         "name": "Cell Signaling Technology Pathways",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9_-]+$",
@@ -9713,7 +9769,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:18.559+00:00",
+        "created": "2019-06-11T14:17:18.559+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9722,7 +9778,7 @@
         "id": 1235,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000430",
-        "modified": "2019-06-11T14:17:18.559+00:00",
+        "modified": "2019-06-11T14:17:18.559+0000",
         "name": "Cell Signaling Technology Antibody",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -9769,7 +9825,7 @@
         "successor": null
       },
       {
-        "created": "2023-04-04T09:37:11.265+00:00",
+        "created": "2023-04-04T09:37:11.265+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9778,7 +9834,7 @@
         "id": 3486,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000998",
-        "modified": "2023-04-04T09:37:11.265+00:00",
+        "modified": "2023-04-04T09:37:11.265+0000",
         "name": "CSTR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{5}\\.\\d{2}\\..*$",
@@ -9825,7 +9881,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:59.108+00:00",
+        "created": "2019-06-11T14:15:59.108+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9834,7 +9890,7 @@
         "id": 320,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000098",
-        "modified": "2019-06-11T14:15:59.108+00:00",
+        "modified": "2019-06-11T14:15:59.108+0000",
         "name": "CTD Chemical",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[CD]\\d+$",
@@ -9881,7 +9937,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:59.348+00:00",
+        "created": "2019-06-11T14:15:59.348+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9890,7 +9946,7 @@
         "id": 323,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000099",
-        "modified": "2019-06-11T14:15:59.348+00:00",
+        "modified": "2019-06-11T14:15:59.348+0000",
         "name": "CTD Disease",
         "namespaceEmbeddedInLui": false,
         "pattern": "^D\\d+$",
@@ -9937,7 +9993,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:59.547+00:00",
+        "created": "2019-06-11T14:15:59.547+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -9946,7 +10002,7 @@
         "id": 325,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000100",
-        "modified": "2019-06-11T14:15:59.547+00:00",
+        "modified": "2019-06-11T14:15:59.547+0000",
         "name": "CTD Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -9993,7 +10049,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:11.437+00:00",
+        "created": "2019-06-11T14:17:11.437+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10002,7 +10058,7 @@
         "id": 1152,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000397",
-        "modified": "2019-06-11T14:17:11.437+00:00",
+        "modified": "2019-06-11T14:17:11.437+0000",
         "name": "Cube db",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z_0-9]+$",
@@ -10049,7 +10105,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:02.239+00:00",
+        "created": "2019-06-11T14:18:02.239+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10058,7 +10114,7 @@
         "id": 1696,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000611",
-        "modified": "2019-06-11T14:18:02.239+00:00",
+        "modified": "2019-06-11T14:18:02.239+0000",
         "name": "DataONE",
         "namespaceEmbeddedInLui": false,
         "pattern": "\\S+",
@@ -10105,7 +10161,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:19.532+00:00",
+        "created": "2019-06-11T14:17:19.532+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10114,7 +10170,7 @@
         "id": 1247,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000434",
-        "modified": "2019-06-11T14:17:19.532+00:00",
+        "modified": "2019-06-11T14:17:19.532+0000",
         "name": "DailyMed",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9-]+",
@@ -10161,7 +10217,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-24T05:11:19.658+00:00",
+        "created": "2020-03-24T05:11:19.658+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10170,7 +10226,7 @@
         "id": 2168,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000786",
-        "modified": "2021-10-18T12:32:14.264+00:00",
+        "modified": "2021-10-18T12:32:14.264+0000",
         "name": "DANDI: Distributed Archives for Neurophysiology Data Integration",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{6}(\\/\\d+\\.\\d+\\.\\d+)?$",
@@ -10217,7 +10273,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:02.814+00:00",
+        "created": "2019-06-11T14:17:02.814+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10226,7 +10282,7 @@
         "id": 1049,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000366",
-        "modified": "2019-06-11T14:17:02.814+00:00",
+        "modified": "2019-06-11T14:17:02.814+0000",
         "name": "DARC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -10273,7 +10329,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:49.634+00:00",
+        "created": "2019-06-11T14:17:49.634+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10282,7 +10338,7 @@
         "id": 1572,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000564",
-        "modified": "2019-06-11T14:17:49.634+00:00",
+        "modified": "2019-06-11T14:17:49.634+0000",
         "name": "DASHR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(hsa-(let|mir)-\\w+(-\\w+)?)|(piR-\\d+)|(chr\\w+.tRNA\\d+-\\w+)|(chr\\w+.tRNA\\d+-\\w+-tRF\\d)|((SNORD|SNORA|ACA|HBII|HBI|U)(-)?\\w+)|(HY\\d\\+(-L\\d+)?)|((LSU|SSU|5S)(-rRNA_Hsa)?(-L\\d+)?)$",
@@ -10329,7 +10385,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:49.866+00:00",
+        "created": "2019-06-11T14:17:49.866+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10338,7 +10394,7 @@
         "id": 1575,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000565",
-        "modified": "2019-06-11T14:17:49.866+00:00",
+        "modified": "2019-06-11T14:17:49.866+0000",
         "name": "DASHR expression",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(hsa-(let|mir)-\\w+(-\\w+)?)|(piR-\\d+)|(chr\\w+.tRNA\\d+-\\w+)|(chr\\w+.tRNA\\d+-\\w+-tRF\\d)|((SNORD|SNORA|ACA|HBII|HBI|U)(-)?\\w+)|(HY\\d\\+(-L\\d+)?)|((LSU|SSU|5S)(-rRNA_Hsa)?(-L\\d+)?)$",
@@ -10385,7 +10441,7 @@
         "successor": null
       },
       {
-        "created": "2020-05-22T09:05:34.813+00:00",
+        "created": "2020-05-22T09:05:34.813+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10394,7 +10450,7 @@
         "id": 2251,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000720",
-        "modified": "2020-05-22T09:05:34.813+00:00",
+        "modified": "2020-05-22T09:05:34.813+0000",
         "name": "Datanator Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^K[0-9]+$",
@@ -10441,7 +10497,7 @@
         "successor": null
       },
       {
-        "created": "2020-05-22T09:04:15.866+00:00",
+        "created": "2020-05-22T09:04:15.866+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10450,7 +10506,7 @@
         "id": 2248,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000718",
-        "modified": "2020-05-22T09:04:15.866+00:00",
+        "modified": "2020-05-22T09:04:15.866+0000",
         "name": "Datanator Metabolite",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z\\-]+$",
@@ -10497,7 +10553,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:56:43.759+00:00",
+        "created": "2021-08-08T09:56:43.759+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10506,7 +10562,7 @@
         "id": 2813,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000855",
-        "modified": "2021-08-08T13:31:35.848+00:00",
+        "modified": "2021-08-08T13:31:35.848+0000",
         "name": "Datanator Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^.*?--%3E.*?$",
@@ -10553,7 +10609,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:24.701+00:00",
+        "created": "2019-06-11T14:17:24.701+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10562,7 +10618,7 @@
         "id": 1307,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000456",
-        "modified": "2019-06-11T14:17:24.701+00:00",
+        "modified": "2019-06-11T14:17:24.701+0000",
         "name": "DATF",
         "namespaceEmbeddedInLui": false,
         "pattern": "^AT[1-5]G\\d{5}(\\.\\d+)?$",
@@ -10609,7 +10665,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:24.514+00:00",
+        "created": "2019-06-11T14:17:24.514+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10618,7 +10674,7 @@
         "id": 1305,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000455",
-        "modified": "2019-06-11T14:17:24.514+00:00",
+        "modified": "2019-06-11T14:17:24.514+0000",
         "name": "DBD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -10665,7 +10721,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:15.166+00:00",
+        "created": "2019-06-11T14:16:15.166+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10674,7 +10730,7 @@
         "id": 493,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000159",
-        "modified": "2019-06-11T14:16:15.166+00:00",
+        "modified": "2019-06-11T14:16:15.166+0000",
         "name": "dbEST",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-Z]+)?\\d+(\\.\\d+)?$",
@@ -10791,7 +10847,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:51.708+00:00",
+        "created": "2019-06-11T14:16:51.708+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10800,7 +10856,7 @@
         "id": 917,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000318",
-        "modified": "2019-06-11T14:16:51.708+00:00",
+        "modified": "2019-06-11T14:16:51.708+0000",
         "name": "DBG2 Introns",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{1,2}\\.(\\w{1,2}\\.)?[A-Za-z0-9]+$",
@@ -10847,7 +10903,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:59.890+00:00",
+        "created": "2019-06-11T14:17:59.890+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10856,7 +10912,7 @@
         "id": 1671,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000602",
-        "modified": "2019-06-11T14:17:59.890+00:00",
+        "modified": "2019-06-11T14:17:59.890+0000",
         "name": "dbGaP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^phs[0-9]{6}(.v\\d+.p\\d+)?$",
@@ -10903,7 +10959,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:15.607+00:00",
+        "created": "2019-06-11T14:16:15.607+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10912,7 +10968,7 @@
         "id": 497,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000160",
-        "modified": "2019-06-11T14:16:15.607+00:00",
+        "modified": "2019-06-11T14:16:15.607+0000",
         "name": "dbProbe",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -10959,7 +11015,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:15.831+00:00",
+        "created": "2019-06-11T14:16:15.831+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -10968,7 +11024,7 @@
         "id": 499,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000161",
-        "modified": "2019-06-11T14:16:15.831+00:00",
+        "modified": "2019-06-11T14:16:15.831+0000",
         "name": "dbSNP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^rs\\d+$",
@@ -11050,7 +11106,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:24.294+00:00",
+        "created": "2019-06-11T14:17:24.294+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11059,7 +11115,7 @@
         "id": 1302,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000454",
-        "modified": "2019-06-11T14:17:24.294+00:00",
+        "modified": "2019-06-11T14:17:24.294+0000",
         "name": "Degradome Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[AMCST][0-9x][0-9]$",
@@ -11106,7 +11162,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:18.034+00:00",
+        "created": "2019-06-11T14:17:18.034+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11115,7 +11171,7 @@
         "id": 1229,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000428",
-        "modified": "2019-06-11T14:17:18.034+00:00",
+        "modified": "2019-06-11T14:17:18.034+0000",
         "name": "DEPOD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -11162,7 +11218,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:12.998+00:00",
+        "created": "2019-06-11T14:18:12.998+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11171,7 +11227,7 @@
         "id": 1820,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000656",
-        "modified": "2019-06-11T14:18:12.998+00:00",
+        "modified": "2019-06-11T14:18:12.998+0000",
         "name": "Development Data Object Service",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9\\-:#\\.]+$",
@@ -11218,7 +11274,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:32:23.416+00:00",
+        "created": "2022-02-27T20:32:23.416+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11227,7 +11283,7 @@
         "id": 3155,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000922",
-        "modified": "2022-02-27T20:32:23.416+00:00",
+        "modified": "2022-02-27T20:32:23.416+0000",
         "name": "The AnVIL",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11274,7 +11330,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-29T19:10:32.057+00:00",
+        "created": "2021-09-29T19:10:32.057+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11283,7 +11339,7 @@
         "id": 2881,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000869",
-        "modified": "2021-09-29T19:10:32.057+00:00",
+        "modified": "2021-09-29T19:10:32.057+0000",
         "name": "BioData Catalyst",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11330,7 +11386,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:30:53.595+00:00",
+        "created": "2022-02-27T20:30:53.595+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11339,7 +11395,7 @@
         "id": 3142,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001019",
-        "modified": "2024-01-09T16:21:12.604+00:00",
+        "modified": "2024-01-09T16:21:12.604+0000",
         "name": "ACCOuNT Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11386,7 +11442,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-09T15:20:17.184+00:00",
+        "created": "2021-08-09T15:20:17.184+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11395,7 +11451,7 @@
         "id": 2821,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000857",
-        "modified": "2021-08-09T15:20:17.184+00:00",
+        "modified": "2021-08-09T15:20:17.184+0000",
         "name": "NCI Data Commons Framework Services",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11442,7 +11498,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-09T18:59:10.775+00:00",
+        "created": "2022-01-09T18:59:10.775+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11451,7 +11507,7 @@
         "id": 2999,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000895",
-        "modified": "2022-01-09T18:59:10.775+00:00",
+        "modified": "2022-01-09T18:59:10.775+0000",
         "name": "BloodPAC",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11498,7 +11554,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:33:18.862+00:00",
+        "created": "2022-02-27T20:33:18.862+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11507,7 +11563,7 @@
         "id": 3168,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001026",
-        "modified": "2022-02-27T20:33:18.862+00:00",
+        "modified": "2022-02-27T20:33:18.862+0000",
         "name": "Chicago Pandemic Response Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11554,7 +11610,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-29T19:13:19.448+00:00",
+        "created": "2021-09-29T19:13:19.448+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11563,7 +11619,7 @@
         "id": 2892,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000876",
-        "modified": "2021-09-29T19:13:19.448+00:00",
+        "modified": "2021-09-29T19:13:19.448+0000",
         "name": "JCOIN",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11610,7 +11666,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:33:06.143+00:00",
+        "created": "2022-02-27T20:33:06.143+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11619,7 +11675,7 @@
         "id": 3165,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000928",
-        "modified": "2022-02-27T20:33:06.143+00:00",
+        "modified": "2022-02-27T20:33:06.143+0000",
         "name": "NHLBI BioData Catalyst",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11666,7 +11722,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:32:37.384+00:00",
+        "created": "2022-02-27T20:32:37.384+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11675,7 +11731,7 @@
         "id": 3158,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000925",
-        "modified": "2022-02-27T20:32:37.384+00:00",
+        "modified": "2022-02-27T20:32:37.384+0000",
         "name": "Environmental Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11722,7 +11778,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:31:14.555+00:00",
+        "created": "2022-02-27T20:31:14.555+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11731,7 +11787,7 @@
         "id": 3146,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000919",
-        "modified": "2022-02-27T20:31:14.555+00:00",
+        "modified": "2022-02-27T20:31:14.555+0000",
         "name": "GenoMEL Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11778,7 +11834,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-29T19:11:14.294+00:00",
+        "created": "2021-09-29T19:11:14.294+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11787,7 +11843,7 @@
         "id": 2884,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000871",
-        "modified": "2021-09-29T19:11:14.294+00:00",
+        "modified": "2021-09-29T19:11:14.294+0000",
         "name": "Anvil",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
@@ -11834,7 +11890,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:38:48.115+00:00",
+        "created": "2022-02-27T20:38:48.115+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11843,7 +11899,7 @@
         "id": 3183,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000940",
-        "modified": "2022-02-27T20:38:48.115+00:00",
+        "modified": "2022-02-27T20:38:48.115+0000",
         "name": "Canine Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11890,7 +11946,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:31:33.330+00:00",
+        "created": "2022-02-27T20:31:33.330+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11899,7 +11955,7 @@
         "id": 3149,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001021",
-        "modified": "2022-02-27T20:31:33.330+00:00",
+        "modified": "2022-02-27T20:31:33.330+0000",
         "name": "NIDDK IBD Genetics Consortium Portal",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -11946,7 +12002,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:29:04.474+00:00",
+        "created": "2022-02-27T20:29:04.474+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -11955,7 +12011,7 @@
         "id": 3135,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000916",
-        "modified": "2023-04-28T10:52:16.460+00:00",
+        "modified": "2023-04-28T10:52:16.460+0000",
         "name": "Veterans Precision Oncology Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12002,7 +12058,7 @@
         "successor": null
       },
       {
-        "created": "2021-11-01T17:49:13.981+00:00",
+        "created": "2021-11-01T17:49:13.981+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12011,7 +12067,7 @@
         "id": 2969,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000887",
-        "modified": "2021-11-01T17:49:13.981+00:00",
+        "modified": "2021-11-01T17:49:13.981+0000",
         "name": "Kids First",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12058,7 +12114,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:39:04.388+00:00",
+        "created": "2022-02-27T20:39:04.388+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12067,7 +12123,7 @@
         "id": 3186,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000942",
-        "modified": "2022-02-27T20:39:04.388+00:00",
+        "modified": "2022-02-27T20:39:04.388+0000",
         "name": "The HEAL platform",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12114,7 +12170,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:40:41.328+00:00",
+        "created": "2022-02-27T20:40:41.328+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12123,7 +12179,7 @@
         "id": 3189,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000944",
-        "modified": "2022-02-27T20:40:41.328+00:00",
+        "modified": "2022-02-27T20:40:41.328+0000",
         "name": "HEAL Data Platform",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12170,7 +12226,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:33:39.208+00:00",
+        "created": "2022-02-27T20:33:39.208+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12179,7 +12235,7 @@
         "id": 3171,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000932",
-        "modified": "2022-02-27T20:33:39.208+00:00",
+        "modified": "2022-02-27T20:33:39.208+0000",
         "name": "MIDRC Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12226,7 +12282,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:30:23.278+00:00",
+        "created": "2022-02-27T20:30:23.278+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12235,7 +12291,7 @@
         "id": 3139,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000917",
-        "modified": "2022-02-27T20:30:23.278+00:00",
+        "modified": "2022-02-27T20:30:23.278+0000",
         "name": "https://accessclinicaldata.niaid.nih.gov/",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12282,7 +12338,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:37:35.848+00:00",
+        "created": "2022-02-27T20:37:35.848+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12291,7 +12347,7 @@
         "id": 3177,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000936",
-        "modified": "2022-02-27T20:37:35.848+00:00",
+        "modified": "2022-02-27T20:37:35.848+0000",
         "name": "NCI Data Commons Framework Services",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12338,7 +12394,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:40:56.446+00:00",
+        "created": "2022-02-27T20:40:56.446+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12347,7 +12403,7 @@
         "id": 3193,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000946",
-        "modified": "2022-02-27T20:40:56.446+00:00",
+        "modified": "2022-02-27T20:40:56.446+0000",
         "name": "UMCCR AGHA Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12394,7 +12450,7 @@
         "successor": null
       },
       {
-        "created": "2023-05-02T09:56:24.768+00:00",
+        "created": "2023-05-02T09:56:24.768+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12403,7 +12459,7 @@
         "id": 3533,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001104",
-        "modified": "2023-05-02T09:56:24.768+00:00",
+        "modified": "2023-05-02T09:56:24.768+0000",
         "name": "VA Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12450,16 +12506,16 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:37:55.926+00:00",
+        "created": "2022-02-27T20:37:55.926+0000",
         "deprecated": true,
-        "deprecationDate": "2023-04-28T10:42:52.292+00:00",
+        "deprecationDate": "2023-04-28T10:42:52.292+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "The Veterans Data Commons supports the management, analysis and sharing of veteran oncologic data for the research community and aims to accelerate discovery and development of therapies, diagnostic tests, and other technologies for precision oncology.",
         "id": 3180,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000938",
-        "modified": "2023-04-28T10:42:52.298+00:00",
+        "modified": "2023-04-28T10:42:52.298+0000",
         "name": "Veterans Precision Oncology Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -12506,7 +12562,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:54.345+00:00",
+        "created": "2019-06-11T14:16:54.345+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12515,7 +12571,7 @@
         "id": 948,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000330",
-        "modified": "2019-06-11T14:16:54.345+00:00",
+        "modified": "2019-06-11T14:16:54.345+0000",
         "name": "Dictybase EST",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DDB\\d+$",
@@ -12562,7 +12618,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:45.247+00:00",
+        "created": "2019-06-11T14:16:45.247+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12571,7 +12627,7 @@
         "id": 839,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000286",
-        "modified": "2019-06-11T14:16:45.247+00:00",
+        "modified": "2019-06-11T14:16:45.247+0000",
         "name": "Dictybase Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DDB_G\\d+$",
@@ -12618,7 +12674,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:21.755+00:00",
+        "created": "2019-06-11T14:18:21.755+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12627,7 +12683,7 @@
         "id": 1913,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000691",
-        "modified": "2019-06-11T14:18:21.755+00:00",
+        "modified": "2019-06-11T14:18:21.755+0000",
         "name": "Decentralized Identifiers (DIDs)",
         "namespaceEmbeddedInLui": true,
         "pattern": "^did:[a-z0-9]+:[A-Za-z0-9.\\-:]+$",
@@ -12674,7 +12730,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:44.329+00:00",
+        "created": "2019-06-11T14:15:44.329+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12683,7 +12739,7 @@
         "id": 166,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000044",
-        "modified": "2019-06-11T14:15:44.329+00:00",
+        "modified": "2019-06-11T14:15:44.329+0000",
         "name": "Database of Interacting Proteins",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DIP(\\:)?\\-\\d{1,}[ENXS]$",
@@ -12730,7 +12786,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:24.278+00:00",
+        "created": "2019-06-11T14:16:24.278+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12739,7 +12795,7 @@
         "id": 598,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000199",
-        "modified": "2021-02-17T17:15:29.025+00:00",
+        "modified": "2021-02-17T17:15:29.025+0000",
         "name": "DisProt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DP\\d{5}$",
@@ -12786,7 +12842,7 @@
         "successor": null
       },
       {
-        "created": "2019-12-09T15:18:31.130+00:00",
+        "created": "2019-12-09T15:18:31.130+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12795,7 +12851,7 @@
         "id": 2061,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000745",
-        "modified": "2019-12-09T15:18:31.130+00:00",
+        "modified": "2019-12-09T15:18:31.130+0000",
         "name": "DisProt region",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DP\\d{5}r\\d{3}$",
@@ -12842,7 +12898,7 @@
         "successor": null
       },
       {
-        "created": "2019-10-01T11:40:36.666+00:00",
+        "created": "2019-10-01T11:40:36.666+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12851,7 +12907,7 @@
         "id": 2026,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000747",
-        "modified": "2019-10-01T11:40:36.666+00:00",
+        "modified": "2019-10-01T11:40:36.666+0000",
         "name": "Linear double stranded DNA sequences",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]{6,7}$",
@@ -12898,7 +12954,7 @@
         "successor": null
       },
       {
-        "created": "2019-09-24T11:03:08.927+00:00",
+        "created": "2019-09-24T11:03:08.927+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12907,7 +12963,7 @@
         "id": 2022,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000742",
-        "modified": "2019-09-24T11:03:08.927+00:00",
+        "modified": "2019-09-24T11:03:08.927+0000",
         "name": "Circular double stranded DNA sequences composed",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]{6,7}$",
@@ -12954,7 +13010,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:34.841+00:00",
+        "created": "2019-06-11T14:15:34.841+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -12963,7 +13019,7 @@
         "id": 75,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000019",
-        "modified": "2023-01-05T18:09:18.209+00:00",
+        "modified": "2023-01-05T18:09:18.209+0000",
         "name": "DOI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(doi\\:)?10\\.\\d+/.*$",
@@ -13045,7 +13101,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:32.719+00:00",
+        "created": "2019-06-11T14:16:32.719+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13054,7 +13110,7 @@
         "id": 689,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000233",
-        "modified": "2020-07-20T14:34:20.285+00:00",
+        "modified": "2020-07-20T14:34:20.285+0000",
         "name": "Human Disease Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^DOID:\\d+$",
@@ -13171,7 +13227,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:04.514+00:00",
+        "created": "2019-06-11T14:17:04.514+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13180,7 +13236,7 @@
         "id": 1071,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000373",
-        "modified": "2019-06-11T14:17:04.514+00:00",
+        "modified": "2019-06-11T14:17:04.514+0000",
         "name": "DOMMINO",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9][A-Za-z0-9]{3}$",
@@ -13227,7 +13283,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:24.062+00:00",
+        "created": "2019-06-11T14:17:24.062+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13236,7 +13292,7 @@
         "id": 1299,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000453",
-        "modified": "2019-06-11T14:17:24.062+00:00",
+        "modified": "2019-06-11T14:17:24.062+0000",
         "name": "DOOR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -13283,7 +13339,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:09.111+00:00",
+        "created": "2019-06-11T14:16:09.111+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13292,7 +13348,7 @@
         "id": 427,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000134",
-        "modified": "2019-06-11T14:16:09.111+00:00",
+        "modified": "2019-06-11T14:16:09.111+0000",
         "name": "Database of Quantitative Cellular Signaling: Model",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -13339,7 +13395,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:09.372+00:00",
+        "created": "2019-06-11T14:16:09.372+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13348,7 +13404,7 @@
         "id": 430,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000135",
-        "modified": "2019-06-11T14:16:09.372+00:00",
+        "modified": "2019-06-11T14:16:09.372+0000",
         "name": "Database of Quantitative Cellular Signaling: Pathway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -13395,7 +13451,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:43.916+00:00",
+        "created": "2019-06-11T14:16:43.916+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13404,7 +13460,7 @@
         "id": 823,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000280",
-        "modified": "2019-06-11T14:16:43.916+00:00",
+        "modified": "2019-06-11T14:16:43.916+0000",
         "name": "DPV",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -13451,7 +13507,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:47.981+00:00",
+        "created": "2019-06-11T14:16:47.981+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13460,7 +13516,7 @@
         "id": 873,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000300",
-        "modified": "2019-06-11T14:16:47.981+00:00",
+        "modified": "2019-06-11T14:16:47.981+0000",
         "name": "DragonDB Allele",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -13507,7 +13563,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:47.375+00:00",
+        "created": "2019-06-11T14:16:47.375+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13516,7 +13572,7 @@
         "id": 866,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000297",
-        "modified": "2019-06-11T14:16:47.375+00:00",
+        "modified": "2019-06-11T14:16:47.375+0000",
         "name": "DragonDB DNA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d\\w+$",
@@ -13563,7 +13619,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:47.798+00:00",
+        "created": "2019-06-11T14:16:47.798+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13572,7 +13628,7 @@
         "id": 871,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000299",
-        "modified": "2019-06-11T14:16:47.798+00:00",
+        "modified": "2019-06-11T14:16:47.798+0000",
         "name": "DragonDB Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -13619,7 +13675,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:47.607+00:00",
+        "created": "2019-06-11T14:16:47.607+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13628,7 +13684,7 @@
         "id": 869,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000298",
-        "modified": "2019-06-11T14:16:47.607+00:00",
+        "modified": "2019-06-11T14:16:47.607+0000",
         "name": "DragonDB Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -13675,7 +13731,7 @@
         "successor": null
       },
       {
-        "created": "2023-06-01T09:26:38.236+00:00",
+        "created": "2023-06-01T09:26:38.236+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13684,7 +13740,7 @@
         "id": 3571,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001014",
-        "modified": "2023-06-01T09:26:38.236+00:00",
+        "modified": "2023-06-01T09:26:38.236+0000",
         "name": "AnVIL DRS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^v2_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
@@ -13731,7 +13787,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:03.033+00:00",
+        "created": "2019-06-11T14:17:03.033+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13740,7 +13796,7 @@
         "id": 1052,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000367",
-        "modified": "2019-06-11T14:17:03.033+00:00",
+        "modified": "2019-06-11T14:17:03.033+0000",
         "name": "DRSC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DRSC\\d+$",
@@ -13787,7 +13843,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:00.005+00:00",
+        "created": "2019-06-11T14:16:00.005+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13796,7 +13852,7 @@
         "id": 330,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000102",
-        "modified": "2019-06-11T14:16:00.005+00:00",
+        "modified": "2019-06-11T14:16:00.005+0000",
         "name": "DrugBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DB\\d{5}$",
@@ -13843,7 +13899,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:41.273+00:00",
+        "created": "2019-06-11T14:17:41.273+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13852,7 +13908,7 @@
         "id": 1485,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000528",
-        "modified": "2019-06-11T14:17:41.273+00:00",
+        "modified": "2019-06-11T14:17:41.273+0000",
         "name": "DrugBank Target v4",
         "namespaceEmbeddedInLui": false,
         "pattern": "^BE\\d{7}$",
@@ -13899,7 +13955,7 @@
         "successor": null
       },
       {
-        "created": "2022-11-04T09:54:32.976+00:00",
+        "created": "2022-11-04T09:54:32.976+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13908,7 +13964,7 @@
         "id": 3298,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000966",
-        "modified": "2022-11-04T09:54:32.976+00:00",
+        "modified": "2022-11-04T09:54:32.976+0000",
         "name": "DrugCentral",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -13955,7 +14011,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:28.483+00:00",
+        "created": "2019-06-11T14:15:28.483+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -13964,7 +14020,7 @@
         "id": 13,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000004",
-        "modified": "2019-06-11T14:15:28.483+00:00",
+        "modified": "2019-06-11T14:15:28.483+0000",
         "name": "Enzyme Nomenclature",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+\\.-\\.-\\.-|\\d+\\.\\d+\\.-\\.-|\\d+\\.\\d+\\.\\d+\\.-|\\d+\\.\\d+\\.\\d+\\.(n)?\\d+$",
@@ -14151,7 +14207,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:24.496+00:00",
+        "created": "2019-06-11T14:16:24.496+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14160,7 +14216,7 @@
         "id": 601,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000200",
-        "modified": "2019-06-11T14:16:24.496+00:00",
+        "modified": "2019-06-11T14:16:24.496+0000",
         "name": "EchoBASE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EB\\d+$",
@@ -14207,7 +14263,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:47.447+00:00",
+        "created": "2019-06-11T14:15:47.447+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14216,7 +14272,7 @@
         "id": 197,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000055",
-        "modified": "2019-06-11T14:15:47.447+00:00",
+        "modified": "2019-06-11T14:15:47.447+0000",
         "name": "Evidence Code Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "ECO:\\d{7}$",
@@ -14298,7 +14354,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:16.429+00:00",
+        "created": "2019-06-11T14:16:16.429+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14307,7 +14363,7 @@
         "id": 505,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000163",
-        "modified": "2019-06-11T14:16:16.429+00:00",
+        "modified": "2019-06-11T14:16:16.429+0000",
         "name": "EcoGene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EG\\d+$",
@@ -14354,7 +14410,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:21.287+00:00",
+        "created": "2019-06-11T14:17:21.287+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14363,7 +14419,7 @@
         "id": 1267,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000442",
-        "modified": "2019-06-11T14:17:21.287+00:00",
+        "modified": "2019-06-11T14:17:21.287+0000",
         "name": "EcoliWiki",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9-]+$",
@@ -14410,7 +14466,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:55.541+00:00",
+        "created": "2019-06-11T14:17:55.541+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14419,7 +14475,7 @@
         "id": 1628,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000585",
-        "modified": "2019-06-11T14:17:55.541+00:00",
+        "modified": "2019-06-11T14:17:55.541+0000",
         "name": "E-cyanobacterium entity",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -14466,7 +14522,7 @@
         "successor": null
       },
       {
-        "created": "2019-09-10T12:51:24.637+00:00",
+        "created": "2019-09-10T12:51:24.637+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14475,7 +14531,7 @@
         "id": 2003,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000760",
-        "modified": "2019-09-10T12:51:24.637+00:00",
+        "modified": "2019-09-10T12:51:24.637+0000",
         "name": "E-cyanobacterium Experimental Data",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -14522,7 +14578,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:55.864+00:00",
+        "created": "2019-06-11T14:17:55.864+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14531,7 +14587,7 @@
         "id": 1631,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000586",
-        "modified": "2019-06-11T14:17:55.864+00:00",
+        "modified": "2019-06-11T14:17:55.864+0000",
         "name": "E-cyanobacterium model",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -14578,7 +14634,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:56.089+00:00",
+        "created": "2019-06-11T14:17:56.089+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14587,7 +14643,7 @@
         "id": 1633,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000587",
-        "modified": "2019-06-11T14:17:56.089+00:00",
+        "modified": "2019-06-11T14:17:56.089+0000",
         "name": "E-cyanobacterium rule",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -14634,7 +14690,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:22.318+00:00",
+        "created": "2019-06-11T14:16:22.318+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14643,7 +14699,7 @@
         "id": 575,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000189",
-        "modified": "2019-06-11T14:16:22.318+00:00",
+        "modified": "2024-03-20T11:53:50.927+0000",
         "name": "EDAM Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(data|topic|operation|format)\\_\\d{4}$",
@@ -14725,7 +14781,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:09.753+00:00",
+        "created": "2019-06-11T14:17:09.753+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14734,7 +14790,7 @@
         "id": 1132,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000391",
-        "modified": "2019-06-11T14:17:09.753+00:00",
+        "modified": "2019-06-11T14:17:09.753+0000",
         "name": "Experimental Factor Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{7}$",
@@ -14851,7 +14907,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:37.233+00:00",
+        "created": "2019-06-11T14:17:37.233+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14860,7 +14916,7 @@
         "id": 1444,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000512",
-        "modified": "2019-06-11T14:17:37.233+00:00",
+        "modified": "2019-06-11T14:17:37.233+0000",
         "name": "European Genome-phenome Archive Dataset",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EGAD\\d{11}$",
@@ -14942,7 +14998,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:36.823+00:00",
+        "created": "2019-06-11T14:17:36.823+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -14951,7 +15007,7 @@
         "id": 1441,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000511",
-        "modified": "2019-06-11T14:17:36.823+00:00",
+        "modified": "2019-06-11T14:17:36.823+0000",
         "name": "European Genome-phenome Archive Study",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EGAS\\d{11}$",
@@ -15033,7 +15089,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:24.719+00:00",
+        "created": "2019-06-11T14:16:24.719+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15042,7 +15098,7 @@
         "id": 604,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000201",
-        "modified": "2019-06-11T14:16:24.719+00:00",
+        "modified": "2019-06-11T14:16:24.719+0000",
         "name": "eggNOG",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -15089,7 +15145,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:37.386+00:00",
+        "created": "2019-06-11T14:16:37.386+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15098,7 +15154,7 @@
         "id": 742,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000250",
-        "modified": "2019-06-11T14:16:37.386+00:00",
+        "modified": "2019-06-11T14:16:37.386+0000",
         "name": "ELM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z_0-9]+$",
@@ -15145,7 +15201,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:48.947+00:00",
+        "created": "2019-06-11T14:17:48.947+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15154,7 +15210,7 @@
         "id": 1565,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000561",
-        "modified": "2023-02-20T08:55:04.411+00:00",
+        "modified": "2023-02-20T08:55:04.411+0000",
         "name": "Electron Microscopy Data Bank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EMD-\\d{4,5}$",
@@ -15201,7 +15257,7 @@
         "successor": null
       },
       {
-        "created": "2023-01-25T11:52:06.260+00:00",
+        "created": "2023-01-25T11:52:06.260+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15210,7 +15266,7 @@
         "id": 3404,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000986",
-        "modified": "2023-01-25T11:52:06.260+00:00",
+        "modified": "2023-01-25T11:52:06.260+0000",
         "name": "EMPIAR",
         "namespaceEmbeddedInLui": false,
         "pattern": "EMPIAR-\\d{5,}",
@@ -15257,7 +15313,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:04.223+00:00",
+        "created": "2019-06-11T14:17:04.223+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15266,7 +15322,7 @@
         "id": 1068,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000372",
-        "modified": "2019-06-11T14:17:04.223+00:00",
+        "modified": "2019-06-11T14:17:04.223+0000",
         "name": "ENA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]+[0-9]+(\\.\\d+)?$",
@@ -15348,7 +15404,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:14.565+00:00",
+        "created": "2019-06-11T14:18:14.565+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15357,7 +15413,7 @@
         "id": 1836,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000662",
-        "modified": "2019-06-11T14:18:14.565+00:00",
+        "modified": "2019-06-11T14:18:14.565+0000",
         "name": "ENCODE: Encyclopedia of DNA Elements",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ENC[A-Za-z]{2}[0-9]{3}[A-Za-z]{3}$",
@@ -15404,7 +15460,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:27.869+00:00",
+        "created": "2019-06-11T14:15:27.869+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15413,7 +15469,7 @@
         "id": 7,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000003",
-        "modified": "2023-01-09T13:51:48.046+00:00",
+        "modified": "2023-01-09T13:51:48.046+0000",
         "name": "Ensembl",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((ENS[FPTG]\\d{11}(\\.\\d+)?)|(FB\\w{2}\\d{7})|(Y[A-Z]{2}\\d{3}[a-zA-Z](\\-[A-Z])?)|([A-Z_a-z0-9]+(\\.)?(t)?(\\d+)?([a-z])?))$",
@@ -15565,7 +15621,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:24.944+00:00",
+        "created": "2019-06-11T14:16:24.944+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15574,7 +15630,7 @@
         "id": 607,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000202",
-        "modified": "2019-06-11T14:16:24.944+00:00",
+        "modified": "2019-06-11T14:16:24.944+0000",
         "name": "Ensembl Bacteria",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((EB\\w+)|([A-Z0-9]+\\_[A-Z0-9]+))$",
@@ -15621,7 +15677,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:25.804+00:00",
+        "created": "2019-06-11T14:16:25.804+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15630,7 +15686,7 @@
         "id": 615,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000206",
-        "modified": "2019-06-11T14:16:25.804+00:00",
+        "modified": "2019-06-11T14:16:25.804+0000",
         "name": "Ensembl Fungi",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z-a-z0-9]+$",
@@ -15677,7 +15733,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:25.396+00:00",
+        "created": "2019-06-11T14:16:25.396+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15686,7 +15742,7 @@
         "id": 611,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000204",
-        "modified": "2019-06-11T14:16:25.396+00:00",
+        "modified": "2019-06-11T14:16:25.396+0000",
         "name": "Ensembl Metazoa",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\.)?\\d+$",
@@ -15733,7 +15789,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:25.597+00:00",
+        "created": "2019-06-11T14:16:25.597+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15742,7 +15798,7 @@
         "id": 613,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000205",
-        "modified": "2019-06-11T14:16:25.597+00:00",
+        "modified": "2019-06-11T14:16:25.597+0000",
         "name": "Ensembl Plants",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\.\\d+)?(\\.\\d+)?$",
@@ -15789,7 +15845,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:25.183+00:00",
+        "created": "2019-06-11T14:16:25.183+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15798,7 +15854,7 @@
         "id": 609,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000203",
-        "modified": "2019-06-11T14:16:25.183+00:00",
+        "modified": "2019-06-11T14:16:25.183+0000",
         "name": "Ensembl Protists",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -15845,7 +15901,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-24T07:50:16.285+00:00",
+        "created": "2020-03-24T07:50:16.285+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15854,7 +15910,7 @@
         "id": 2198,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000727",
-        "modified": "2020-03-24T07:50:16.285+00:00",
+        "modified": "2020-03-24T07:50:16.285+0000",
         "name": "enviPath",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[\\w^_]{8}-[\\w^_]{4}-[\\w^_]{4}-[\\w^_]{4}-[\\w^_]{12}\\/[\\w-]+\\/[\\w^_]{8}-[\\w^_]{4}-[\\w^_]{4}-[\\w^_]{4}-[\\w^_]{12}$",
@@ -15901,7 +15957,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:57.267+00:00",
+        "created": "2019-06-11T14:17:57.267+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -15910,7 +15966,7 @@
         "id": 1644,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000591",
-        "modified": "2021-04-17T20:07:01.902+00:00",
+        "modified": "2021-04-17T20:07:01.902+0000",
         "name": "Environment Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^ENVO:\\d{7,8}$",
@@ -15992,7 +16048,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:38.985+00:00",
+        "created": "2019-06-11T14:17:38.985+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16001,7 +16057,7 @@
         "id": 1462,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000518",
-        "modified": "2019-06-11T14:17:38.985+00:00",
+        "modified": "2019-06-11T14:17:38.985+0000",
         "name": "Plant Environment Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^(P)?EO\\:\\d{7}$",
@@ -16118,7 +16174,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:14.109+00:00",
+        "created": "2019-06-11T14:17:14.109+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16127,7 +16183,7 @@
         "id": 1185,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000408",
-        "modified": "2019-06-11T14:17:14.109+00:00",
+        "modified": "2019-06-11T14:17:14.109+0000",
         "name": "EPD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z-_0-9]+$",
@@ -16174,7 +16230,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-19T15:38:51.382+00:00",
+        "created": "2019-06-19T15:38:51.382+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16183,7 +16239,7 @@
         "id": 1942,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000763",
-        "modified": "2019-06-19T15:38:51.382+00:00",
+        "modified": "2019-06-19T15:38:51.382+0000",
         "name": "European Registry of Materials",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ERM[0-9]{8}$",
@@ -16230,7 +16286,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:04.072+00:00",
+        "created": "2019-06-11T14:18:04.072+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16239,7 +16295,7 @@
         "id": 1718,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000619",
-        "modified": "2019-06-11T14:18:04.072+00:00",
+        "modified": "2019-06-11T14:18:04.072+0000",
         "name": "Human Endogenous Retrovirus Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9\\-\\_]+$",
@@ -16286,7 +16342,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:09.859+00:00",
+        "created": "2019-06-11T14:18:09.859+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16295,7 +16351,7 @@
         "id": 1786,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000644",
-        "modified": "2019-06-11T14:18:09.859+00:00",
+        "modified": "2019-06-11T14:18:09.859+0000",
         "name": "JRC Data Catalogue",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z0-9\\-_]+$",
@@ -16342,7 +16398,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:43.129+00:00",
+        "created": "2019-06-11T14:17:43.129+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16351,7 +16407,7 @@
         "id": 1504,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000536",
-        "modified": "2019-06-11T14:17:43.129+00:00",
+        "modified": "2019-06-11T14:17:43.129+0000",
         "name": "EU Clinical Trials",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{4}\\-\\d{6}\\-\\d{2}$",
@@ -16398,7 +16454,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:45.890+00:00",
+        "created": "2019-06-11T14:17:45.890+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16407,7 +16463,7 @@
         "id": 1535,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000548",
-        "modified": "2019-06-11T14:17:45.890+00:00",
+        "modified": "2019-06-11T14:17:45.890+0000",
         "name": "ExAC Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ENSG\\d{11}$",
@@ -16454,7 +16510,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:45.691+00:00",
+        "created": "2019-06-11T14:17:45.691+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16463,7 +16519,7 @@
         "id": 1533,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000547",
-        "modified": "2019-06-11T14:17:45.691+00:00",
+        "modified": "2019-06-11T14:17:45.691+0000",
         "name": "ExAC Transcript",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ENST\\d{11}$",
@@ -16510,7 +16566,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:44.275+00:00",
+        "created": "2019-06-11T14:17:44.275+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16519,7 +16575,7 @@
         "id": 1518,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000541",
-        "modified": "2019-06-11T14:17:44.275+00:00",
+        "modified": "2019-06-11T14:17:44.275+0000",
         "name": "ExAC Variant",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{1,2}\\-\\d+\\-[GATC]\\-[GATC]$",
@@ -16566,7 +16622,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:32:53.923+00:00",
+        "created": "2022-02-27T20:32:53.923+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16575,7 +16631,7 @@
         "id": 3161,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000926",
-        "modified": "2022-02-27T20:32:53.923+00:00",
+        "modified": "2022-02-27T20:32:53.923+0000",
         "name": "Kids First Data Catalog",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}",
@@ -16622,7 +16678,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:09.365+00:00",
+        "created": "2019-06-11T14:18:09.365+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16631,7 +16687,7 @@
         "id": 1780,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000642",
-        "modified": "2019-06-11T14:18:09.365+00:00",
+        "modified": "2019-06-11T14:18:09.365+0000",
         "name": "FaceBase Data Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^FB\\d{8}$",
@@ -16678,7 +16734,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:02.358+00:00",
+        "created": "2019-06-11T14:17:02.358+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16687,7 +16743,7 @@
         "id": 1043,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000364",
-        "modified": "2019-06-11T14:17:02.358+00:00",
+        "modified": "2019-06-11T14:17:02.358+0000",
         "name": "FAIRsharing",
         "namespaceEmbeddedInLui": false,
         "pattern": "^bsg-[dscp]?\\d{6}$",
@@ -16734,7 +16790,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:40.188+00:00",
+        "created": "2019-06-11T14:15:40.188+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16743,7 +16799,7 @@
         "id": 125,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000030",
-        "modified": "2019-06-11T14:15:40.188+00:00",
+        "modified": "2019-06-11T14:15:40.188+0000",
         "name": "FlyBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^FB\\w{2}\\d{7}$",
@@ -16860,7 +16916,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:14.533+00:00",
+        "created": "2019-06-11T14:17:14.533+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16869,7 +16925,7 @@
         "id": 1189,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000410",
-        "modified": "2019-06-11T14:17:14.533+00:00",
+        "modified": "2019-06-11T14:17:14.533+0000",
         "name": "Fungal Barcode",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -16916,7 +16972,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-09T18:54:14.401+00:00",
+        "created": "2022-01-09T18:54:14.401+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16925,7 +16981,7 @@
         "id": 2991,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000891",
-        "modified": "2022-01-09T18:54:14.401+00:00",
+        "modified": "2022-01-09T18:54:14.401+0000",
         "name": "the FAIR Cookbook",
         "namespaceEmbeddedInLui": false,
         "pattern": "^FCB\\d{3}",
@@ -16972,7 +17028,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:17.129+00:00",
+        "created": "2019-06-11T14:18:17.129+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -16981,7 +17037,7 @@
         "id": 1861,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000672",
-        "modified": "2019-06-11T14:18:17.129+00:00",
+        "modified": "2019-06-11T14:18:17.129+0000",
         "name": "FlowRepository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^FR\\-FCM\\-\\w{4}$",
@@ -17028,7 +17084,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:50.895+00:00",
+        "created": "2019-06-11T14:15:50.895+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17037,7 +17093,7 @@
         "id": 233,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000067",
-        "modified": "2019-06-11T14:15:50.895+00:00",
+        "modified": "2019-06-11T14:15:50.895+0000",
         "name": "FMA",
         "namespaceEmbeddedInLui": true,
         "pattern": "^FMA:\\d+$",
@@ -17119,7 +17175,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:41.796+00:00",
+        "created": "2019-06-11T14:17:41.796+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17128,7 +17184,7 @@
         "id": 1491,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000530",
-        "modified": "2019-06-11T14:17:41.796+00:00",
+        "modified": "2019-06-11T14:17:41.796+0000",
         "name": "FooDB Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^FDB\\d+$",
@@ -17175,7 +17231,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:14.340+00:00",
+        "created": "2019-06-11T14:18:14.340+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17184,7 +17240,7 @@
         "id": 1834,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000661",
-        "modified": "2019-06-11T14:18:14.340+00:00",
+        "modified": "2019-06-11T14:18:14.340+0000",
         "name": "FoodOn Food Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^FOODON:[0-9]{8}$",
@@ -17231,7 +17287,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:11.924+00:00",
+        "created": "2019-06-11T14:18:11.924+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17240,7 +17296,7 @@
         "id": 1809,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000651",
-        "modified": "2019-06-11T14:18:11.924+00:00",
+        "modified": "2019-06-11T14:18:11.924+0000",
         "name": "FamPlex",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9][A-Za-z0-9_]+$",
@@ -17251,7 +17307,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2021-05-10T19:46:22.120+00:00",
+            "deprecationDate": "2021-05-10T19:46:22.120+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "FPLX through BioPortal",
@@ -17322,7 +17378,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:33.340+00:00",
+        "created": "2019-06-11T14:17:33.340+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17331,7 +17387,7 @@
         "id": 1406,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000496",
-        "modified": "2019-06-11T14:17:33.340+00:00",
+        "modified": "2019-06-11T14:17:33.340+0000",
         "name": "F-SNP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^rs\\d+$",
@@ -17378,7 +17434,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:25.854+00:00",
+        "created": "2019-06-11T14:17:25.854+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17387,7 +17443,7 @@
         "id": 1321,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000461",
-        "modified": "2019-06-11T14:17:25.854+00:00",
+        "modified": "2019-06-11T14:17:25.854+0000",
         "name": "FuncBase Fly",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -17434,7 +17490,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:26.074+00:00",
+        "created": "2019-06-11T14:17:26.074+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17443,7 +17499,7 @@
         "id": 1324,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000462",
-        "modified": "2019-06-11T14:17:26.074+00:00",
+        "modified": "2019-06-11T14:17:26.074+0000",
         "name": "FuncBase Human",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -17490,7 +17546,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:26.285+00:00",
+        "created": "2019-06-11T14:17:26.285+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17499,7 +17555,7 @@
         "id": 1326,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000463",
-        "modified": "2019-06-11T14:17:26.285+00:00",
+        "modified": "2019-06-11T14:17:26.285+0000",
         "name": "FuncBase Mouse",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -17546,7 +17602,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:26.470+00:00",
+        "created": "2019-06-11T14:17:26.470+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17555,7 +17611,7 @@
         "id": 1328,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000464",
-        "modified": "2019-06-11T14:17:26.470+00:00",
+        "modified": "2019-06-11T14:17:26.470+0000",
         "name": "FuncBase Yeast",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -17602,7 +17658,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:41:19.080+00:00",
+        "created": "2021-08-08T09:41:19.080+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17611,7 +17667,7 @@
         "id": 2800,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000847",
-        "modified": "2021-08-08T09:41:19.080+00:00",
+        "modified": "2021-08-08T09:41:19.080+0000",
         "name": "FunderRegistry",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{9,9}$",
@@ -17658,7 +17714,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:02.591+00:00",
+        "created": "2019-06-11T14:17:02.591+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17667,7 +17723,7 @@
         "id": 1046,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000365",
-        "modified": "2019-06-11T14:17:02.591+00:00",
+        "modified": "2019-06-11T14:17:02.591+0000",
         "name": "FungiDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z_0-9]+$",
@@ -17714,7 +17770,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:16.879+00:00",
+        "created": "2019-06-11T14:18:16.879+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17723,7 +17779,7 @@
         "id": 1859,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000671",
-        "modified": "2019-06-11T14:18:16.879+00:00",
+        "modified": "2019-06-11T14:18:16.879+0000",
         "name": "Data Object Service",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9\\-:#/\\.]+$",
@@ -17770,7 +17826,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:16.652+00:00",
+        "created": "2019-06-11T14:16:16.652+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17779,7 +17835,7 @@
         "id": 508,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000164",
-        "modified": "2019-06-11T14:16:16.652+00:00",
+        "modified": "2019-06-11T14:16:16.652+0000",
         "name": "GABI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -17826,7 +17882,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-26T07:35:34.234+00:00",
+        "created": "2021-02-26T07:35:34.234+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17835,7 +17891,7 @@
         "id": 2548,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000796",
-        "modified": "2021-02-26T07:35:34.234+00:00",
+        "modified": "2021-02-26T07:35:34.234+0000",
         "name": "gateway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
@@ -17882,7 +17938,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-17T12:55:17.868+00:00",
+        "created": "2019-06-17T12:55:17.868+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17891,7 +17947,7 @@
         "id": 1934,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000715",
-        "modified": "2020-09-23T11:03:41.882+00:00",
+        "modified": "2020-09-23T11:03:41.882+0000",
         "name": "GWAS Catalog",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GCST\\d{6}\\d*$",
@@ -17938,7 +17994,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:00.311+00:00",
+        "created": "2019-06-11T14:18:00.311+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -17947,7 +18003,7 @@
         "id": 1676,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000604",
-        "modified": "2019-06-11T14:18:00.311+00:00",
+        "modified": "2019-06-11T14:18:00.311+0000",
         "name": "Genomic Data Commons Data Portal",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$",
@@ -17994,7 +18050,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:18.593+00:00",
+        "created": "2019-06-11T14:18:18.593+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18003,7 +18059,7 @@
         "id": 1878,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000678",
-        "modified": "2019-06-11T14:18:18.593+00:00",
+        "modified": "2019-06-11T14:18:18.593+0000",
         "name": "Genomics of Drug Sensitivity in Cancer",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -18050,7 +18106,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:26.301+00:00",
+        "created": "2019-06-11T14:16:26.301+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18059,7 +18115,7 @@
         "id": 620,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000208",
-        "modified": "2019-06-11T14:16:26.301+00:00",
+        "modified": "2019-06-11T14:16:26.301+0000",
         "name": "Genatlas",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -18106,7 +18162,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:52.858+00:00",
+        "created": "2019-06-11T14:16:52.858+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18115,7 +18171,7 @@
         "id": 932,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000323",
-        "modified": "2019-06-11T14:16:52.858+00:00",
+        "modified": "2019-06-11T14:16:52.858+0000",
         "name": "GeneCards",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z-0-9_]+(\\@)?$",
@@ -18162,16 +18218,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:00.951+00:00",
+        "created": "2019-06-11T14:16:00.951+0000",
         "deprecated": true,
-        "deprecationDate": "2023-01-05T20:09:01.370+00:00",
+        "deprecationDate": "2023-01-05T20:09:01.370+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "GeneDB is a genome database for prokaryotic and eukaryotic organisms and provides a portal through which data generated by the \"Pathogen Genomics\" group at the Wellcome Trust Sanger Institute and other collaborating sequencing centres can be accessed.",
         "id": 341,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000106",
-        "modified": "2023-09-12T10:55:57.622+00:00",
+        "modified": "2023-09-12T10:55:57.622+0000",
         "name": "GeneDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[\\w\\d\\.-]*$",
@@ -18218,7 +18274,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:27.145+00:00",
+        "created": "2019-06-11T14:16:27.145+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18227,7 +18283,7 @@
         "id": 628,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000211",
-        "modified": "2019-06-11T14:16:27.145+00:00",
+        "modified": "2019-06-11T14:16:27.145+0000",
         "name": "GeneFarm",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -18274,7 +18330,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:27.950+00:00",
+        "created": "2019-06-11T14:16:27.950+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18283,7 +18339,7 @@
         "id": 637,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000214",
-        "modified": "2019-06-11T14:16:27.950+00:00",
+        "modified": "2019-06-11T14:16:27.950+0000",
         "name": "GeneTree",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ENSGT\\d+$",
@@ -18330,7 +18386,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:31.086+00:00",
+        "created": "2019-06-11T14:17:31.086+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18339,7 +18395,7 @@
         "id": 1382,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000487",
-        "modified": "2019-06-11T14:17:31.086+00:00",
+        "modified": "2019-06-11T14:17:31.086+0000",
         "name": "Gene Wiki",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -18386,7 +18442,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:57.671+00:00",
+        "created": "2019-06-11T14:16:57.671+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18395,7 +18451,7 @@
         "id": 989,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000345",
-        "modified": "2019-06-11T14:16:57.671+00:00",
+        "modified": "2019-06-11T14:16:57.671+0000",
         "name": "GenPept",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{3}\\d{5}(\\.\\d+)?$",
@@ -18442,7 +18498,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:21.507+00:00",
+        "created": "2019-06-11T14:17:21.507+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18451,7 +18507,7 @@
         "id": 1270,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000443",
-        "modified": "2019-06-11T14:17:21.507+00:00",
+        "modified": "2019-06-11T14:17:21.507+0000",
         "name": "Genome Properties",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GenProp\\d+$",
@@ -18498,7 +18554,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:47.245+00:00",
+        "created": "2019-06-11T14:15:47.245+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18507,7 +18563,7 @@
         "id": 195,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000054",
-        "modified": "2019-06-11T14:15:47.245+00:00",
+        "modified": "2019-06-11T14:15:47.245+0000",
         "name": "GEO",
         "namespaceEmbeddedInLui": false,
         "pattern": "^G(PL|SM|SE|DS)\\d+$",
@@ -18554,7 +18610,7 @@
         "successor": null
       },
       {
-        "created": "2021-05-30T10:17:36.624+00:00",
+        "created": "2021-05-30T10:17:36.624+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18563,7 +18619,7 @@
         "id": 2677,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000824",
-        "modified": "2021-05-30T10:17:36.624+00:00",
+        "modified": "2021-05-30T10:17:36.624+0000",
         "name": "Geographical Entity Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GEO_[0-9]{9}$",
@@ -18610,7 +18666,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:13.424+00:00",
+        "created": "2019-06-11T14:16:13.424+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18619,7 +18675,7 @@
         "id": 473,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000151",
-        "modified": "2019-06-11T14:16:13.424+00:00",
+        "modified": "2019-06-11T14:16:13.424+0000",
         "name": "GiardiaDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -18666,7 +18722,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:49:13.100+00:00",
+        "created": "2021-08-08T09:49:13.100+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18675,7 +18731,7 @@
         "id": 2810,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000853",
-        "modified": "2021-08-08T09:49:13.100+00:00",
+        "modified": "2021-08-08T09:49:13.100+0000",
         "name": "github",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+$",
@@ -18722,7 +18778,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-09T19:35:24.140+00:00",
+        "created": "2022-01-09T19:35:24.140+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18731,7 +18787,7 @@
         "id": 3013,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000901",
-        "modified": "2022-01-29T17:48:48.838+00:00",
+        "modified": "2022-01-29T17:48:48.838+0000",
         "name": "GitLab",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9A-Za-z_][0-9A-Za-z-_()\\. ]*/[0-9A-Za-z_][0-9A-Za-z-_\\. ]*$",
@@ -18778,7 +18834,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:32.633+00:00",
+        "created": "2019-06-11T14:17:32.633+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18787,7 +18843,7 @@
         "id": 1398,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000493",
-        "modified": "2019-06-11T14:17:32.633+00:00",
+        "modified": "2019-06-11T14:17:32.633+0000",
         "name": "GLIDA GPCR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z-_0-9]+$",
@@ -18834,7 +18890,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:32.872+00:00",
+        "created": "2019-06-11T14:17:32.872+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18843,7 +18899,7 @@
         "id": 1401,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000494",
-        "modified": "2019-06-11T14:17:32.872+00:00",
+        "modified": "2019-06-11T14:17:32.872+0000",
         "name": "GLIDA Ligand",
         "namespaceEmbeddedInLui": false,
         "pattern": "^L\\d+$",
@@ -18890,7 +18946,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:29.214+00:00",
+        "created": "2019-06-11T14:17:29.214+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18899,7 +18955,7 @@
         "id": 1360,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000478",
-        "modified": "2019-06-11T14:17:29.214+00:00",
+        "modified": "2019-06-11T14:17:29.214+0000",
         "name": "GlycoEpitope",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EP\\d{4}$",
@@ -18946,7 +19002,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:03.253+00:00",
+        "created": "2019-06-11T14:16:03.253+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -18955,7 +19011,7 @@
         "id": 363,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000114",
-        "modified": "2019-06-11T14:16:03.253+00:00",
+        "modified": "2019-06-11T14:16:03.253+0000",
         "name": "GlycomeDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -19002,7 +19058,7 @@
         "successor": null
       },
       {
-        "created": "2021-06-28T19:11:39.342+00:00",
+        "created": "2021-06-28T19:11:39.342+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19011,7 +19067,7 @@
         "id": 2714,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000830",
-        "modified": "2022-11-08T15:20:10.791+00:00",
+        "modified": "2022-11-08T15:20:10.791+0000",
         "name": "GlycoNAVI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GN_[A-Za-z]*[_]*[A-Za-z0-9-:_]+$",
@@ -19058,7 +19114,7 @@
         "successor": null
       },
       {
-        "created": "2020-10-08T09:25:59.424+00:00",
+        "created": "2020-10-08T09:25:59.424+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19067,7 +19123,7 @@
         "id": 2384,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000721",
-        "modified": "2020-10-08T09:25:59.424+00:00",
+        "modified": "2020-10-08T09:25:59.424+0000",
         "name": "GlycoPOST",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GPST[0-9]{6}$",
@@ -19114,7 +19170,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:01.543+00:00",
+        "created": "2019-06-11T14:18:01.543+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19123,7 +19179,7 @@
         "id": 1688,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000608",
-        "modified": "2019-06-11T14:18:01.543+00:00",
+        "modified": "2019-06-11T14:18:01.543+0000",
         "name": "GlyTouCan",
         "namespaceEmbeddedInLui": false,
         "pattern": "^G[0-9]{5}[A-Z]{2}$",
@@ -19170,7 +19226,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:42.514+00:00",
+        "created": "2019-06-11T14:16:42.514+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19179,7 +19235,7 @@
         "id": 805,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000274",
-        "modified": "2019-06-11T14:16:42.514+00:00",
+        "modified": "2019-06-11T14:16:42.514+0000",
         "name": "Golm Metabolome Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$",
@@ -19226,7 +19282,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:17.661+00:00",
+        "created": "2019-06-11T14:17:17.661+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19235,7 +19291,7 @@
         "id": 1225,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000426",
-        "modified": "2019-06-11T14:17:17.661+00:00",
+        "modified": "2019-06-11T14:17:17.661+0000",
         "name": "Golm Metabolome Database Analyte",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$",
@@ -19282,7 +19338,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:17.255+00:00",
+        "created": "2019-06-11T14:17:17.255+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19291,7 +19347,7 @@
         "id": 1221,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000424",
-        "modified": "2019-06-11T14:17:17.255+00:00",
+        "modified": "2019-06-11T14:17:17.255+0000",
         "name": "Golm Metabolome Database GC-MS spectra",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$",
@@ -19338,7 +19394,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:17.038+00:00",
+        "created": "2019-06-11T14:17:17.038+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19347,7 +19403,7 @@
         "id": 1219,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000423",
-        "modified": "2019-06-11T14:17:17.038+00:00",
+        "modified": "2019-06-11T14:17:17.038+0000",
         "name": "Golm Metabolome Database Profile",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$",
@@ -19394,7 +19450,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:17.475+00:00",
+        "created": "2019-06-11T14:17:17.475+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19403,7 +19459,7 @@
         "id": 1223,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000425",
-        "modified": "2019-06-11T14:17:17.475+00:00",
+        "modified": "2019-06-11T14:17:17.475+0000",
         "name": "Golm Metabolome Database Reference Substance",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$",
@@ -19450,7 +19506,7 @@
         "successor": null
       },
       {
-        "created": "2023-04-14T08:41:21.064+00:00",
+        "created": "2023-04-14T08:41:21.064+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19459,7 +19515,7 @@
         "id": 3501,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001002",
-        "modified": "2023-04-14T08:41:21.064+00:00",
+        "modified": "2023-04-14T08:41:21.064+0000",
         "name": "Gemeinsame Normdatei",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9X\\-]+",
@@ -19506,7 +19562,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:05.948+00:00",
+        "created": "2019-06-11T14:18:05.948+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19515,7 +19571,7 @@
         "id": 1741,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000627",
-        "modified": "2019-06-11T14:18:05.948+00:00",
+        "modified": "2019-06-11T14:18:05.948+0000",
         "name": "GnpIS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -19562,7 +19618,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:35.970+00:00",
+        "created": "2019-06-11T14:15:35.970+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19571,7 +19627,7 @@
         "id": 87,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000022",
-        "modified": "2019-06-11T14:15:35.970+00:00",
+        "modified": "2019-06-11T14:15:35.970+0000",
         "name": "Gene Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^GO:\\d{7}$",
@@ -19793,7 +19849,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:23.452+00:00",
+        "created": "2019-06-11T14:17:23.452+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19802,7 +19858,7 @@
         "id": 1292,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000450",
-        "modified": "2020-07-30T07:27:34.233+00:00",
+        "modified": "2020-07-30T07:27:34.233+0000",
         "name": "Gene Ontology Reference",
         "namespaceEmbeddedInLui": true,
         "pattern": "^GO_REF:\\d{7}$",
@@ -19849,7 +19905,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:23.594+00:00",
+        "created": "2019-06-11T14:16:23.594+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19858,7 +19914,7 @@
         "id": 590,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000196",
-        "modified": "2019-06-11T14:16:23.594+00:00",
+        "modified": "2019-06-11T14:16:23.594+0000",
         "name": "GOA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9]))|(URS[0-9A-F]{10}(_[0-9]+){0,1})|(EBI-[0-9]+)$",
@@ -19905,7 +19961,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-17T08:03:56.077+00:00",
+        "created": "2020-03-17T08:03:56.077+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19914,7 +19970,7 @@
         "id": 2129,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000733",
-        "modified": "2020-03-17T08:03:56.077+00:00",
+        "modified": "2020-03-17T08:03:56.077+0000",
         "name": "Genomes OnLine Database (GOLD)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z][a-z][0-9]+$",
@@ -19961,7 +20017,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:12.343+00:00",
+        "created": "2019-06-11T14:17:12.343+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -19970,7 +20026,7 @@
         "id": 1164,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000401",
-        "modified": "2020-03-26T09:37:26.767+00:00",
+        "modified": "2020-03-26T09:37:26.767+0000",
         "name": "GOLD genome",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(Gi|Gc)\\d+$",
@@ -20017,7 +20073,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:12.564+00:00",
+        "created": "2019-06-11T14:17:12.564+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20026,7 +20082,7 @@
         "id": 1167,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000402",
-        "modified": "2020-03-26T09:38:38.398+00:00",
+        "modified": "2020-03-26T09:38:38.398+0000",
         "name": "GOLD metadata",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Gm\\d+$",
@@ -20073,7 +20129,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:43.371+00:00",
+        "created": "2019-06-11T14:17:43.371+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20082,7 +20138,7 @@
         "id": 1507,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000537",
-        "modified": "2019-06-11T14:17:43.371+00:00",
+        "modified": "2019-06-11T14:17:43.371+0000",
         "name": "Google Patents",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]{2}\\d+([A-Z])?$",
@@ -20129,7 +20185,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:27.419+00:00",
+        "created": "2019-06-11T14:16:27.419+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20138,7 +20194,7 @@
         "id": 631,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000212",
-        "modified": "2019-06-11T14:16:27.419+00:00",
+        "modified": "2019-06-11T14:16:27.419+0000",
         "name": "GPCRDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -20185,7 +20241,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:11.249+00:00",
+        "created": "2019-06-11T14:18:11.249+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20194,7 +20250,7 @@
         "id": 1802,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000649",
-        "modified": "2019-06-11T14:18:11.249+00:00",
+        "modified": "2019-06-11T14:18:11.249+0000",
         "name": "GPMDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GPM\\d+$",
@@ -20276,7 +20332,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:20.812+00:00",
+        "created": "2019-06-11T14:16:20.812+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20285,7 +20341,7 @@
         "id": 558,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000182",
-        "modified": "2019-06-11T14:16:20.812+00:00",
+        "modified": "2019-06-11T14:16:20.812+0000",
         "name": "Gramene genes",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GR\\:\\d+$",
@@ -20332,7 +20388,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:20.589+00:00",
+        "created": "2019-06-11T14:16:20.589+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20341,7 +20397,7 @@
         "id": 555,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000181",
-        "modified": "2019-06-11T14:16:20.589+00:00",
+        "modified": "2019-06-11T14:16:20.589+0000",
         "name": "Gramene protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -20388,7 +20444,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:21.219+00:00",
+        "created": "2019-06-11T14:16:21.219+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20397,7 +20453,7 @@
         "id": 562,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000184",
-        "modified": "2019-06-11T14:16:21.219+00:00",
+        "modified": "2019-06-11T14:16:21.219+0000",
         "name": "Gramene QTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -20444,7 +20500,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:21.008+00:00",
+        "created": "2019-06-11T14:16:21.008+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20453,7 +20509,7 @@
         "id": 560,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000183",
-        "modified": "2019-06-11T14:16:21.008+00:00",
+        "modified": "2019-06-11T14:16:21.008+0000",
         "name": "Gramene Taxonomy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GR\\_tax\\:\\d+$",
@@ -20500,7 +20556,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:16.885+00:00",
+        "created": "2019-06-11T14:16:16.885+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20509,7 +20565,7 @@
         "id": 511,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000165",
-        "modified": "2019-06-11T14:16:16.885+00:00",
+        "modified": "2019-06-11T14:16:16.885+0000",
         "name": "GreenGenes",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -20556,7 +20612,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:57.806+00:00",
+        "created": "2019-06-11T14:17:57.806+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20565,7 +20621,7 @@
         "id": 1650,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000593",
-        "modified": "2019-06-11T14:17:57.806+00:00",
+        "modified": "2019-06-11T14:17:57.806+0000",
         "name": "GRID",
         "namespaceEmbeddedInLui": false,
         "pattern": "^grid\\.[0-9]+\\.[a-f0-9]{1,2}$",
@@ -20612,7 +20668,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:17.150+00:00",
+        "created": "2019-06-11T14:16:17.150+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20621,7 +20677,7 @@
         "id": 514,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000166",
-        "modified": "2019-06-11T14:16:17.150+00:00",
+        "modified": "2019-06-11T14:16:17.150+0000",
         "name": "GRIN Plant Taxonomy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -20668,7 +20724,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:36.384+00:00",
+        "created": "2019-06-11T14:17:36.384+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20677,7 +20733,7 @@
         "id": 1437,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000508",
-        "modified": "2023-01-10T16:08:16.467+00:00",
+        "modified": "2023-01-10T16:08:16.467+0000",
         "name": "Gramene Growth Stage Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^GRO:\\d+$",
@@ -20724,7 +20780,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:33.087+00:00",
+        "created": "2019-06-11T14:17:33.087+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20733,7 +20789,7 @@
         "id": 1403,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000495",
-        "modified": "2019-06-11T14:17:33.087+00:00",
+        "modified": "2019-06-11T14:17:33.087+0000",
         "name": "GRSDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -20780,7 +20836,7 @@
         "successor": null
       },
       {
-        "created": "2020-11-05T10:42:17.722+00:00",
+        "created": "2020-11-05T10:42:17.722+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20789,7 +20845,7 @@
         "id": 2423,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000712",
-        "modified": "2020-11-05T10:59:53.808+00:00",
+        "modified": "2020-11-05T10:59:53.808+0000",
         "name": "Gender, Sex, and Sexual Orientation (GSSO) Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^GSSO:\\d{6}$",
@@ -20836,7 +20892,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:14.830+00:00",
+        "created": "2019-06-11T14:18:14.830+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20845,7 +20901,7 @@
         "id": 1839,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000663",
-        "modified": "2019-06-11T14:18:14.830+00:00",
+        "modified": "2019-06-11T14:18:14.830+0000",
         "name": "GTEx",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w.+$",
@@ -20892,7 +20948,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:09.598+00:00",
+        "created": "2019-06-11T14:18:09.598+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20901,7 +20957,7 @@
         "id": 1783,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000643",
-        "modified": "2019-06-11T14:18:09.598+00:00",
+        "modified": "2019-06-11T14:18:09.598+0000",
         "name": "GUDMAP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[-0-9a-zA-Z]+(@[-0-9a-zA-Z]+)?$",
@@ -20948,7 +21004,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:44.511+00:00",
+        "created": "2019-06-11T14:17:44.511+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -20957,7 +21013,7 @@
         "id": 1521,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000542",
-        "modified": "2019-06-11T14:17:44.511+00:00",
+        "modified": "2019-06-11T14:17:44.511+0000",
         "name": "GWAS Central Marker",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HGVM\\d+$",
@@ -21004,7 +21060,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:44.698+00:00",
+        "created": "2019-06-11T14:17:44.698+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21013,7 +21069,7 @@
         "id": 1523,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000543",
-        "modified": "2021-02-01T16:43:30.697+00:00",
+        "modified": "2021-02-01T16:43:30.697+0000",
         "name": "GWAS Central Phenotype",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HGVPM\\d+$",
@@ -21060,7 +21116,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:44.062+00:00",
+        "created": "2019-06-11T14:17:44.062+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21069,7 +21125,7 @@
         "id": 1516,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000540",
-        "modified": "2019-06-11T14:17:44.062+00:00",
+        "modified": "2019-06-11T14:17:44.062+0000",
         "name": "GWAS Central Study",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HGVST\\d+$",
@@ -21116,7 +21172,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:06.163+00:00",
+        "created": "2019-06-11T14:17:06.163+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21125,7 +21181,7 @@
         "id": 1091,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000379",
-        "modified": "2019-06-11T14:17:06.163+00:00",
+        "modified": "2019-06-11T14:17:06.163+0000",
         "name": "GXA Expt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[AEP]-\\w{4}-\\d+$",
@@ -21207,7 +21263,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:05.964+00:00",
+        "created": "2019-06-11T14:17:05.964+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21216,7 +21272,7 @@
         "id": 1089,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000378",
-        "modified": "2019-06-11T14:17:05.964+00:00",
+        "modified": "2019-06-11T14:17:05.964+0000",
         "name": "GXA Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -21263,7 +21319,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:46.532+00:00",
+        "created": "2019-06-11T14:16:46.532+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21272,7 +21328,7 @@
         "id": 856,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000292",
-        "modified": "2019-06-11T14:16:46.532+00:00",
+        "modified": "2019-06-11T14:16:46.532+0000",
         "name": "HAMAP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MF_\\d+$",
@@ -21319,7 +21375,7 @@
         "successor": null
       },
       {
-        "created": "2024-01-05T09:25:24.380+00:00",
+        "created": "2024-01-05T09:25:24.380+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21328,7 +21384,7 @@
         "id": 3781,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001040",
-        "modified": "2024-01-05T09:25:24.380+00:00",
+        "modified": "2024-01-05T09:25:24.380+0000",
         "name": "Human Chromosome Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^.+$",
@@ -21375,7 +21431,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:26.018+00:00",
+        "created": "2019-06-11T14:16:26.018+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21384,7 +21440,7 @@
         "id": 617,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000207",
-        "modified": "2019-06-11T14:16:26.018+00:00",
+        "modified": "2019-06-11T14:16:26.018+0000",
         "name": "HCVDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^M\\d{5}$",
@@ -21431,7 +21487,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:33.593+00:00",
+        "created": "2019-06-11T14:17:33.593+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21440,7 +21496,7 @@
         "id": 1409,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000497",
-        "modified": "2019-06-11T14:17:33.593+00:00",
+        "modified": "2019-06-11T14:17:33.593+0000",
         "name": "Homeodomain Research",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -21487,7 +21543,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:10.208+00:00",
+        "created": "2019-06-11T14:17:10.208+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21496,7 +21552,7 @@
         "id": 1136,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000392",
-        "modified": "2019-06-11T14:17:10.208+00:00",
+        "modified": "2019-06-11T14:17:10.208+0000",
         "name": "HGMD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z_0-9]+$",
@@ -21543,7 +21599,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:54.375+00:00",
+        "created": "2019-06-11T14:15:54.375+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21552,7 +21608,7 @@
         "id": 271,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000080",
-        "modified": "2019-06-11T14:15:54.375+00:00",
+        "modified": "2019-06-11T14:15:54.375+0000",
         "name": "HGNC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((HGNC|hgnc):)?\\d{1,5}$",
@@ -21599,16 +21655,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:39.700+00:00",
+        "created": "2019-06-11T14:17:39.700+0000",
         "deprecated": true,
-        "deprecationDate": "2020-07-16T06:11:33.734+00:00",
+        "deprecationDate": "2020-07-16T06:11:33.734+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "The HGNC (HUGO Gene Nomenclature Committee) provides an approved gene name and symbol (short-form abbreviation) for each known human gene. All approved symbols are stored in the HGNC database, and each symbol is unique. In addition, HGNC also provides symbols for both structural and functional gene families. This collection refers to records using the HGNC family symbol.",
         "id": 1468,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000520",
-        "modified": "2020-07-16T06:11:33.736+00:00",
+        "modified": "2020-07-16T06:11:33.736+0000",
         "name": "HGNC Family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9-]+(#[A-Z0-9-]+)?$",
@@ -21619,7 +21675,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2020-07-16T06:11:29.395+00:00",
+            "deprecationDate": "2020-07-16T06:11:29.395+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "HGNC Family at HUGO Genome Nomenclature Committee",
@@ -21655,7 +21711,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:51.916+00:00",
+        "created": "2019-06-11T14:17:51.916+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21664,7 +21720,7 @@
         "id": 1596,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000573",
-        "modified": "2019-06-11T14:17:51.916+00:00",
+        "modified": "2019-06-11T14:17:51.916+0000",
         "name": "HGNC gene family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -21711,7 +21767,7 @@
         "successor": null
       },
       {
-        "created": "2020-07-16T06:20:43.698+00:00",
+        "created": "2020-07-16T06:20:43.698+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21720,7 +21776,7 @@
         "id": 2306,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000709",
-        "modified": "2020-07-16T06:20:43.698+00:00",
+        "modified": "2020-07-16T06:20:43.698+0000",
         "name": "HGNC Gene Group",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -21767,7 +21823,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:01.955+00:00",
+        "created": "2019-06-11T14:17:01.955+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21776,7 +21832,7 @@
         "id": 1039,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000362",
-        "modified": "2019-06-11T14:17:01.955+00:00",
+        "modified": "2019-06-11T14:17:01.955+0000",
         "name": "HGNC Symbol",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z-0-9_]+(\\@)?$",
@@ -21823,7 +21879,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:17.382+00:00",
+        "created": "2019-06-11T14:16:17.382+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21832,7 +21888,7 @@
         "id": 517,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000167",
-        "modified": "2019-06-11T14:16:17.382+00:00",
+        "modified": "2019-06-11T14:16:17.382+0000",
         "name": "H-InvDb Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HIX\\d{7}(\\.\\d+)?$",
@@ -21879,7 +21935,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:17.817+00:00",
+        "created": "2019-06-11T14:16:17.817+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21888,7 +21944,7 @@
         "id": 522,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000169",
-        "modified": "2019-06-11T14:16:17.817+00:00",
+        "modified": "2019-06-11T14:16:17.817+0000",
         "name": "H-InvDb Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HIP\\d{9}(\\.\\d+)?$",
@@ -21935,7 +21991,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:17.622+00:00",
+        "created": "2019-06-11T14:16:17.622+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -21944,7 +22000,7 @@
         "id": 520,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000168",
-        "modified": "2019-06-11T14:16:17.622+00:00",
+        "modified": "2019-06-11T14:16:17.622+0000",
         "name": "H-InvDb Transcript",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HIT\\d{9}(\\.\\d+)?$",
@@ -21991,7 +22047,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:46.469+00:00",
+        "created": "2019-06-11T14:15:46.469+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22000,7 +22056,7 @@
         "id": 186,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000051",
-        "modified": "2019-06-11T14:15:46.469+00:00",
+        "modified": "2019-06-11T14:15:46.469+0000",
         "name": "HMDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HMDB\\d+$",
@@ -22047,7 +22103,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:27.678+00:00",
+        "created": "2019-06-11T14:16:27.678+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22056,7 +22112,7 @@
         "id": 634,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000213",
-        "modified": "2019-06-11T14:16:27.678+00:00",
+        "modified": "2019-06-11T14:16:27.678+0000",
         "name": "HOGENOM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -22103,7 +22159,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:18.019+00:00",
+        "created": "2019-06-11T14:16:18.019+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22112,7 +22168,7 @@
         "id": 524,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000170",
-        "modified": "2019-06-11T14:16:18.019+00:00",
+        "modified": "2019-06-11T14:16:18.019+0000",
         "name": "HOMD Sequence Metainformation",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SEQF\\d+$",
@@ -22159,7 +22215,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:18.268+00:00",
+        "created": "2019-06-11T14:16:18.268+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22168,7 +22224,7 @@
         "id": 527,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000171",
-        "modified": "2019-06-11T14:16:18.268+00:00",
+        "modified": "2019-06-11T14:16:18.268+0000",
         "name": "HOMD Taxonomy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -22215,7 +22271,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:42.733+00:00",
+        "created": "2019-06-11T14:16:42.733+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22224,7 +22280,7 @@
         "id": 808,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000275",
-        "modified": "2019-06-11T14:16:42.733+00:00",
+        "modified": "2019-06-11T14:16:42.733+0000",
         "name": "HomoloGene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -22306,7 +22362,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:52.667+00:00",
+        "created": "2019-06-11T14:15:52.667+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22315,7 +22371,7 @@
         "id": 252,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000074",
-        "modified": "2019-06-11T14:15:52.667+00:00",
+        "modified": "2019-06-11T14:15:52.667+0000",
         "name": "HOVERGEN",
         "namespaceEmbeddedInLui": false,
         "pattern": "^HBG\\d+$",
@@ -22362,7 +22418,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:51.237+00:00",
+        "created": "2019-06-11T14:17:51.237+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22371,7 +22427,7 @@
         "id": 1589,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000571",
-        "modified": "2019-06-11T14:17:51.237+00:00",
+        "modified": "2019-06-11T14:17:51.237+0000",
         "name": "Human Phenotype Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^HP:\\d{7}$",
@@ -22453,7 +22509,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:55.662+00:00",
+        "created": "2019-06-11T14:16:55.662+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22462,7 +22518,7 @@
         "id": 964,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000336",
-        "modified": "2019-06-11T14:16:55.662+00:00",
+        "modified": "2019-06-11T14:16:55.662+0000",
         "name": "HPA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ENSG\\d{11}$",
@@ -22509,7 +22565,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:41.032+00:00",
+        "created": "2019-06-11T14:17:41.032+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22518,7 +22574,7 @@
         "id": 1483,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000527",
-        "modified": "2019-06-11T14:17:41.032+00:00",
+        "modified": "2019-06-11T14:17:41.032+0000",
         "name": "Human Proteome Map Peptide",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -22565,7 +22621,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:40.825+00:00",
+        "created": "2019-06-11T14:17:40.825+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22574,7 +22630,7 @@
         "id": 1481,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000526",
-        "modified": "2019-06-11T14:17:40.825+00:00",
+        "modified": "2019-06-11T14:17:40.825+0000",
         "name": "Human Proteome Map Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -22621,7 +22677,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:05.741+00:00",
+        "created": "2019-06-11T14:17:05.741+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22630,7 +22686,7 @@
         "id": 1086,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000377",
-        "modified": "2019-06-11T14:17:05.741+00:00",
+        "modified": "2019-06-11T14:17:05.741+0000",
         "name": "HPRD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -22677,7 +22733,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:17.630+00:00",
+        "created": "2019-06-11T14:18:17.630+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22686,7 +22742,7 @@
         "id": 1867,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000674",
-        "modified": "2019-06-11T14:18:17.630+00:00",
+        "modified": "2019-06-11T14:18:17.630+0000",
         "name": "Human Pluripotent Stem Cell Registry",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]{2,6}(e|i)[A-Za-z0-9]{3}-[A-Z]{1,2}(-[A-Za-z0-9]{1,2})?$",
@@ -22697,7 +22753,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2021-05-10T19:10:24.237+00:00",
+            "deprecationDate": "2021-05-10T19:10:24.237+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "Human Pluripotent Stem Cell Registry",
@@ -22768,7 +22824,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:28.184+00:00",
+        "created": "2019-06-11T14:16:28.184+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22777,7 +22833,7 @@
         "id": 639,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000215",
-        "modified": "2019-06-11T14:16:28.184+00:00",
+        "modified": "2019-06-11T14:16:28.184+0000",
         "name": "HSSP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{4}$",
@@ -22859,7 +22915,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:39.763+00:00",
+        "created": "2019-06-11T14:16:39.763+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22868,7 +22924,7 @@
         "id": 772,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000263",
-        "modified": "2019-06-11T14:16:39.763+00:00",
+        "modified": "2019-06-11T14:16:39.763+0000",
         "name": "HUGE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^KIAA\\d{4}$",
@@ -22915,7 +22971,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:00.081+00:00",
+        "created": "2019-06-11T14:18:00.081+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22924,7 +22980,7 @@
         "id": 1673,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000603",
-        "modified": "2019-06-11T14:18:00.081+00:00",
+        "modified": "2019-06-11T14:18:00.081+0000",
         "name": "Information Artifact Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{7}$",
@@ -22971,7 +23027,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:31.658+00:00",
+        "created": "2019-06-11T14:15:31.658+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -22980,7 +23036,7 @@
         "id": 43,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000009",
-        "modified": "2019-06-11T14:15:31.658+00:00",
+        "modified": "2019-06-11T14:15:31.658+0000",
         "name": "ICD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]\\d+(\\.[-\\d+])?$",
@@ -23027,7 +23083,7 @@
         "successor": null
       },
       {
-        "created": "2021-05-10T19:40:34.200+00:00",
+        "created": "2021-05-10T19:40:34.200+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23036,7 +23092,7 @@
         "id": 2638,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000812",
-        "modified": "2022-03-31T16:55:06.915+00:00",
+        "modified": "2022-03-31T16:55:06.915+0000",
         "name": "Integrated Canine Data Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{6}$",
@@ -23083,7 +23139,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:27.338+00:00",
+        "created": "2019-06-11T14:17:27.338+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23092,7 +23148,7 @@
         "id": 1338,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000469",
-        "modified": "2019-06-11T14:17:27.338+00:00",
+        "modified": "2019-06-11T14:17:27.338+0000",
         "name": "ICEberg element",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -23139,7 +23195,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:27.601+00:00",
+        "created": "2019-06-11T14:17:27.601+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23148,7 +23204,7 @@
         "id": 1341,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000470",
-        "modified": "2019-06-11T14:17:27.601+00:00",
+        "modified": "2019-06-11T14:17:27.601+0000",
         "name": "ICEberg family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -23195,7 +23251,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:11.651+00:00",
+        "created": "2019-06-11T14:17:11.651+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23204,7 +23260,7 @@
         "id": 1155,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000398",
-        "modified": "2019-06-11T14:17:11.651+00:00",
+        "modified": "2019-06-11T14:17:11.651+0000",
         "name": "IDEAL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^IID\\d+$",
@@ -23251,7 +23307,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-05T17:52:59.264+00:00",
+        "created": "2021-09-05T17:52:59.264+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23260,7 +23316,7 @@
         "id": 2844,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000859",
-        "modified": "2021-09-05T17:52:59.264+00:00",
+        "modified": "2021-09-05T17:52:59.264+0000",
         "name": "Identifiers.org namespace",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z_\\.]+$",
@@ -23307,7 +23363,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:18.372+00:00",
+        "created": "2019-06-11T14:18:18.372+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23316,7 +23372,7 @@
         "id": 1876,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000677",
-        "modified": "2019-06-11T14:18:18.372+00:00",
+        "modified": "2019-06-11T14:18:18.372+0000",
         "name": "Infectious Disease Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -23363,7 +23419,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:19.905+00:00",
+        "created": "2019-06-11T14:18:19.905+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23372,7 +23428,7 @@
         "id": 1893,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000683",
-        "modified": "2019-06-11T14:18:19.905+00:00",
+        "modified": "2019-06-11T14:18:19.905+0000",
         "name": "Identifiers.org Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-zA-Z]+$",
@@ -23419,7 +23475,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:39.487+00:00",
+        "created": "2019-06-11T14:17:39.487+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23428,7 +23484,7 @@
         "id": 1466,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000519",
-        "modified": "2019-06-11T14:17:39.487+00:00",
+        "modified": "2019-06-11T14:17:39.487+0000",
         "name": "Identifiers.org Terms",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z]+$",
@@ -23475,7 +23531,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-02T17:27:03.688+00:00",
+        "created": "2020-03-02T17:27:03.688+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23484,7 +23540,7 @@
         "id": 2108,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000743",
-        "modified": "2020-03-02T17:27:03.688+00:00",
+        "modified": "2020-03-02T17:27:03.688+0000",
         "name": "Image Data Resource",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]{4}$",
@@ -23531,7 +23587,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-05T17:58:19.858+00:00",
+        "created": "2021-09-05T17:58:19.858+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23540,7 +23596,7 @@
         "id": 2857,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000865",
-        "modified": "2021-09-05T17:58:19.858+00:00",
+        "modified": "2021-09-05T17:58:19.858+0000",
         "name": "Immune Epitope Database (IEDB)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -23587,7 +23643,7 @@
         "successor": null
       },
       {
-        "created": "2021-03-15T19:52:42.073+00:00",
+        "created": "2021-03-15T19:52:42.073+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23596,7 +23652,7 @@
         "id": 2594,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000806",
-        "modified": "2021-03-15T19:52:42.073+00:00",
+        "modified": "2021-03-15T19:52:42.073+0000",
         "name": "International Geo Sample Number",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z]{2,4}[A-Za-z0-9.-]{1,71}$",
@@ -23643,7 +23699,7 @@
         "successor": null
       },
       {
-        "created": "2021-05-22T16:59:04.850+00:00",
+        "created": "2021-05-22T16:59:04.850+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23652,7 +23708,7 @@
         "id": 2647,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000814",
-        "modified": "2021-05-22T16:59:04.850+00:00",
+        "modified": "2021-05-22T16:59:04.850+0000",
         "name": "InterLex",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -23699,7 +23755,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:05.272+00:00",
+        "created": "2019-06-11T14:16:05.272+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23708,7 +23764,7 @@
         "id": 386,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000122",
-        "modified": "2019-06-11T14:16:05.272+00:00",
+        "modified": "2019-06-11T14:16:05.272+0000",
         "name": "IMEx",
         "namespaceEmbeddedInLui": false,
         "pattern": "^IM-\\d+(-?)(\\d+?)$",
@@ -23790,7 +23846,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:19.420+00:00",
+        "created": "2019-06-11T14:16:19.420+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23799,7 +23855,7 @@
         "id": 541,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000176",
-        "modified": "2019-06-11T14:16:19.420+00:00",
+        "modified": "2019-06-11T14:16:19.420+0000",
         "name": "Integrated Microbial Genomes Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -23846,7 +23902,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:19.173+00:00",
+        "created": "2019-06-11T14:16:19.173+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23855,7 +23911,7 @@
         "id": 538,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000175",
-        "modified": "2019-06-11T14:16:19.173+00:00",
+        "modified": "2019-06-11T14:16:19.173+0000",
         "name": "Integrated Microbial Genomes Taxon",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -23902,7 +23958,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:54.535+00:00",
+        "created": "2019-06-11T14:16:54.535+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23911,7 +23967,7 @@
         "id": 950,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000331",
-        "modified": "2019-06-11T14:16:54.535+00:00",
+        "modified": "2019-06-11T14:16:54.535+0000",
         "name": "IMGT HLA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9*:]+$",
@@ -23958,7 +24014,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:45.469+00:00",
+        "created": "2019-06-11T14:16:45.469+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -23967,7 +24023,7 @@
         "id": 842,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000287",
-        "modified": "2019-06-11T14:16:45.469+00:00",
+        "modified": "2019-06-11T14:16:45.469+0000",
         "name": "IMGT LIGM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^M\\d+$",
@@ -24049,7 +24105,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:07.236+00:00",
+        "created": "2019-06-11T14:17:07.236+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24058,7 +24114,7 @@
         "id": 1103,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000383",
-        "modified": "2019-06-11T14:17:07.236+00:00",
+        "modified": "2019-06-11T14:17:07.236+0000",
         "name": "InChI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^InChI\\=1S?\\/[A-Za-z0-9\\.]+(\\+[0-9]+)?(\\/[cnpqbtmsih][A-Za-z0-9\\-\\+\\(\\)\\,\\/\\?\\;\\.]+)*$",
@@ -24210,7 +24266,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:08.649+00:00",
+        "created": "2019-06-11T14:17:08.649+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24219,7 +24275,7 @@
         "id": 1120,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000387",
-        "modified": "2019-06-11T14:17:08.649+00:00",
+        "modified": "2019-06-11T14:17:08.649+0000",
         "name": "InChIKey",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]{14}\\-[A-Z]{10}(\\-[A-Z])?",
@@ -24336,7 +24392,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:39.496+00:00",
+        "created": "2019-06-11T14:15:39.496+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24345,7 +24401,7 @@
         "id": 119,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000029",
-        "modified": "2023-03-06T09:23:15.163+00:00",
+        "modified": "2023-03-06T09:23:15.163+0000",
         "name": "Nucleotide Sequence Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-Z]\\d{5}|[A-Z]{2}\\d{6}|[A-Z]{4,6}\\d{8,10}|[A-J][A-Z]{2}\\d{5})(\\.\\d+)?$",
@@ -24497,7 +24553,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:00.782+00:00",
+        "created": "2019-06-11T14:18:00.782+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24506,7 +24562,7 @@
         "id": 1681,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000606",
-        "modified": "2019-06-11T14:18:00.782+00:00",
+        "modified": "2019-06-11T14:18:00.782+0000",
         "name": "INSDC CDS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-Z]\\d{5}|[A-Z]{2}\\d{6}|[A-Z]{4}\\d{8}|[A-J][A-Z]{2}\\d{5})(\\.\\d+)?$",
@@ -24623,7 +24679,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:01.236+00:00",
+        "created": "2019-06-11T14:18:01.236+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24632,7 +24688,7 @@
         "id": 1685,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000607",
-        "modified": "2023-10-30T09:41:30.572+00:00",
+        "modified": "2023-10-30T09:41:30.572+0000",
         "name": "Genome assembly database - INSDC accessions",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GCA_[0-9]{9}(\\.[0-9]+)?$",
@@ -24714,7 +24770,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:35.560+00:00",
+        "created": "2019-06-11T14:16:35.560+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24723,7 +24779,7 @@
         "id": 721,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000243",
-        "modified": "2019-06-11T14:16:35.560+00:00",
+        "modified": "2019-06-11T14:16:35.560+0000",
         "name": "Sequence Read Archive",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[SED]R[APRSXZ]\\d+$",
@@ -24840,7 +24896,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:31.920+00:00",
+        "created": "2019-06-11T14:15:31.920+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24849,7 +24905,7 @@
         "id": 46,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000010",
-        "modified": "2019-06-11T14:15:31.920+00:00",
+        "modified": "2019-06-11T14:15:31.920+0000",
         "name": "IntAct",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EBI\\-[0-9]+$",
@@ -24896,7 +24952,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:17.850+00:00",
+        "created": "2019-06-11T14:17:17.850+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24905,7 +24961,7 @@
         "id": 1227,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000427",
-        "modified": "2019-06-11T14:17:17.850+00:00",
+        "modified": "2019-06-11T14:17:17.850+0000",
         "name": "IntAct Molecule",
         "namespaceEmbeddedInLui": false,
         "pattern": "^EBI\\-[0-9]+$",
@@ -24952,7 +25008,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:32.153+00:00",
+        "created": "2019-06-11T14:15:32.153+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -24961,7 +25017,7 @@
         "id": 48,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000011",
-        "modified": "2019-06-11T14:15:32.153+00:00",
+        "modified": "2019-06-11T14:15:32.153+0000",
         "name": "InterPro",
         "namespaceEmbeddedInLui": false,
         "pattern": "^IPR\\d{6}$",
@@ -25043,7 +25099,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:18.461+00:00",
+        "created": "2019-06-11T14:16:18.461+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25052,7 +25108,7 @@
         "id": 529,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000172",
-        "modified": "2019-06-11T14:16:18.461+00:00",
+        "modified": "2019-06-11T14:16:18.461+0000",
         "name": "IRD Segment Sequence",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\_)?\\d+(\\.\\d+)?$",
@@ -25099,7 +25155,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:05.614+00:00",
+        "created": "2019-06-11T14:16:05.614+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25108,7 +25164,7 @@
         "id": 389,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000123",
-        "modified": "2019-06-11T14:16:05.614+00:00",
+        "modified": "2019-06-11T14:16:05.614+0000",
         "name": "iRefWeb",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25155,7 +25211,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:50.037+00:00",
+        "created": "2019-06-11T14:15:50.037+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25164,7 +25220,7 @@
         "id": 223,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000064",
-        "modified": "2019-06-11T14:15:50.037+00:00",
+        "modified": "2019-06-11T14:15:50.037+0000",
         "name": "ISBN",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(ISBN)?(-13|-10)?[:]?[ ]?(\\d{2,3}[ -]?)?\\d{1,5}[ -]?\\d{1,7}[ -]?\\d{1,6}[ -]?(\\d|X)$",
@@ -25246,7 +25302,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:18.690+00:00",
+        "created": "2019-06-11T14:16:18.690+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25255,7 +25311,7 @@
         "id": 532,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000173",
-        "modified": "2019-06-11T14:16:18.690+00:00",
+        "modified": "2019-06-11T14:16:18.690+0000",
         "name": "ISFinder",
         "namespaceEmbeddedInLui": false,
         "pattern": "^IS\\w+(\\-\\d)?$",
@@ -25302,7 +25358,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:20.121+00:00",
+        "created": "2019-06-11T14:18:20.121+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25311,7 +25367,7 @@
         "id": 1895,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000684",
-        "modified": "2019-06-11T14:18:20.121+00:00",
+        "modified": "2019-06-11T14:18:20.121+0000",
         "name": "International Standard Name Identifier",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]{15}[0-9X]{1}$",
@@ -25358,7 +25414,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:48.189+00:00",
+        "created": "2019-06-11T14:16:48.189+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25367,7 +25423,7 @@
         "id": 875,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000301",
-        "modified": "2019-06-11T14:16:48.189+00:00",
+        "modified": "2019-06-11T14:16:48.189+0000",
         "name": "ISSN",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{4}-\\d{3}[\\dX]$",
@@ -25449,7 +25505,7 @@
         "successor": null
       },
       {
-        "created": "2021-03-15T19:37:56.820+00:00",
+        "created": "2021-03-15T19:37:56.820+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25458,7 +25514,7 @@
         "id": 2585,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000802",
-        "modified": "2021-03-15T19:37:56.820+00:00",
+        "modified": "2021-03-15T19:37:56.820+0000",
         "name": "Intelligence Task Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^.+$",
@@ -25505,7 +25561,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:51.481+00:00",
+        "created": "2019-06-11T14:16:51.481+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25514,7 +25570,7 @@
         "id": 914,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000317",
-        "modified": "2019-06-11T14:16:51.481+00:00",
+        "modified": "2019-06-11T14:16:51.481+0000",
         "name": "IUPHAR family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25561,7 +25617,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:24.936+00:00",
+        "created": "2019-06-11T14:17:24.936+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25570,7 +25626,7 @@
         "id": 1310,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000457",
-        "modified": "2019-06-11T14:17:24.936+00:00",
+        "modified": "2019-06-11T14:17:24.936+0000",
         "name": "IUPHAR ligand",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25617,7 +25673,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:44.139+00:00",
+        "created": "2019-06-11T14:16:44.139+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25626,7 +25682,7 @@
         "id": 826,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000281",
-        "modified": "2019-06-11T14:16:44.139+00:00",
+        "modified": "2019-06-11T14:16:44.139+0000",
         "name": "IUPHAR receptor",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25673,7 +25729,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:55.877+00:00",
+        "created": "2019-06-11T14:16:55.877+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25682,7 +25738,7 @@
         "id": 967,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000337",
-        "modified": "2019-06-11T14:16:55.877+00:00",
+        "modified": "2019-06-11T14:16:55.877+0000",
         "name": "JAX Mice",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25729,7 +25785,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:29.437+00:00",
+        "created": "2019-06-11T14:17:29.437+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25738,7 +25794,7 @@
         "id": 1363,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000479",
-        "modified": "2019-06-11T14:17:29.437+00:00",
+        "modified": "2019-06-11T14:17:29.437+0000",
         "name": "JCGGDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^JCGG-STR\\d{6}$",
@@ -25785,7 +25841,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:18.921+00:00",
+        "created": "2019-06-11T14:16:18.921+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25794,7 +25850,7 @@
         "id": 535,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000174",
-        "modified": "2019-06-11T14:16:18.921+00:00",
+        "modified": "2019-06-11T14:16:18.921+0000",
         "name": "Japan Collection of Microorganisms",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25841,7 +25897,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:34.772+00:00",
+        "created": "2019-06-11T14:16:34.772+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25850,7 +25906,7 @@
         "id": 712,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000241",
-        "modified": "2019-06-11T14:16:34.772+00:00",
+        "modified": "2019-06-11T14:16:34.772+0000",
         "name": "Japan Chemical Substance Dictionary",
         "namespaceEmbeddedInLui": false,
         "pattern": "^J\\d{1,3}(\\.\\d{3})?(\\.\\d{1,3})?[A-Za-z]$",
@@ -25897,7 +25953,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:21.690+00:00",
+        "created": "2019-06-11T14:17:21.690+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25906,7 +25962,7 @@
         "id": 1272,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000444",
-        "modified": "2019-06-11T14:17:21.690+00:00",
+        "modified": "2019-06-11T14:17:21.690+0000",
         "name": "JSTOR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -25953,7 +26009,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:07.820+00:00",
+        "created": "2019-06-11T14:16:07.820+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -25962,7 +26018,7 @@
         "id": 412,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000130",
-        "modified": "2019-06-11T14:16:07.820+00:00",
+        "modified": "2019-06-11T14:16:07.820+0000",
         "name": "JWS Online",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -26079,7 +26135,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:19.662+00:00",
+        "created": "2019-06-11T14:18:19.662+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26088,7 +26144,7 @@
         "id": 1890,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000682",
-        "modified": "2019-06-11T14:18:19.662+00:00",
+        "modified": "2019-06-11T14:18:19.662+0000",
         "name": "Kaggle",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-zA-Z\\-]+\\/[0-9a-zA-Z\\-]+$",
@@ -26135,7 +26191,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:53.298+00:00",
+        "created": "2019-06-11T14:17:53.298+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26144,7 +26200,7 @@
         "id": 1609,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000578",
-        "modified": "2019-06-11T14:17:53.298+00:00",
+        "modified": "2019-06-11T14:17:53.298+0000",
         "name": "Kyoto Encyclopedia of Genes and Genomes",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([CHDEGTMKR]\\d+)|(\\w+:[\\w\\d\\.-]*)|([a-z]{3,5})|(\\w{2,4}\\d{5})$",
@@ -26191,7 +26247,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:32.730+00:00",
+        "created": "2019-06-11T14:15:32.730+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26200,7 +26256,7 @@
         "id": 53,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000013",
-        "modified": "2019-06-11T14:15:32.730+00:00",
+        "modified": "2019-06-11T14:15:32.730+0000",
         "name": "KEGG Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C\\d+$",
@@ -26247,7 +26303,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:28.601+00:00",
+        "created": "2019-06-11T14:17:28.601+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26256,7 +26312,7 @@
         "id": 1353,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000475",
-        "modified": "2019-06-11T14:17:28.601+00:00",
+        "modified": "2019-06-11T14:17:28.601+0000",
         "name": "KEGG Disease",
         "namespaceEmbeddedInLui": false,
         "pattern": "^H\\d+$",
@@ -26303,7 +26359,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:38.268+00:00",
+        "created": "2019-06-11T14:15:38.268+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26312,7 +26368,7 @@
         "id": 109,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000025",
-        "modified": "2019-06-11T14:15:38.268+00:00",
+        "modified": "2019-06-11T14:15:38.268+0000",
         "name": "KEGG Drug",
         "namespaceEmbeddedInLui": false,
         "pattern": "^D\\d+$",
@@ -26359,7 +26415,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:09.349+00:00",
+        "created": "2019-06-11T14:17:09.349+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26368,7 +26424,7 @@
         "id": 1127,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000389",
-        "modified": "2019-06-11T14:17:09.349+00:00",
+        "modified": "2019-06-11T14:17:09.349+0000",
         "name": "KEGG Environ",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(ev\\:)?E\\d+$",
@@ -26415,7 +26471,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:51.781+00:00",
+        "created": "2019-06-11T14:15:51.781+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26424,7 +26480,7 @@
         "id": 242,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000070",
-        "modified": "2019-06-11T14:15:51.781+00:00",
+        "modified": "2019-06-11T14:15:51.781+0000",
         "name": "KEGG Genes",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+:[\\w\\d\\.-]*$",
@@ -26471,7 +26527,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:34.113+00:00",
+        "created": "2019-06-11T14:16:34.113+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26480,7 +26536,7 @@
         "id": 704,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000238",
-        "modified": "2019-06-11T14:16:34.113+00:00",
+        "modified": "2019-06-11T14:16:34.113+0000",
         "name": "KEGG Genome",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(T0\\d+|\\w{3,5})$",
@@ -26527,7 +26583,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:38.579+00:00",
+        "created": "2019-06-11T14:15:38.579+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26536,7 +26592,7 @@
         "id": 111,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000026",
-        "modified": "2019-06-11T14:15:38.579+00:00",
+        "modified": "2019-06-11T14:15:38.579+0000",
         "name": "KEGG Glycan",
         "namespaceEmbeddedInLui": false,
         "pattern": "^G\\d+$",
@@ -26583,7 +26639,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:34.345+00:00",
+        "created": "2019-06-11T14:16:34.345+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26592,7 +26648,7 @@
         "id": 707,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000239",
-        "modified": "2019-06-11T14:16:34.345+00:00",
+        "modified": "2019-06-11T14:16:34.345+0000",
         "name": "KEGG Metagenome",
         "namespaceEmbeddedInLui": false,
         "pattern": "^T3\\d+$",
@@ -26639,7 +26695,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:28.414+00:00",
+        "created": "2019-06-11T14:17:28.414+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26648,7 +26704,7 @@
         "id": 1351,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000474",
-        "modified": "2019-06-11T14:17:28.414+00:00",
+        "modified": "2019-06-11T14:17:28.414+0000",
         "name": "KEGG Module",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([a-z]{3,5}_)?M\\d{5}$",
@@ -26695,7 +26751,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:03.735+00:00",
+        "created": "2019-06-11T14:16:03.735+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26704,7 +26760,7 @@
         "id": 369,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000116",
-        "modified": "2019-06-11T14:16:03.735+00:00",
+        "modified": "2019-06-11T14:16:03.735+0000",
         "name": "KEGG Orthology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^K\\d+$",
@@ -26751,7 +26807,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:32.480+00:00",
+        "created": "2019-06-11T14:15:32.480+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26760,7 +26816,7 @@
         "id": 51,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000012",
-        "modified": "2019-06-11T14:15:32.480+00:00",
+        "modified": "2019-06-11T14:15:32.480+0000",
         "name": "KEGG Pathway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{2,4}\\d{5}$",
@@ -26807,7 +26863,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:32.930+00:00",
+        "created": "2019-06-11T14:15:32.930+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26816,7 +26872,7 @@
         "id": 55,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000014",
-        "modified": "2019-06-11T14:15:32.930+00:00",
+        "modified": "2019-06-11T14:15:32.930+0000",
         "name": "KEGG Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^R\\d+$",
@@ -26863,7 +26919,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:41.635+00:00",
+        "created": "2019-06-11T14:16:41.635+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26872,7 +26928,7 @@
         "id": 794,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000271",
-        "modified": "2020-04-22T09:28:07.963+00:00",
+        "modified": "2020-04-22T09:28:07.963+0000",
         "name": "KNApSAcK",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C\\d{8}",
@@ -26919,7 +26975,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:20.599+00:00",
+        "created": "2019-06-11T14:18:20.599+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26928,7 +26984,7 @@
         "id": 1901,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000686",
-        "modified": "2019-06-11T14:18:20.599+00:00",
+        "modified": "2019-06-11T14:18:20.599+0000",
         "name": "Global LEI Index",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9A-Z]{4}[0-9A-Z]{14}[0-9A-Z]{2}$",
@@ -26975,7 +27031,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-05T18:01:14.906+00:00",
+        "created": "2021-09-05T18:01:14.906+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -26984,7 +27040,7 @@
         "id": 2862,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000867",
-        "modified": "2021-09-05T18:01:14.906+00:00",
+        "modified": "2021-09-05T18:01:14.906+0000",
         "name": "LG Chemical Entity Detection Dataset (LGCEDe)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LGCEDe-S-\\d{9}$",
@@ -27031,7 +27087,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:56.548+00:00",
+        "created": "2019-06-11T14:15:56.548+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27040,7 +27096,7 @@
         "id": 292,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000087",
-        "modified": "2019-06-11T14:15:56.548+00:00",
+        "modified": "2019-06-11T14:15:56.548+0000",
         "name": "Ligand-Gated Ion Channel database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -27087,7 +27143,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:06.185+00:00",
+        "created": "2019-06-11T14:18:06.185+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27096,7 +27152,7 @@
         "id": 1744,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000628",
-        "modified": "2019-06-11T14:18:06.185+00:00",
+        "modified": "2019-06-11T14:18:06.185+0000",
         "name": "LiceBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9\\-\\/]+$",
@@ -27143,7 +27199,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:19.416+00:00",
+        "created": "2019-06-11T14:18:19.416+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27152,7 +27208,7 @@
         "id": 1887,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000681",
-        "modified": "2019-06-11T14:18:19.416+00:00",
+        "modified": "2019-06-11T14:18:19.416+0000",
         "name": "LigandBook",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -27199,7 +27255,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:28.979+00:00",
+        "created": "2019-06-11T14:17:28.979+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27208,7 +27264,7 @@
         "id": 1357,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000477",
-        "modified": "2020-11-20T10:55:30.526+00:00",
+        "modified": "2020-11-20T10:55:30.526+0000",
         "name": "LigandBox",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(HTS|KSH)[0-9]{4}-[0-9]{8}|PDB_[0-9,A-Z]{2,3}|[CD][0-9]{5}$",
@@ -27255,7 +27311,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:49.385+00:00",
+        "created": "2019-06-11T14:15:49.385+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27264,7 +27320,7 @@
         "id": 217,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000062",
-        "modified": "2019-06-11T14:15:49.385+00:00",
+        "modified": "2019-06-11T14:15:49.385+0000",
         "name": "Ligand Expo",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(\\w){3}$",
@@ -27346,7 +27402,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:44.903+00:00",
+        "created": "2019-06-11T14:17:44.903+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27355,7 +27411,7 @@
         "id": 1525,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000544",
-        "modified": "2019-06-11T14:17:44.903+00:00",
+        "modified": "2019-06-11T14:17:44.903+0000",
         "name": "LINCS Cell",
         "namespaceEmbeddedInLui": false,
         "pattern": "(^LCL-\\d+$)|(^LDC-\\d+$)|(^ES-\\d+$)|(^LSC-\\d+$)|(^LPC-\\d+$)",
@@ -27402,7 +27458,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:56.343+00:00",
+        "created": "2019-06-11T14:17:56.343+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27411,7 +27467,7 @@
         "id": 1635,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000588",
-        "modified": "2019-06-11T14:17:56.343+00:00",
+        "modified": "2019-06-11T14:17:56.343+0000",
         "name": "LINCS Data",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[EL]D[SG]-\\d+$",
@@ -27493,7 +27549,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:45.145+00:00",
+        "created": "2019-06-11T14:17:45.145+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27502,7 +27558,7 @@
         "id": 1528,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000545",
-        "modified": "2019-06-11T14:17:45.145+00:00",
+        "modified": "2019-06-11T14:17:45.145+0000",
         "name": "LINCS Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -27549,7 +27605,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:45.396+00:00",
+        "created": "2019-06-11T14:17:45.396+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27558,7 +27614,7 @@
         "id": 1530,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000546",
-        "modified": "2019-06-11T14:17:45.396+00:00",
+        "modified": "2019-06-11T14:17:45.396+0000",
         "name": "LINCS Small Molecule",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LSM-\\d+$",
@@ -27605,7 +27661,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:42:52.720+00:00",
+        "created": "2021-08-08T09:42:52.720+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27614,7 +27670,7 @@
         "id": 2804,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000849",
-        "modified": "2021-08-08T09:42:52.720+00:00",
+        "modified": "2021-08-08T09:42:52.720+0000",
         "name": "Linguist",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9 +#'*]+$",
@@ -27661,7 +27717,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:03.490+00:00",
+        "created": "2019-06-11T14:16:03.490+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27670,7 +27726,7 @@
         "id": 366,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000115",
-        "modified": "2019-06-11T14:16:03.490+00:00",
+        "modified": "2019-06-11T14:16:03.490+0000",
         "name": "LipidBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+\\d+$",
@@ -27717,7 +27773,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:46.708+00:00",
+        "created": "2019-06-11T14:15:46.708+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27726,7 +27782,7 @@
         "id": 189,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000052",
-        "modified": "2019-06-11T14:15:46.708+00:00",
+        "modified": "2019-06-11T14:15:46.708+0000",
         "name": "LIPID MAPS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LM(FA|GL|GP|SP|ST|PR|SL|PK)[0-9]{4}([0-9a-zA-Z]{4,6})?$",
@@ -27808,7 +27864,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:05.115+00:00",
+        "created": "2019-06-11T14:17:05.115+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -27817,7 +27873,7 @@
         "id": 1078,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000376",
-        "modified": "2020-05-22T10:35:39.544+00:00",
+        "modified": "2020-05-22T10:35:39.544+0000",
         "name": "Locus Reference Genomic",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LRG_\\d+$",
@@ -28004,7 +28060,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:21.919+00:00",
+        "created": "2019-06-11T14:17:21.919+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28013,7 +28069,7 @@
         "id": 1275,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000445",
-        "modified": "2019-06-11T14:17:21.919+00:00",
+        "modified": "2019-06-11T14:17:21.919+0000",
         "name": "Mouse Adult Gross Anatomy",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MA:\\d+$",
@@ -28130,7 +28186,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:53.388+00:00",
+        "created": "2019-06-11T14:15:53.388+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28139,7 +28195,7 @@
         "id": 261,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000077",
-        "modified": "2019-06-11T14:15:53.388+00:00",
+        "modified": "2019-06-11T14:15:53.388+0000",
         "name": "MACiE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^M\\d{4}$",
@@ -28186,7 +28242,7 @@
         "successor": null
       },
       {
-        "created": "2023-11-27T10:19:40.971+00:00",
+        "created": "2023-11-27T10:19:40.971+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28195,7 +28251,7 @@
         "id": 3759,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001038",
-        "modified": "2023-11-27T10:19:40.971+00:00",
+        "modified": "2023-11-27T10:19:40.971+0000",
         "name": "Maggot",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -28242,7 +28298,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:19.610+00:00",
+        "created": "2019-06-11T14:16:19.610+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28251,7 +28307,7 @@
         "id": 543,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000177",
-        "modified": "2019-06-11T14:16:19.610+00:00",
+        "modified": "2019-06-11T14:16:19.610+0000",
         "name": "MaizeGDB Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -28298,7 +28354,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:38.625+00:00",
+        "created": "2019-06-11T14:17:38.625+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28307,7 +28363,7 @@
         "id": 1459,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000517",
-        "modified": "2019-06-11T14:17:38.625+00:00",
+        "modified": "2019-06-11T14:17:38.625+0000",
         "name": "Mathematical Modelling Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MAMO_\\d{7}$",
@@ -28389,7 +28445,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:42.071+00:00",
+        "created": "2019-06-11T14:16:42.071+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28398,7 +28454,7 @@
         "id": 800,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000273",
-        "modified": "2022-12-13T16:15:18.652+00:00",
+        "modified": "2022-12-13T16:15:18.652+0000",
         "name": "MassBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MSBNK-[0-9a-zA-Z_]+-[A-Z0-9_]+$",
@@ -28480,7 +28536,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:11.594+00:00",
+        "created": "2019-06-11T14:18:11.594+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28489,7 +28545,7 @@
         "id": 1806,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000650",
-        "modified": "2019-06-11T14:18:11.594+00:00",
+        "modified": "2019-06-11T14:18:11.594+0000",
         "name": "MassIVE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MSV\\d+$",
@@ -28571,7 +28627,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:51.252+00:00",
+        "created": "2019-06-11T14:15:51.252+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28580,7 +28636,7 @@
         "id": 236,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000068",
-        "modified": "2019-06-11T14:15:51.252+00:00",
+        "modified": "2019-06-11T14:15:51.252+0000",
         "name": "MatrixDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])_.*|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9]_.*)|(GAG_.*)|(MULT_.*)|(PFRAG_.*)|(LIP_.*)|(CAT_.*)$",
@@ -28627,7 +28683,7 @@
         "successor": null
       },
       {
-        "created": "2023-10-30T09:40:47.492+00:00",
+        "created": "2023-10-30T09:40:47.492+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28636,7 +28692,7 @@
         "id": 3723,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001032",
-        "modified": "2023-10-30T09:40:47.492+00:00",
+        "modified": "2023-10-30T09:40:47.492+0000",
         "name": "Medical Action Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "\\d{7}",
@@ -28683,7 +28739,63 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:52.138+00:00",
+        "created": "2024-03-20T10:56:06.644+0000",
+        "deprecated": false,
+        "deprecationDate": null,
+        "deprecationOfflineDate": null,
+        "deprecationStatement": null,
+        "description": "An ontology representing the model card structure, he aim of this work is to describe machine learning models to communicate information about specific details about the model (trade offs, intended users, licensing, etc.). ",
+        "id": 3832,
+        "infoOnPostmortemAccess": null,
+        "mirId": "MIR:00001049",
+        "modified": "2024-03-20T10:56:06.644+0000",
+        "name": "Model Card Ontology",
+        "namespaceEmbeddedInLui": true,
+        "pattern": "^MCRO:\\d+$",
+        "prefix": "mcro",
+        "renderDeprecatedLanding": false,
+        "resources": [
+          {
+            "authHelpDescription": null,
+            "authHelpUrl": null,
+            "deprecated": false,
+            "deprecationDate": null,
+            "deprecationOfflineDate": null,
+            "deprecationStatement": null,
+            "description": "ontology modeling the model card report for machine learning model assests",
+            "id": 3833,
+            "institution": {
+              "description": "At EMBL-EBI, we make the world’s public biological data freely available to the scientific community via a range of services and tools, perform basic research and provide professional training in bioinformatics. \nWe are part of the European Molecular Biology Laboratory (EMBL), an international, innovative and interdisciplinary research organisation funded by 26 member states and two associate member states.",
+              "homeUrl": "https://www.ebi.ac.uk",
+              "id": 2,
+              "location": {
+                "countryCode": "GB",
+                "countryName": "United Kingdom"
+              },
+              "name": "European Bioinformatics Institute",
+              "rorId": "https://ror.org/02catss52"
+            },
+            "location": {
+              "countryCode": "GB",
+              "countryName": "United Kingdom"
+            },
+            "mirId": "MIR:00001048",
+            "name": "MCRO via OLS",
+            "official": true,
+            "protectedUrls": false,
+            "providerCode": "ols",
+            "renderDeprecatedLanding": false,
+            "renderProtectedLanding": false,
+            "resourceHomeUrl": "https://www.ebi.ac.uk/ols4/ontologies/mcro",
+            "sampleId": "0000027",
+            "urlPattern": "https://www.ebi.ac.uk/ols4/ontologies/mcro/classes?obo_id=MCRO:{$id}"
+          }
+        ],
+        "sampleId": "0000027",
+        "successor": null
+      },
+      {
+        "created": "2019-06-11T14:17:52.138+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28692,7 +28804,7 @@
         "id": 1598,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000574",
-        "modified": "2019-06-11T14:17:52.138+00:00",
+        "modified": "2019-06-11T14:17:52.138+0000",
         "name": "MDM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -28739,7 +28851,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:49.428+00:00",
+        "created": "2019-06-11T14:17:49.428+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28748,7 +28860,7 @@
         "id": 1570,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000563",
-        "modified": "2019-06-11T14:17:49.428+00:00",
+        "modified": "2019-06-11T14:17:49.428+0000",
         "name": "MedDRA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -28795,7 +28907,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:58.068+00:00",
+        "created": "2019-06-11T14:17:58.068+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28804,7 +28916,7 @@
         "id": 1653,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000594",
-        "modified": "2019-06-11T14:17:58.068+00:00",
+        "modified": "2019-06-11T14:17:58.068+0000",
         "name": "MedGen",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[CN]*\\d{4,7}$",
@@ -28851,7 +28963,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:28.795+00:00",
+        "created": "2019-06-11T14:17:28.795+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28860,7 +28972,7 @@
         "id": 1355,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000476",
-        "modified": "2019-06-11T14:17:28.795+00:00",
+        "modified": "2019-06-11T14:17:28.795+0000",
         "name": "MedlinePlus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -28907,7 +29019,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:48.677+00:00",
+        "created": "2019-06-11T14:15:48.677+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28916,7 +29028,7 @@
         "id": 209,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000059",
-        "modified": "2019-06-11T14:15:48.677+00:00",
+        "modified": "2019-06-11T14:15:48.677+0000",
         "name": "MEROPS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[SCTAGMNU]\\d{2}\\.([AB]\\d{2}|\\d{3})$",
@@ -28963,7 +29075,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:48.579+00:00",
+        "created": "2019-06-11T14:16:48.579+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -28972,7 +29084,7 @@
         "id": 880,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000302",
-        "modified": "2019-06-11T14:16:48.579+00:00",
+        "modified": "2019-06-11T14:16:48.579+0000",
         "name": "MEROPS Family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[SCTAGMNU]\\d+$",
@@ -29019,7 +29131,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:32.129+00:00",
+        "created": "2019-06-11T14:17:32.129+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29028,7 +29140,7 @@
         "id": 1392,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000491",
-        "modified": "2019-06-11T14:17:32.129+00:00",
+        "modified": "2019-06-11T14:17:32.129+0000",
         "name": "MEROPS Inhibitor",
         "namespaceEmbeddedInLui": false,
         "pattern": "^I\\d{2}\\.\\d{3}$",
@@ -29075,7 +29187,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:48.752+00:00",
+        "created": "2019-06-11T14:17:48.752+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29084,7 +29196,7 @@
         "id": 1563,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000560",
-        "modified": "2020-04-21T17:40:51.334+00:00",
+        "modified": "2020-04-21T17:40:51.334+0000",
         "name": "MeSH",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(C|D)\\d{6,9}$",
@@ -29131,7 +29243,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:41.417+00:00",
+        "created": "2019-06-11T14:16:41.417+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29140,7 +29252,7 @@
         "id": 791,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000270",
-        "modified": "2019-06-11T14:16:41.417+00:00",
+        "modified": "2019-06-11T14:16:41.417+0000",
         "name": "MeSH 2012",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -29187,7 +29299,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:28.224+00:00",
+        "created": "2019-06-11T14:17:28.224+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29196,7 +29308,7 @@
         "id": 1349,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000473",
-        "modified": "2019-06-11T14:17:28.224+00:00",
+        "modified": "2019-06-11T14:17:28.224+0000",
         "name": "MeSH 2013",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -29243,7 +29355,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:06.457+00:00",
+        "created": "2019-06-11T14:17:06.457+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29252,7 +29364,7 @@
         "id": 1094,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000380",
-        "modified": "2019-06-11T14:17:06.457+00:00",
+        "modified": "2019-06-11T14:17:06.457+0000",
         "name": "MetaboLights",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MTBLS\\d+$",
@@ -29334,7 +29446,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:01.783+00:00",
+        "created": "2019-06-11T14:18:01.783+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29343,7 +29455,7 @@
         "id": 1691,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000609",
-        "modified": "2021-04-17T19:53:03.023+00:00",
+        "modified": "2021-04-17T19:53:03.023+0000",
         "name": "MetaCyc Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9+_.%-:]+$",
@@ -29390,7 +29502,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:02.043+00:00",
+        "created": "2019-06-11T14:18:02.043+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29399,7 +29511,7 @@
         "id": 1694,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000610",
-        "modified": "2021-04-17T19:55:01.284+00:00",
+        "modified": "2021-04-17T19:55:01.284+0000",
         "name": "MetaCyc Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9+_.%-:]+$",
@@ -29446,7 +29558,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:50.332+00:00",
+        "created": "2019-06-11T14:17:50.332+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29455,7 +29567,7 @@
         "id": 1580,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000567",
-        "modified": "2021-02-26T09:36:59.253+00:00",
+        "modified": "2021-02-26T09:36:59.253+0000",
         "name": "MetaNetX chemical",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(MNXM\\d+|BIOMASS|WATER)$",
@@ -29502,7 +29614,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:50.805+00:00",
+        "created": "2019-06-11T14:17:50.805+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29511,7 +29623,7 @@
         "id": 1585,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000569",
-        "modified": "2021-02-26T09:49:03.051+00:00",
+        "modified": "2021-02-26T09:49:03.051+0000",
         "name": "MetaNetX compartment",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(MNX[CD]\\d+|BOUNDARY|IN|OUT)$",
@@ -29558,7 +29670,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:50.605+00:00",
+        "created": "2019-06-11T14:17:50.605+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29567,7 +29679,7 @@
         "id": 1583,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000568",
-        "modified": "2021-02-26T09:43:13.847+00:00",
+        "modified": "2021-02-26T09:43:13.847+0000",
         "name": "MetaNetX reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(MNXR\\d+|EMPTY)$",
@@ -29614,7 +29726,7 @@
         "successor": null
       },
       {
-        "created": "2022-08-08T18:36:40.981+00:00",
+        "created": "2022-08-08T18:36:40.981+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29623,7 +29735,7 @@
         "id": 3263,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000959",
-        "modified": "2022-08-08T18:36:40.981+00:00",
+        "modified": "2022-08-08T18:36:40.981+0000",
         "name": "Metabolic Atlas",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MA[MR]\\d{5}[a-z]?$",
@@ -29670,7 +29782,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:52.640+00:00",
+        "created": "2019-06-11T14:16:52.640+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29679,7 +29791,7 @@
         "id": 929,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000322",
-        "modified": "2019-06-11T14:16:52.640+00:00",
+        "modified": "2019-06-11T14:16:52.640+0000",
         "name": "METLIN",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{4}$",
@@ -29726,7 +29838,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:10.861+00:00",
+        "created": "2019-06-11T14:18:10.861+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29735,7 +29847,7 @@
         "id": 1798,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000648",
-        "modified": "2019-06-11T14:18:10.861+00:00",
+        "modified": "2019-06-11T14:18:10.861+0000",
         "name": "Metabolome Express",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -29817,16 +29929,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:49.786+00:00",
+        "created": "2019-06-11T14:15:49.786+0000",
         "deprecated": true,
-        "deprecationDate": "2023-01-10T13:18:19.506+00:00",
+        "deprecationDate": "2023-01-10T13:18:19.506+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "ACLAME is a database dedicated to the collection and classification of mobile genetic elements (MGEs) from various sources, comprising all known phage genomes, plasmids and transposons.",
         "id": 220,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000063",
-        "modified": "2023-09-12T09:47:26.445+00:00",
+        "modified": "2023-09-12T09:47:26.445+0000",
         "name": "Aclame",
         "namespaceEmbeddedInLui": true,
         "pattern": "^mge:\\d+$",
@@ -29873,7 +29985,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:42.331+00:00",
+        "created": "2019-06-11T14:15:42.331+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -29882,7 +29994,7 @@
         "id": 146,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000037",
-        "modified": "2019-06-11T14:15:42.331+00:00",
+        "modified": "2019-06-11T14:15:42.331+0000",
         "name": "Mouse Genome Database",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MGI:\\d+$",
@@ -29999,7 +30111,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:42.938+00:00",
+        "created": "2019-06-11T14:17:42.938+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30008,7 +30120,7 @@
         "id": 1502,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000535",
-        "modified": "2019-06-11T14:17:42.938+00:00",
+        "modified": "2019-06-11T14:17:42.938+0000",
         "name": "MGnify Project",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]+[0-9]+$",
@@ -30055,7 +30167,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:36.594+00:00",
+        "created": "2019-06-11T14:17:36.594+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30064,7 +30176,7 @@
         "id": 1439,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000510",
-        "modified": "2019-06-11T14:17:36.594+00:00",
+        "modified": "2019-06-11T14:17:36.594+0000",
         "name": "MGnify Sample",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]+[0-9]+$",
@@ -30111,7 +30223,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:01.860+00:00",
+        "created": "2019-06-11T14:16:01.860+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30120,7 +30232,7 @@
         "id": 350,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000109",
-        "modified": "2020-06-26T10:17:31.752+00:00",
+        "modified": "2020-06-26T10:17:31.752+0000",
         "name": "Molecular Interactions Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MI:\\d{4}$",
@@ -30167,7 +30279,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:06.853+00:00",
+        "created": "2019-06-11T14:18:06.853+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30176,7 +30288,7 @@
         "id": 1752,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000631",
-        "modified": "2019-06-11T14:18:06.853+00:00",
+        "modified": "2019-06-11T14:18:06.853+0000",
         "name": "MicroScope",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -30223,7 +30335,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:13.630+00:00",
+        "created": "2019-06-11T14:16:13.630+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30232,7 +30344,7 @@
         "id": 475,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000152",
-        "modified": "2019-06-11T14:16:13.630+00:00",
+        "modified": "2019-06-11T14:16:13.630+0000",
         "name": "MicrosporidiaDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -30279,7 +30391,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:33.878+00:00",
+        "created": "2019-06-11T14:15:33.878+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30288,7 +30400,7 @@
         "id": 65,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000016",
-        "modified": "2019-06-11T14:15:33.878+00:00",
+        "modified": "2019-06-11T14:15:33.878+0000",
         "name": "OMIM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[*#+%^]?\\d{6}$",
@@ -30370,7 +30482,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:37.622+00:00",
+        "created": "2019-06-11T14:16:37.622+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30379,7 +30491,7 @@
         "id": 745,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000251",
-        "modified": "2019-06-11T14:16:37.622+00:00",
+        "modified": "2019-06-11T14:16:37.622+0000",
         "name": "MimoDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -30426,7 +30538,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:10.091+00:00",
+        "created": "2019-06-11T14:18:10.091+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30435,7 +30547,7 @@
         "id": 1789,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000645",
-        "modified": "2020-03-20T09:37:38.029+00:00",
+        "modified": "2020-03-20T09:37:38.029+0000",
         "name": "Minimal Viable Identifier",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -30482,7 +30594,7 @@
         "successor": null
       },
       {
-        "created": "2020-02-25T11:14:38.686+00:00",
+        "created": "2020-02-25T11:14:38.686+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30491,7 +30603,7 @@
         "id": 2085,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000707",
-        "modified": "2020-02-28T10:24:36.137+00:00",
+        "modified": "2020-02-28T10:24:36.137+0000",
         "name": "MINID Test",
         "namespaceEmbeddedInLui": false,
         "pattern": "[A-Za-z0-9]+$",
@@ -30538,7 +30650,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:43.925+00:00",
+        "created": "2019-06-11T14:15:43.925+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30547,7 +30659,7 @@
         "id": 162,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000042",
-        "modified": "2019-06-11T14:15:43.925+00:00",
+        "modified": "2019-06-11T14:15:43.925+0000",
         "name": "MINT",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MINT\\-\\d{1,7}$",
@@ -30629,7 +30741,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:38.756+00:00",
+        "created": "2019-06-11T14:16:38.756+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30638,7 +30750,7 @@
         "id": 759,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000256",
-        "modified": "2019-06-11T14:16:38.756+00:00",
+        "modified": "2019-06-11T14:16:38.756+0000",
         "name": "MIPModDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -30685,7 +30797,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:59.221+00:00",
+        "created": "2019-06-11T14:17:59.221+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30694,7 +30806,7 @@
         "id": 1664,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000599",
-        "modified": "2019-06-11T14:17:59.221+00:00",
+        "modified": "2019-06-11T14:17:59.221+0000",
         "name": "Identifiers.org Registry",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MIR:\\d{8}$",
@@ -30741,7 +30853,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:53.607+00:00",
+        "created": "2019-06-11T14:15:53.607+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30750,7 +30862,7 @@
         "id": 263,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000078",
-        "modified": "2019-06-11T14:15:53.607+00:00",
+        "modified": "2019-06-11T14:15:53.607+0000",
         "name": "miRBase Sequence",
         "namespaceEmbeddedInLui": false,
         "pattern": "MI\\d{7}",
@@ -30797,7 +30909,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:33.415+00:00",
+        "created": "2019-06-11T14:16:33.415+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30806,7 +30918,7 @@
         "id": 696,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000235",
-        "modified": "2019-06-11T14:16:33.415+00:00",
+        "modified": "2019-06-11T14:16:33.415+0000",
         "name": "miRBase mature sequence",
         "namespaceEmbeddedInLui": false,
         "pattern": "MIMAT\\d{7}",
@@ -30853,7 +30965,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:54.147+00:00",
+        "created": "2019-06-11T14:16:54.147+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30862,7 +30974,7 @@
         "id": 946,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000329",
-        "modified": "2019-06-11T14:16:54.147+00:00",
+        "modified": "2019-06-11T14:16:54.147+0000",
         "name": "mirEX",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+(\\w+)?$",
@@ -30909,16 +31021,16 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:31.442+00:00",
+        "created": "2019-06-11T14:15:31.442+0000",
         "deprecated": true,
-        "deprecationDate": "2020-06-04T11:17:21.453+00:00",
+        "deprecationDate": "2020-06-04T11:17:21.453+0000",
         "deprecationOfflineDate": null,
         "deprecationStatement": null,
         "description": "MIRIAM Registry is an online resource created to catalogue collections (Gene Ontology, Taxonomy or PubMed are some examples) and the corresponding resources (physical locations) providing access to those data collections. The Registry provides unique and perennial URIs for each entity of those data collections.",
         "id": 41,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000008",
-        "modified": "2024-02-06T14:56:58.330+00:00",
+        "modified": "2024-02-06T14:56:58.330+0000",
         "name": "MIRIAM Registry collection",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MIR:000\\d{5}$",
@@ -30929,7 +31041,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2020-06-04T10:00:30.300+00:00",
+            "deprecationDate": "2020-06-04T10:00:30.300+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "MIRIAM Resources (data collection)",
@@ -30965,7 +31077,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:22.127+00:00",
+        "created": "2019-06-11T14:16:22.127+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -30974,7 +31086,7 @@
         "id": 573,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000188",
-        "modified": "2019-06-11T14:16:22.127+00:00",
+        "modified": "2019-06-11T14:16:22.127+0000",
         "name": "MIRIAM Registry resource",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MIR:001\\d{5}$",
@@ -31021,7 +31133,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:36.416+00:00",
+        "created": "2019-06-11T14:16:36.416+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31030,7 +31142,7 @@
         "id": 730,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000246",
-        "modified": "2019-06-11T14:16:36.416+00:00",
+        "modified": "2019-06-11T14:16:36.416+0000",
         "name": "miRNEST",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MNEST\\d+$",
@@ -31077,7 +31189,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:49.171+00:00",
+        "created": "2019-06-11T14:17:49.171+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31086,7 +31198,7 @@
         "id": 1567,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000562",
-        "modified": "2019-06-11T14:17:49.171+00:00",
+        "modified": "2019-06-11T14:17:49.171+0000",
         "name": "miRTarBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MIRT\\d{6}$",
@@ -31133,7 +31245,7 @@
         "successor": null
       },
       {
-        "created": "2021-06-24T16:02:06.844+00:00",
+        "created": "2021-06-24T16:02:06.844+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31142,7 +31254,7 @@
         "id": 2709,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000828",
-        "modified": "2021-06-24T16:02:06.844+00:00",
+        "modified": "2021-06-24T16:02:06.844+0000",
         "name": "MLCommons Association",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-zA-Z\\.\\-\\_]+$",
@@ -31189,7 +31301,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:05.062+00:00",
+        "created": "2019-06-11T14:16:05.062+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31198,7 +31310,7 @@
         "id": 384,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000121",
-        "modified": "2019-06-11T14:16:05.062+00:00",
+        "modified": "2019-06-11T14:16:05.062+0000",
         "name": "Molecular Modeling Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{1,5}$",
@@ -31245,7 +31357,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:52.916+00:00",
+        "created": "2019-06-11T14:15:52.916+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31254,7 +31366,7 @@
         "id": 255,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000075",
-        "modified": "2019-06-11T14:15:52.916+00:00",
+        "modified": "2019-06-11T14:15:52.916+0000",
         "name": "Melanoma Molecular Map Project Biomaps",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -31301,7 +31413,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:03.141+00:00",
+        "created": "2019-06-11T14:18:03.141+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31310,7 +31422,7 @@
         "id": 1707,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000615",
-        "modified": "2019-06-11T14:18:03.141+00:00",
+        "modified": "2019-06-11T14:18:03.141+0000",
         "name": "MarCat",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MMP\\d+.\\d+$",
@@ -31357,7 +31469,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:02.934+00:00",
+        "created": "2019-06-11T14:18:02.934+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31366,7 +31478,7 @@
         "id": 1705,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000614",
-        "modified": "2019-06-11T14:18:02.934+00:00",
+        "modified": "2019-06-11T14:18:02.934+0000",
         "name": "MarDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MMP\\d+.\\d+$",
@@ -31413,7 +31525,7 @@
         "successor": null
       },
       {
-        "created": "2019-09-10T10:50:49.547+00:00",
+        "created": "2019-09-10T10:50:49.547+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31422,7 +31534,7 @@
         "id": 1997,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000729",
-        "modified": "2019-09-10T10:50:49.547+00:00",
+        "modified": "2019-09-10T10:50:49.547+0000",
         "name": "MarFun",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MMP\\d+.\\d+$",
@@ -31469,7 +31581,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:02.696+00:00",
+        "created": "2019-06-11T14:18:02.696+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31478,7 +31590,7 @@
         "id": 1702,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000613",
-        "modified": "2019-06-11T14:18:02.696+00:00",
+        "modified": "2019-06-11T14:18:02.696+0000",
         "name": "MarRef",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MMP\\d+.\\d+$",
@@ -31525,7 +31637,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:53.082+00:00",
+        "created": "2019-06-11T14:16:53.082+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31534,7 +31646,7 @@
         "id": 935,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000324",
-        "modified": "2019-06-11T14:16:53.082+00:00",
+        "modified": "2019-06-11T14:16:53.082+0000",
         "name": "MMRRC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -31581,7 +31693,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:48.772+00:00",
+        "created": "2019-06-11T14:16:48.772+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31590,7 +31702,7 @@
         "id": 882,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000303",
-        "modified": "2019-06-11T14:16:48.772+00:00",
+        "modified": "2019-06-11T14:16:48.772+0000",
         "name": "MGED Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -31672,7 +31784,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:08.223+00:00",
+        "created": "2019-06-11T14:18:08.223+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31681,7 +31793,7 @@
         "id": 1768,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000637",
-        "modified": "2019-06-11T14:18:08.223+00:00",
+        "modified": "2019-06-11T14:18:08.223+0000",
         "name": "MobiDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$",
@@ -31728,7 +31840,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:47.775+00:00",
+        "created": "2019-06-11T14:15:47.775+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31737,7 +31849,7 @@
         "id": 200,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000056",
-        "modified": "2019-06-11T14:15:47.775+00:00",
+        "modified": "2019-06-11T14:15:47.775+0000",
         "name": "Protein Modification Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MOD:\\d{5}",
@@ -31819,7 +31931,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:08.429+00:00",
+        "created": "2019-06-11T14:16:08.429+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31828,7 +31940,7 @@
         "id": 419,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000131",
-        "modified": "2019-06-11T14:16:08.429+00:00",
+        "modified": "2019-06-11T14:16:08.429+0000",
         "name": "ModelDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -31875,7 +31987,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-29T10:45:35.629+00:00",
+        "created": "2022-01-29T10:45:35.629+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31884,7 +31996,7 @@
         "id": 3036,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000905",
-        "modified": "2022-01-29T10:45:35.629+00:00",
+        "modified": "2022-01-29T10:45:35.629+0000",
         "name": "ModelDB concept",
         "namespaceEmbeddedInLui": false,
         "pattern": "\\d+",
@@ -31931,7 +32043,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:25.144+00:00",
+        "created": "2019-06-11T14:17:25.144+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31940,7 +32052,7 @@
         "id": 1312,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000458",
-        "modified": "2019-06-11T14:17:25.144+00:00",
+        "modified": "2019-06-11T14:17:25.144+0000",
         "name": "Molbase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(\\d{1,7}\\-\\d{2}\\-\\d)|([A-Za-z0-9\\+\\-\\_]+)$",
@@ -31987,7 +32099,7 @@
         "successor": null
       },
       {
-        "created": "2020-07-03T09:30:53.125+00:00",
+        "created": "2020-07-03T09:30:53.125+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -31996,7 +32108,7 @@
         "id": 2277,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000768",
-        "modified": "2020-07-03T09:30:53.125+00:00",
+        "modified": "2020-07-03T09:30:53.125+0000",
         "name": "MolMeDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[m,M]{2}[0-9]{5}[0-9]*$",
@@ -32043,7 +32155,7 @@
         "successor": null
       },
       {
-        "created": "2020-10-07T10:43:05.918+00:00",
+        "created": "2020-10-07T10:43:05.918+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32052,7 +32164,7 @@
         "id": 2377,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000725",
-        "modified": "2020-10-07T10:43:05.918+00:00",
+        "modified": "2020-10-07T10:43:05.918+0000",
         "name": "Morpheus model repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^M[0-9]{4,}$",
@@ -32099,7 +32211,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:53.926+00:00",
+        "created": "2019-06-11T14:17:53.926+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32108,7 +32220,7 @@
         "id": 1614,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000580",
-        "modified": "2019-06-11T14:17:53.926+00:00",
+        "modified": "2019-06-11T14:17:53.926+0000",
         "name": "Mammalian Phenotype Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MP:\\d{7}$",
@@ -32225,7 +32337,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:05.849+00:00",
+        "created": "2019-06-11T14:16:05.849+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32234,7 +32346,7 @@
         "id": 392,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000124",
-        "modified": "2019-06-11T14:16:05.849+00:00",
+        "modified": "2019-06-11T14:16:05.849+0000",
         "name": "Microbial Protein Interaction Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -32316,7 +32428,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:56.919+00:00",
+        "created": "2019-06-11T14:17:56.919+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32325,7 +32437,7 @@
         "id": 1641,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000590",
-        "modified": "2019-06-11T14:17:56.919+00:00",
+        "modified": "2019-06-11T14:17:56.919+0000",
         "name": "Mass Spectrometry Controlled Vocabulary",
         "namespaceEmbeddedInLui": true,
         "pattern": "^MS:\\d{7}$",
@@ -32407,7 +32519,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:55.320+00:00",
+        "created": "2019-06-11T14:17:55.320+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32416,7 +32528,7 @@
         "id": 1626,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000584",
-        "modified": "2019-06-11T14:17:55.320+00:00",
+        "modified": "2019-06-11T14:17:55.320+0000",
         "name": "MultiCellDS Digital Cell Line",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MCDS_L_[a-zA-Z0-9]{1,10}$",
@@ -32463,7 +32575,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:54.753+00:00",
+        "created": "2019-06-11T14:17:54.753+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32472,7 +32584,7 @@
         "id": 1621,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000582",
-        "modified": "2019-06-11T14:17:54.753+00:00",
+        "modified": "2019-06-11T14:17:54.753+0000",
         "name": "MultiCellDS collection",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MCDS_C_[a-zA-Z0-9]{1,10}$",
@@ -32519,7 +32631,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:55.012+00:00",
+        "created": "2019-06-11T14:17:55.012+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32528,7 +32640,7 @@
         "id": 1624,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000583",
-        "modified": "2019-06-11T14:17:55.012+00:00",
+        "modified": "2019-06-11T14:17:55.012+0000",
         "name": "MultiCellDS Digital snapshot",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MCDS_S_[a-zA-Z0-9]{1,10}$",
@@ -32575,7 +32687,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:10.677+00:00",
+        "created": "2019-06-11T14:18:10.677+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32584,7 +32696,7 @@
         "id": 1796,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000647",
-        "modified": "2019-06-11T14:18:10.677+00:00",
+        "modified": "2019-06-11T14:18:10.677+0000",
         "name": "Metabolomics Workbench Project",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PR[0-9]{6}$",
@@ -32631,7 +32743,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:10.316+00:00",
+        "created": "2019-06-11T14:18:10.316+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32640,7 +32752,7 @@
         "id": 1792,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000646",
-        "modified": "2019-06-11T14:18:10.316+00:00",
+        "modified": "2019-06-11T14:18:10.316+0000",
         "name": "Metabolomics Workbench Study",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ST[0-9]{6}$",
@@ -32722,7 +32834,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:28.887+00:00",
+        "created": "2019-06-11T14:16:28.887+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32731,7 +32843,7 @@
         "id": 647,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000217",
-        "modified": "2019-06-11T14:16:28.887+00:00",
+        "modified": "2019-06-11T14:16:28.887+0000",
         "name": "MycoBrowser leprae",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ML\\w+$",
@@ -32778,7 +32890,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:29.087+00:00",
+        "created": "2019-06-11T14:16:29.087+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32787,7 +32899,7 @@
         "id": 649,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000218",
-        "modified": "2019-06-11T14:16:29.087+00:00",
+        "modified": "2019-06-11T14:16:29.087+0000",
         "name": "MycoBrowser marinum",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MMAR\\_\\d+$",
@@ -32834,7 +32946,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:29.310+00:00",
+        "created": "2019-06-11T14:16:29.310+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32843,7 +32955,7 @@
         "id": 651,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000219",
-        "modified": "2019-06-11T14:16:29.310+00:00",
+        "modified": "2019-06-11T14:16:29.310+0000",
         "name": "MycoBrowser smegmatis",
         "namespaceEmbeddedInLui": false,
         "pattern": "^MSMEG\\w+$",
@@ -32890,7 +33002,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:28.639+00:00",
+        "created": "2019-06-11T14:16:28.639+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32899,7 +33011,7 @@
         "id": 644,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000216",
-        "modified": "2019-06-11T14:16:28.639+00:00",
+        "modified": "2019-06-11T14:16:28.639+0000",
         "name": "MycoBrowser tuberculosis",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Rv\\d{4}(A|B|c)?$",
@@ -32946,7 +33058,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:19.843+00:00",
+        "created": "2019-06-11T14:16:19.843+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -32955,7 +33067,7 @@
         "id": 546,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000178",
-        "modified": "2019-06-11T14:16:19.843+00:00",
+        "modified": "2019-06-11T14:16:19.843+0000",
         "name": "MycoBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -33002,7 +33114,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:05.468+00:00",
+        "created": "2019-06-11T14:18:05.468+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33011,7 +33123,7 @@
         "id": 1735,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000625",
-        "modified": "2019-06-11T14:18:05.468+00:00",
+        "modified": "2019-06-11T14:18:05.468+0000",
         "name": "Universal Spectrum Identifier",
         "namespaceEmbeddedInLui": true,
         "pattern": "^mzspec:.+$",
@@ -33093,7 +33205,7 @@
         "successor": null
       },
       {
-        "created": "2023-05-09T12:26:02.992+00:00",
+        "created": "2023-05-09T12:26:02.992+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33102,7 +33214,7 @@
         "id": 3536,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001010",
-        "modified": "2023-05-09T13:07:17.390+00:00",
+        "modified": "2023-05-09T13:07:17.390+0000",
         "name": "Nanbyo Disease Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^NANDO:[0-9]+$",
@@ -33149,7 +33261,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:04.316+00:00",
+        "created": "2019-06-11T14:18:04.316+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33158,7 +33270,7 @@
         "id": 1721,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000620",
-        "modified": "2019-06-11T14:18:04.316+00:00",
+        "modified": "2019-06-11T14:18:04.316+0000",
         "name": "Natural Product-Drug Interaction Research Data Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -33205,7 +33317,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:36.669+00:00",
+        "created": "2019-06-11T14:16:36.669+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33214,7 +33326,7 @@
         "id": 733,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000247",
-        "modified": "2019-06-11T14:16:36.669+00:00",
+        "modified": "2019-06-11T14:16:36.669+0000",
         "name": "NAPP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -33261,7 +33373,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:34.542+00:00",
+        "created": "2019-06-11T14:16:34.542+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33270,7 +33382,7 @@
         "id": 709,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000240",
-        "modified": "2019-06-11T14:16:34.542+00:00",
+        "modified": "2019-06-11T14:16:34.542+0000",
         "name": "NARCIS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^oai\\:cwi\\.nl\\:\\d+$",
@@ -33317,7 +33429,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:49.131+00:00",
+        "created": "2019-06-11T14:16:49.131+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33326,7 +33438,7 @@
         "id": 886,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000304",
-        "modified": "2019-06-11T14:16:49.131+00:00",
+        "modified": "2019-06-11T14:16:49.131+0000",
         "name": "NASC code",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(\\w+)?\\d+$",
@@ -33373,7 +33485,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:06.748+00:00",
+        "created": "2019-06-11T14:17:06.748+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33382,7 +33494,7 @@
         "id": 1097,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000381",
-        "modified": "2023-06-19T09:28:27.741+00:00",
+        "modified": "2023-06-19T09:28:27.741+0000",
         "name": "National Bibliography Number",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(urn|URN):(nbn|NBN)(:[A-Za-z_0-9]+)*.+$",
@@ -33429,7 +33541,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:20.103+00:00",
+        "created": "2019-06-11T14:16:20.103+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33438,7 +33550,7 @@
         "id": 549,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000179",
-        "modified": "2019-06-11T14:16:20.103+00:00",
+        "modified": "2019-06-11T14:16:20.103+0000",
         "name": "NITE Biological Research Center Catalogue",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -33485,7 +33597,7 @@
         "successor": null
       },
       {
-        "created": "2023-10-31T16:13:48.191+00:00",
+        "created": "2023-10-31T16:13:48.191+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33494,7 +33606,7 @@
         "id": 3730,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001034",
-        "modified": "2023-10-31T16:13:48.191+00:00",
+        "modified": "2023-10-31T16:13:48.191+0000",
         "name": "NCBI Data Repository Service",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-fA-F]{32}$",
@@ -33541,7 +33653,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:51.483+00:00",
+        "created": "2019-06-11T14:15:51.483+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33550,7 +33662,7 @@
         "id": 239,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000069",
-        "modified": "2019-06-11T14:15:51.483+00:00",
+        "modified": "2019-06-11T14:15:51.483+0000",
         "name": "NCBI Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -33632,7 +33744,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:57.477+00:00",
+        "created": "2019-06-11T14:16:57.477+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33641,7 +33753,7 @@
         "id": 987,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000344",
-        "modified": "2019-06-11T14:16:57.477+00:00",
+        "modified": "2019-06-11T14:16:57.477+0000",
         "name": "NCBI Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(\\w+\\d+(\\.\\d+)?)|(NP_\\d+)$",
@@ -33688,7 +33800,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:59.945+00:00",
+        "created": "2019-06-11T14:16:59.945+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33697,7 +33809,7 @@
         "id": 1015,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000353",
-        "modified": "2019-06-11T14:16:59.945+00:00",
+        "modified": "2019-06-11T14:16:59.945+0000",
         "name": "NCIm",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C\\d+$",
@@ -33744,7 +33856,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:10.500+00:00",
+        "created": "2019-06-11T14:16:10.500+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33753,7 +33865,7 @@
         "id": 441,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000139",
-        "modified": "2019-06-11T14:16:10.500+00:00",
+        "modified": "2019-06-11T14:16:10.500+0000",
         "name": "NCIt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C\\d+$",
@@ -33835,7 +33947,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:18.754+00:00",
+        "created": "2019-06-11T14:17:18.754+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33844,7 +33956,7 @@
         "id": 1237,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000431",
-        "modified": "2019-06-11T14:17:18.754+00:00",
+        "modified": "2019-06-11T14:17:18.754+0000",
         "name": "National Drug Code",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+\\-\\d+\\-\\d+",
@@ -33926,7 +34038,7 @@
         "successor": null
       },
       {
-        "created": "2019-09-19T13:46:35.999+00:00",
+        "created": "2019-09-19T13:46:35.999+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33935,7 +34047,7 @@
         "id": 2013,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000744",
-        "modified": "2019-10-02T08:18:15.555+00:00",
+        "modified": "2019-10-02T08:18:15.555+0000",
         "name": "Neuroscience Multi-Omic BRAIN Initiative Data",
         "namespaceEmbeddedInLui": false,
         "pattern": "[a-z]{3}-[a-km-z0-9]{7}",
@@ -33982,7 +34094,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:06.417+00:00",
+        "created": "2019-06-11T14:16:06.417+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -33991,7 +34103,7 @@
         "id": 398,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000126",
-        "modified": "2019-06-11T14:16:06.417+00:00",
+        "modified": "2019-06-11T14:16:06.417+0000",
         "name": "NeuroLex",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([Bb]irnlex_|Sao|nlx_|GO_|CogPO|HDO|nifext_)\\d+$",
@@ -34073,7 +34185,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:58.342+00:00",
+        "created": "2019-06-11T14:15:58.342+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34082,7 +34194,7 @@
         "id": 312,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000095",
-        "modified": "2019-06-11T14:15:58.342+00:00",
+        "modified": "2019-06-11T14:15:58.342+0000",
         "name": "NeuroMorpho",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -34129,7 +34241,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:58.106+00:00",
+        "created": "2019-06-11T14:15:58.106+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34138,7 +34250,7 @@
         "id": 309,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000094",
-        "modified": "2019-06-11T14:15:58.106+00:00",
+        "modified": "2019-06-11T14:15:58.106+0000",
         "name": "NeuronDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -34185,7 +34297,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:07.777+00:00",
+        "created": "2019-06-11T14:18:07.777+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34194,7 +34306,7 @@
         "id": 1763,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000635",
-        "modified": "2019-06-11T14:18:07.777+00:00",
+        "modified": "2019-06-11T14:18:07.777+0000",
         "name": "NeuroVault Collection",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[1-9][0-9]*$",
@@ -34241,7 +34353,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:08.473+00:00",
+        "created": "2019-06-11T14:18:08.473+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34250,7 +34362,7 @@
         "id": 1771,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000638",
-        "modified": "2019-06-11T14:18:08.473+00:00",
+        "modified": "2019-06-11T14:18:08.473+0000",
         "name": "NeuroVault Image",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[1-9][0-9]*$",
@@ -34297,7 +34409,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:46.065+00:00",
+        "created": "2019-06-11T14:16:46.065+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34306,7 +34418,7 @@
         "id": 850,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000289",
-        "modified": "2019-06-11T14:16:46.065+00:00",
+        "modified": "2019-06-11T14:16:46.065+0000",
         "name": "NEXTDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -34353,7 +34465,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:33.634+00:00",
+        "created": "2019-06-11T14:16:33.634+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34362,7 +34474,7 @@
         "id": 698,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000236",
-        "modified": "2019-06-11T14:16:33.634+00:00",
+        "modified": "2019-06-11T14:16:33.634+0000",
         "name": "nextProt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^NX_\\w+",
@@ -34409,7 +34521,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:03.826+00:00",
+        "created": "2019-06-11T14:18:03.826+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34418,7 +34530,7 @@
         "id": 1715,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000618",
-        "modified": "2019-06-11T14:18:03.826+00:00",
+        "modified": "2019-06-11T14:18:03.826+0000",
         "name": "NASA GeneLab",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GLDS-\\d+$",
@@ -34465,7 +34577,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:49.376+00:00",
+        "created": "2019-06-11T14:16:49.376+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34474,7 +34586,7 @@
         "id": 889,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000305",
-        "modified": "2019-06-11T14:16:49.376+00:00",
+        "modified": "2019-06-11T14:16:49.376+0000",
         "name": "NIAEST",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w\\d{4}\\w\\d{2}(\\-[35])?$",
@@ -34521,7 +34633,7 @@
         "successor": null
       },
       {
-        "created": "2023-02-03T09:47:17.713+00:00",
+        "created": "2023-02-03T09:47:17.713+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34530,7 +34642,7 @@
         "id": 3429,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000988",
-        "modified": "2023-02-03T09:47:17.713+00:00",
+        "modified": "2023-02-03T09:47:17.713+0000",
         "name": "NLFFF Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -34577,7 +34689,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-05T19:51:36.087+00:00",
+        "created": "2021-08-05T19:51:36.087+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34586,7 +34698,7 @@
         "id": 2756,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000837",
-        "modified": "2021-08-05T19:51:36.087+00:00",
+        "modified": "2021-08-05T19:51:36.087+0000",
         "name": "National Microbiome Data Collaborative",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9._~\\-\\:]+$",
@@ -34633,7 +34745,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:08.710+00:00",
+        "created": "2019-06-11T14:18:08.710+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34642,7 +34754,7 @@
         "id": 1773,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000639",
-        "modified": "2019-06-11T14:18:08.710+00:00",
+        "modified": "2019-06-11T14:18:08.710+0000",
         "name": "Nuclear Magnetic Resonance Controlled Vocabulary",
         "namespaceEmbeddedInLui": true,
         "pattern": "^NMR:\\d+$",
@@ -34689,7 +34801,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-17T12:41:40.413+00:00",
+        "created": "2020-03-17T12:41:40.413+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34698,7 +34810,7 @@
         "id": 2140,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000748",
-        "modified": "2020-03-17T12:43:18.460+00:00",
+        "modified": "2020-03-17T12:43:18.460+0000",
         "name": "NMR Shift Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -34745,7 +34857,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:36.900+00:00",
+        "created": "2019-06-11T14:16:36.900+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34754,7 +34866,7 @@
         "id": 736,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000248",
-        "modified": "2019-06-11T14:16:36.900+00:00",
+        "modified": "2019-06-11T14:16:36.900+0000",
         "name": "NONCODE v3",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -34801,7 +34913,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:29.649+00:00",
+        "created": "2019-06-11T14:17:29.649+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34810,7 +34922,7 @@
         "id": 1366,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000480",
-        "modified": "2019-06-11T14:17:29.649+00:00",
+        "modified": "2019-06-11T14:17:29.649+0000",
         "name": "NONCODE v4 Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^NONHSAG\\d{5}$",
@@ -34857,7 +34969,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:29.833+00:00",
+        "created": "2019-06-11T14:17:29.833+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34866,7 +34978,7 @@
         "id": 1368,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000481",
-        "modified": "2019-06-11T14:17:29.833+00:00",
+        "modified": "2019-06-11T14:17:29.833+0000",
         "name": "NONCODE v4 Transcript",
         "namespaceEmbeddedInLui": false,
         "pattern": "^NONHSAT\\d{6}$",
@@ -34913,7 +35025,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:33.862+00:00",
+        "created": "2019-06-11T14:17:33.862+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34922,7 +35034,7 @@
         "id": 1412,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000498",
-        "modified": "2019-06-11T14:17:33.862+00:00",
+        "modified": "2019-06-11T14:17:33.862+0000",
         "name": "NORINE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^NOR\\d+$",
@@ -34969,7 +35081,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:00.593+00:00",
+        "created": "2019-06-11T14:17:00.593+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -34978,7 +35090,7 @@
         "id": 1022,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000356",
-        "modified": "2019-06-11T14:17:00.593+00:00",
+        "modified": "2019-06-11T14:17:00.593+0000",
         "name": "NucleaRDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+\\_\\w+$",
@@ -35025,7 +35137,7 @@
         "successor": null
       },
       {
-        "created": "2021-10-17T10:21:25.826+00:00",
+        "created": "2021-10-17T10:21:25.826+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35034,7 +35146,7 @@
         "id": 2926,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000882",
-        "modified": "2021-10-17T10:24:40.143+00:00",
+        "modified": "2021-10-17T10:24:40.143+0000",
         "name": "Nucleotide",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9_\\.]+$",
@@ -35081,7 +35193,63 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:06.780+00:00",
+        "created": "2024-03-21T14:43:39.901+0000",
+        "deprecated": false,
+        "deprecationDate": null,
+        "deprecationOfflineDate": null,
+        "deprecationStatement": null,
+        "description": "OBCS stands for the Ontology of Biological and Clinical Statistics. OBCS is an ontology in the domain of biological and clinical statistics. It is aligned with the Basic Formal Ontology (BFO) and the Ontology for Biomedical Investigations (OBI)",
+        "id": 3852,
+        "infoOnPostmortemAccess": null,
+        "mirId": "MIR:00001053",
+        "modified": "2024-03-21T14:43:39.901+0000",
+        "name": " Ontology of Biological and Clinical Statistics",
+        "namespaceEmbeddedInLui": true,
+        "pattern": "^OBCS:\\d+$",
+        "prefix": "obcs",
+        "renderDeprecatedLanding": false,
+        "resources": [
+          {
+            "authHelpDescription": null,
+            "authHelpUrl": null,
+            "deprecated": false,
+            "deprecationDate": null,
+            "deprecationOfflineDate": null,
+            "deprecationStatement": null,
+            "description": "OBCS stands for the Ontology of Biological and Clinical Statistics",
+            "id": 3853,
+            "institution": {
+              "description": "At EMBL-EBI, we make the world’s public biological data freely available to the scientific community via a range of services and tools, perform basic research and provide professional training in bioinformatics. \nWe are part of the European Molecular Biology Laboratory (EMBL), an international, innovative and interdisciplinary research organisation funded by 26 member states and two associate member states.",
+              "homeUrl": "https://www.ebi.ac.uk",
+              "id": 2,
+              "location": {
+                "countryCode": "GB",
+                "countryName": "United Kingdom"
+              },
+              "name": "European Bioinformatics Institute",
+              "rorId": "https://ror.org/02catss52"
+            },
+            "location": {
+              "countryCode": "GB",
+              "countryName": "United Kingdom"
+            },
+            "mirId": "MIR:00001052",
+            "name": "OBCS via OLS",
+            "official": true,
+            "protectedUrls": false,
+            "providerCode": "ols",
+            "renderDeprecatedLanding": false,
+            "renderProtectedLanding": false,
+            "resourceHomeUrl": "https://www.ebi.ac.uk/ols4/ontologies/obcs",
+            "sampleId": "0000086",
+            "urlPattern": "https://www.ebi.ac.uk/ols4/ontologies/obcs/classes?obo_id=OBCS:{$id}"
+          }
+        ],
+        "sampleId": "0000086",
+        "successor": null
+      },
+      {
+        "created": "2019-06-11T14:16:06.780+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35090,7 +35258,7 @@
         "id": 402,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000127",
-        "modified": "2019-06-11T14:16:06.780+00:00",
+        "modified": "2019-06-11T14:16:06.780+0000",
         "name": "Ontology for Biomedical Investigations",
         "namespaceEmbeddedInLui": false,
         "pattern": "(^OBI:\\d{7}$)|(^OBI_\\d{7}$)",
@@ -35207,7 +35375,7 @@
         "successor": null
       },
       {
-        "created": "2023-04-11T08:16:21.531+00:00",
+        "created": "2023-04-11T08:16:21.531+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35216,7 +35384,7 @@
         "id": 3494,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001000",
-        "modified": "2023-04-11T08:16:21.531+00:00",
+        "modified": "2023-04-11T08:16:21.531+0000",
         "name": "Austrian Library Network",
         "namespaceEmbeddedInLui": false,
         "pattern": "AC[0-9]{8}",
@@ -35263,7 +35431,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:22.186+00:00",
+        "created": "2019-06-11T14:18:22.186+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35272,7 +35440,7 @@
         "id": 1918,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000693",
-        "modified": "2019-06-11T14:18:22.186+00:00",
+        "modified": "2019-06-11T14:18:22.186+0000",
         "name": "OpenCitations Corpus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z][a-z]/[0-9]+$",
@@ -35319,7 +35487,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:13.968+00:00",
+        "created": "2019-06-11T14:18:13.968+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35328,7 +35496,7 @@
         "id": 1831,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000660",
-        "modified": "2023-05-12T15:05:01.546+00:00",
+        "modified": "2023-05-12T15:05:01.546+0000",
         "name": "OCI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^0[1-9]+0[0-9]+-0[1-9]+0[0-9]+$",
@@ -35375,7 +35543,7 @@
         "successor": null
       },
       {
-        "created": "2019-09-10T09:27:59.693+00:00",
+        "created": "2019-09-10T09:27:59.693+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35384,7 +35552,7 @@
         "id": 1989,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000738",
-        "modified": "2019-09-10T09:27:59.693+00:00",
+        "modified": "2019-09-10T09:27:59.693+0000",
         "name": "Ontology Concept Identifiers",
         "namespaceEmbeddedInLui": true,
         "pattern": "ocid:[0-9]{12}",
@@ -35395,7 +35563,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2021-10-17T10:39:01.622+00:00",
+            "deprecationDate": "2021-10-17T10:39:01.622+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "SciWalker is an open access ontology based search tool for annotated data and extracted knowledge from scientific databases, patents and scientific documents.",
@@ -35466,7 +35634,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:16.344+00:00",
+        "created": "2019-06-11T14:18:16.344+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35475,7 +35643,7 @@
         "id": 1853,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000669",
-        "modified": "2019-06-11T14:18:16.344+00:00",
+        "modified": "2019-06-11T14:18:16.344+0000",
         "name": "Online Computer Library Center (OCLC) WorldCat",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+$",
@@ -35522,7 +35690,7 @@
         "successor": null
       },
       {
-        "created": "2020-07-08T15:12:19.317+00:00",
+        "created": "2020-07-08T15:12:19.317+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35531,7 +35699,7 @@
         "id": 2293,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000722",
-        "modified": "2020-07-08T15:12:19.317+00:00",
+        "modified": "2020-07-08T15:12:19.317+0000",
         "name": "Open Data for Access and Mining",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -35578,7 +35746,7 @@
         "successor": null
       },
       {
-        "created": "2021-03-15T19:43:45.400+00:00",
+        "created": "2021-03-15T19:43:45.400+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35587,7 +35755,7 @@
         "id": 2589,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000804",
-        "modified": "2021-03-15T19:43:45.400+00:00",
+        "modified": "2021-03-15T19:43:45.400+0000",
         "name": "Open Data Commons for Spinal Cord Injury",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]*$",
@@ -35634,7 +35802,7 @@
         "successor": null
       },
       {
-        "created": "2021-05-22T17:51:43.225+00:00",
+        "created": "2021-05-22T17:51:43.225+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35643,7 +35811,7 @@
         "id": 2650,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000816",
-        "modified": "2021-05-22T17:51:43.225+00:00",
+        "modified": "2021-05-22T17:51:43.225+0000",
         "name": "Open Data Commons for Traumatic Brain Injury",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]*$",
@@ -35690,7 +35858,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:34.340+00:00",
+        "created": "2019-06-11T14:17:34.340+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35699,7 +35867,7 @@
         "id": 1418,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000500",
-        "modified": "2019-06-11T14:17:34.340+00:00",
+        "modified": "2019-06-11T14:17:34.340+0000",
         "name": "Odor Molecules DataBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -35746,7 +35914,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:17.389+00:00",
+        "created": "2019-06-11T14:18:17.389+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35755,7 +35923,7 @@
         "id": 1864,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000673",
-        "modified": "2019-06-11T14:18:17.389+00:00",
+        "modified": "2019-06-11T14:18:17.389+0000",
         "name": "OID Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[\\d.]+$",
@@ -35802,7 +35970,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:57.285+00:00",
+        "created": "2019-06-11T14:16:57.285+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35811,7 +35979,7 @@
         "id": 985,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000343",
-        "modified": "2019-06-11T14:16:57.285+00:00",
+        "modified": "2019-06-11T14:16:57.285+0000",
         "name": "OMA Group",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]+$",
@@ -35858,7 +36026,7 @@
         "successor": null
       },
       {
-        "created": "2020-12-14T12:57:54.560+00:00",
+        "created": "2020-12-14T12:57:54.560+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35867,7 +36035,7 @@
         "id": 2484,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000785",
-        "modified": "2023-01-10T16:04:39.504+00:00",
+        "modified": "2023-01-10T16:04:39.504+0000",
         "name": "OMA HOGs",
         "namespaceEmbeddedInLui": true,
         "pattern": "^HOG:[0-9]{7}(\\.[0-9a-z.]+)?(_[0-9]+)?$",
@@ -35914,7 +36082,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:57.058+00:00",
+        "created": "2019-06-11T14:16:57.058+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35923,7 +36091,7 @@
         "id": 982,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000342",
-        "modified": "2019-06-11T14:16:57.058+00:00",
+        "modified": "2019-06-11T14:16:57.058+0000",
         "name": "OMA Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]{5}\\d+$",
@@ -35970,7 +36138,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:11.523+00:00",
+        "created": "2019-06-11T14:16:11.523+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -35979,7 +36147,7 @@
         "id": 451,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000142",
-        "modified": "2019-06-11T14:16:11.523+00:00",
+        "modified": "2019-06-11T14:16:11.523+0000",
         "name": "OMIA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36026,7 +36194,7 @@
         "successor": null
       },
       {
-        "created": "2023-04-28T08:49:50.354+00:00",
+        "created": "2023-04-28T08:49:50.354+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36035,7 +36203,7 @@
         "id": 3510,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001004",
-        "modified": "2023-04-28T08:49:50.354+00:00",
+        "modified": "2023-04-28T08:49:50.354+0000",
         "name": "OpenCitations Meta Identifier",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z][a-z]/06[1-9]*0[1-9][0-9]*$",
@@ -36082,7 +36250,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:00.566+00:00",
+        "created": "2019-06-11T14:18:00.566+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36091,7 +36259,7 @@
         "id": 1679,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000605",
-        "modified": "2019-06-11T14:18:00.566+00:00",
+        "modified": "2019-06-11T14:18:00.566+0000",
         "name": "OMIT",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{7}$",
@@ -36138,7 +36306,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:07.624+00:00",
+        "created": "2019-06-11T14:16:07.624+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36147,7 +36315,7 @@
         "id": 410,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000129",
-        "modified": "2019-06-11T14:16:07.624+00:00",
+        "modified": "2019-06-11T14:16:07.624+0000",
         "name": "Ontology of Physics for Biology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^OPB_\\d+$",
@@ -36194,7 +36362,63 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:54.970+00:00",
+        "created": "2024-03-20T10:39:56.678+0000",
+        "deprecated": false,
+        "deprecationDate": null,
+        "deprecationOfflineDate": null,
+        "deprecationStatement": null,
+        "description": "The Ontology for Parasite Lifecycle (OPL) models the life cycle stage details of various parasites, including Trypanosoma sp., Leishmania major, and Plasmodium sp., etc.",
+        "id": 3827,
+        "infoOnPostmortemAccess": null,
+        "mirId": "MIR:00001047",
+        "modified": "2024-03-20T10:39:56.678+0000",
+        "name": "Ontology for Parasite Lifecycle",
+        "namespaceEmbeddedInLui": true,
+        "pattern": "^OPL:\\d+$",
+        "prefix": "opl",
+        "renderDeprecatedLanding": false,
+        "resources": [
+          {
+            "authHelpDescription": null,
+            "authHelpUrl": null,
+            "deprecated": false,
+            "deprecationDate": null,
+            "deprecationOfflineDate": null,
+            "deprecationStatement": null,
+            "description": "The Ontology for Parasite Lifecycle (OPL) models the life cycle stage details of various parasites, including Trypanosoma sp., Leishmania major, and Plasmodium sp., etc",
+            "id": 3828,
+            "institution": {
+              "description": "At EMBL-EBI, we make the world’s public biological data freely available to the scientific community via a range of services and tools, perform basic research and provide professional training in bioinformatics. \nWe are part of the European Molecular Biology Laboratory (EMBL), an international, innovative and interdisciplinary research organisation funded by 26 member states and two associate member states.",
+              "homeUrl": "https://www.ebi.ac.uk",
+              "id": 2,
+              "location": {
+                "countryCode": "GB",
+                "countryName": "United Kingdom"
+              },
+              "name": "European Bioinformatics Institute",
+              "rorId": "https://ror.org/02catss52"
+            },
+            "location": {
+              "countryCode": "GB",
+              "countryName": "United Kingdom"
+            },
+            "mirId": "MIR:00001046",
+            "name": "OPL via OLS",
+            "official": true,
+            "protectedUrls": false,
+            "providerCode": "ols",
+            "renderDeprecatedLanding": false,
+            "renderProtectedLanding": false,
+            "resourceHomeUrl": "https://www.ebi.ac.uk/ols4/ontologies/opl",
+            "sampleId": "0000134",
+            "urlPattern": "https://www.ebi.ac.uk/ols4/ontologies/opl/classes?obo_id=OPL:{$id}"
+          }
+        ],
+        "sampleId": "0000134",
+        "successor": null
+      },
+      {
+        "created": "2019-06-11T14:16:54.970+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36203,7 +36427,7 @@
         "id": 955,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000333",
-        "modified": "2019-06-11T14:16:54.970+00:00",
+        "modified": "2019-06-11T14:16:54.970+0000",
         "name": "OPM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9][A-Za-z0-9]{3}$",
@@ -36250,7 +36474,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:06.994+00:00",
+        "created": "2019-06-11T14:17:06.994+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36259,7 +36483,7 @@
         "id": 1100,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000382",
-        "modified": "2019-06-11T14:17:06.994+00:00",
+        "modified": "2019-06-11T14:17:06.994+0000",
         "name": "ORCID",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}(\\d|X)$",
@@ -36306,7 +36530,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:34.104+00:00",
+        "created": "2019-06-11T14:17:34.104+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36315,7 +36539,7 @@
         "id": 1415,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000499",
-        "modified": "2019-06-11T14:17:34.104+00:00",
+        "modified": "2019-06-11T14:17:34.104+0000",
         "name": "Olfactory Receptor Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36362,7 +36586,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:03.475+00:00",
+        "created": "2019-06-11T14:17:03.475+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36371,7 +36595,7 @@
         "id": 1058,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000369",
-        "modified": "2019-06-11T14:17:03.475+00:00",
+        "modified": "2019-06-11T14:17:03.475+0000",
         "name": "OriDB Saccharomyces",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36418,7 +36642,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:03.255+00:00",
+        "created": "2019-06-11T14:17:03.255+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36427,7 +36651,7 @@
         "id": 1055,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000368",
-        "modified": "2019-06-11T14:17:03.255+00:00",
+        "modified": "2019-06-11T14:17:03.255+0000",
         "name": "OriDB Schizosaccharomyces",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36474,7 +36698,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:29.544+00:00",
+        "created": "2019-06-11T14:16:29.544+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36483,7 +36707,7 @@
         "id": 653,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000220",
-        "modified": "2019-06-11T14:16:29.544+00:00",
+        "modified": "2019-06-11T14:16:29.544+0000",
         "name": "Orphanet",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36565,7 +36789,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:42.194+00:00",
+        "created": "2019-06-11T14:17:42.194+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36574,7 +36798,7 @@
         "id": 1495,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000532",
-        "modified": "2019-06-11T14:17:42.194+00:00",
+        "modified": "2019-06-11T14:17:42.194+0000",
         "name": "Orphanet Rare Disease Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Orphanet(_|:)C?\\d+$",
@@ -36621,7 +36845,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:29.860+00:00",
+        "created": "2019-06-11T14:16:29.860+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36630,7 +36854,7 @@
         "id": 657,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000221",
-        "modified": "2019-06-11T14:16:29.860+00:00",
+        "modified": "2019-06-11T14:16:29.860+0000",
         "name": "OrthoDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -36677,7 +36901,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:30.027+00:00",
+        "created": "2019-06-11T14:17:30.027+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36686,7 +36910,7 @@
         "id": 1370,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000482",
-        "modified": "2019-06-11T14:17:30.027+00:00",
+        "modified": "2019-06-11T14:17:30.027+0000",
         "name": "Oryzabase Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36733,7 +36957,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:30.248+00:00",
+        "created": "2019-06-11T14:17:30.248+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36742,7 +36966,7 @@
         "id": 1373,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000483",
-        "modified": "2019-06-11T14:17:30.248+00:00",
+        "modified": "2019-06-11T14:17:30.248+0000",
         "name": "Oryzabase Mutant",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36789,7 +37013,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:21.361+00:00",
+        "created": "2019-06-11T14:18:21.361+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36798,7 +37022,7 @@
         "id": 1909,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000689",
-        "modified": "2019-06-11T14:18:21.361+00:00",
+        "modified": "2019-06-11T14:18:21.361+0000",
         "name": "Oryzabase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36845,7 +37069,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:30.616+00:00",
+        "created": "2019-06-11T14:17:30.616+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36854,7 +37078,7 @@
         "id": 1377,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000485",
-        "modified": "2019-06-11T14:17:30.616+00:00",
+        "modified": "2019-06-11T14:17:30.616+0000",
         "name": "Oryzabase Stage",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36901,7 +37125,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:30.425+00:00",
+        "created": "2019-06-11T14:17:30.425+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36910,7 +37134,7 @@
         "id": 1375,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000484",
-        "modified": "2019-06-11T14:17:30.425+00:00",
+        "modified": "2019-06-11T14:17:30.425+0000",
         "name": "Oryzabase Strain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -36957,7 +37181,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:30.833+00:00",
+        "created": "2019-06-11T14:17:30.833+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -36966,7 +37190,7 @@
         "id": 1379,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000486",
-        "modified": "2019-06-11T14:17:30.833+00:00",
+        "modified": "2019-06-11T14:17:30.833+0000",
         "name": "Oryza Tag Line",
         "namespaceEmbeddedInLui": false,
         "pattern": "^A[A-Z]+\\d+$",
@@ -37013,7 +37237,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:34.528+00:00",
+        "created": "2019-06-11T14:17:34.528+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37022,7 +37246,7 @@
         "id": 1420,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000501",
-        "modified": "2019-06-11T14:17:34.528+00:00",
+        "modified": "2019-06-11T14:17:34.528+0000",
         "name": "P3DB Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37069,7 +37293,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:34.763+00:00",
+        "created": "2019-06-11T14:17:34.763+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37078,7 +37302,7 @@
         "id": 1423,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000502",
-        "modified": "2019-06-11T14:17:34.763+00:00",
+        "modified": "2019-06-11T14:17:34.763+0000",
         "name": "P3DB Site",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37125,7 +37349,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:23.782+00:00",
+        "created": "2019-06-11T14:16:23.782+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37134,7 +37358,7 @@
         "id": 592,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000197",
-        "modified": "2019-06-11T14:16:23.782+00:00",
+        "modified": "2019-06-11T14:16:23.782+0000",
         "name": "PaleoDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37181,7 +37405,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:48.923+00:00",
+        "created": "2019-06-11T14:15:48.923+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37190,7 +37414,7 @@
         "id": 212,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000060",
-        "modified": "2019-06-11T14:15:48.923+00:00",
+        "modified": "2019-06-11T14:15:48.923+0000",
         "name": "PANTHER Family",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PTHR\\d{5}(\\:SF\\d{1,3})?$",
@@ -37237,7 +37461,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:04.735+00:00",
+        "created": "2019-06-11T14:17:04.735+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37246,7 +37470,7 @@
         "id": 1074,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000374",
-        "modified": "2019-06-11T14:17:04.735+00:00",
+        "modified": "2019-06-11T14:17:04.735+0000",
         "name": "PANTHER Node",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PTN\\d{9}$",
@@ -37293,7 +37517,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:02.153+00:00",
+        "created": "2019-06-11T14:17:02.153+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37302,7 +37526,7 @@
         "id": 1041,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000363",
-        "modified": "2019-06-11T14:17:02.153+00:00",
+        "modified": "2019-06-11T14:17:02.153+0000",
         "name": "PANTHER Pathway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^P\\d{5}$",
@@ -37349,7 +37573,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:16.858+00:00",
+        "created": "2019-06-11T14:17:16.858+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37358,7 +37582,7 @@
         "id": 1217,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000422",
-        "modified": "2023-01-04T16:32:41.267+00:00",
+        "modified": "2023-01-04T16:32:41.267+0000",
         "name": "PANTHER Pathway Component",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[GPUCS]\\d{5}$",
@@ -37405,7 +37629,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:27.086+00:00",
+        "created": "2019-06-11T14:17:27.086+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37414,7 +37638,7 @@
         "id": 1335,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000468",
-        "modified": "2019-06-11T14:17:27.086+00:00",
+        "modified": "2019-06-11T14:17:27.086+0000",
         "name": "PASS2",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37461,7 +37685,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:52.436+00:00",
+        "created": "2019-06-11T14:15:52.436+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37470,7 +37694,7 @@
         "id": 249,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000073",
-        "modified": "2019-06-11T14:15:52.436+00:00",
+        "modified": "2019-06-11T14:15:52.436+0000",
         "name": "Pathway Commons",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37517,7 +37741,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:02.730+00:00",
+        "created": "2019-06-11T14:16:02.730+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37526,7 +37750,7 @@
         "id": 358,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000112",
-        "modified": "2019-06-11T14:16:02.730+00:00",
+        "modified": "2019-06-11T14:16:02.730+0000",
         "name": "PATO",
         "namespaceEmbeddedInLui": true,
         "pattern": "^PATO:\\d{7}$",
@@ -37608,7 +37832,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:31.315+00:00",
+        "created": "2019-06-11T14:17:31.315+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37617,7 +37841,7 @@
         "id": 1384,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000488",
-        "modified": "2019-06-11T14:17:31.315+00:00",
+        "modified": "2019-06-11T14:17:31.315+0000",
         "name": "PaxDb Organism",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37664,7 +37888,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:31.566+00:00",
+        "created": "2019-06-11T14:17:31.566+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37673,7 +37897,7 @@
         "id": 1387,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000489",
-        "modified": "2019-06-11T14:17:31.566+00:00",
+        "modified": "2019-06-11T14:17:31.566+0000",
         "name": "PaxDb Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -37720,7 +37944,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:49.605+00:00",
+        "created": "2019-06-11T14:16:49.605+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37729,7 +37953,7 @@
         "id": 892,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000306",
-        "modified": "2019-06-11T14:16:49.605+00:00",
+        "modified": "2019-06-11T14:16:49.605+0000",
         "name": "Pazar Transcription Factor",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TF\\w+$",
@@ -37776,7 +38000,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:35.100+00:00",
+        "created": "2019-06-11T14:15:35.100+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -37785,7 +38009,7 @@
         "id": 78,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000020",
-        "modified": "2019-06-11T14:15:35.100+00:00",
+        "modified": "2019-06-11T14:15:35.100+0000",
         "name": "Protein Data Bank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9][A-Za-z0-9]{3}$",
@@ -38007,7 +38231,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:03.054+00:00",
+        "created": "2019-06-11T14:16:03.054+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38016,7 +38240,7 @@
         "id": 361,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000113",
-        "modified": "2022-05-18T15:48:21.884+00:00",
+        "modified": "2022-05-18T15:48:21.884+0000",
         "name": "Chemical Component Dictionary",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{1,3}$",
@@ -38063,7 +38287,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:31.784+00:00",
+        "created": "2019-06-11T14:17:31.784+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38072,7 +38296,7 @@
         "id": 1389,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000490",
-        "modified": "2019-06-11T14:17:31.784+00:00",
+        "modified": "2019-06-11T14:17:31.784+0000",
         "name": "Protein Data Bank Ligand",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -38154,7 +38378,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-17T18:02:05.160+00:00",
+        "created": "2021-02-17T18:02:05.160+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38163,7 +38387,7 @@
         "id": 2521,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000777",
-        "modified": "2021-02-17T18:02:05.160+00:00",
+        "modified": "2021-02-17T18:02:05.160+0000",
         "name": "Protein Ensemble Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PED\\d{5}$",
@@ -38210,7 +38434,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-17T18:06:52.762+00:00",
+        "created": "2021-02-17T18:06:52.762+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38219,7 +38443,7 @@
         "id": 2524,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000795",
-        "modified": "2021-02-17T18:06:52.762+00:00",
+        "modified": "2021-02-17T18:06:52.762+0000",
         "name": "Protein Ensemble Database ensemble",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PED\\d{5}e\\d{3}$",
@@ -38266,7 +38490,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:46.969+00:00",
+        "created": "2019-06-11T14:15:46.969+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38275,7 +38499,7 @@
         "id": 192,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000053",
-        "modified": "2019-06-11T14:15:46.969+00:00",
+        "modified": "2019-06-11T14:15:46.969+0000",
         "name": "PeptideAtlas",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PAp[0-9]{8}$",
@@ -38322,7 +38546,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:21.571+00:00",
+        "created": "2019-06-11T14:18:21.571+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38331,7 +38555,7 @@
         "id": 1911,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000690",
-        "modified": "2019-06-11T14:18:21.571+00:00",
+        "modified": "2019-06-11T14:18:21.571+0000",
         "name": "PeptideAtlas Dataset",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PASS\\d{5}$",
@@ -38378,7 +38602,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:30.097+00:00",
+        "created": "2019-06-11T14:16:30.097+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38387,7 +38611,7 @@
         "id": 660,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000222",
-        "modified": "2019-06-11T14:16:30.097+00:00",
+        "modified": "2019-06-11T14:16:30.097+0000",
         "name": "Peroxibase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -38434,7 +38658,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:39.270+00:00",
+        "created": "2019-06-11T14:15:39.270+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38443,7 +38667,7 @@
         "id": 117,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000028",
-        "modified": "2019-06-11T14:15:39.270+00:00",
+        "modified": "2019-06-11T14:15:39.270+0000",
         "name": "Pfam",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PF\\d{5}$",
@@ -38490,7 +38714,7 @@
         "successor": null
       },
       {
-        "created": "2020-04-22T09:46:18.729+00:00",
+        "created": "2020-04-22T09:46:18.729+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38499,7 +38723,7 @@
         "id": 2215,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000753",
-        "modified": "2020-04-22T09:46:18.729+00:00",
+        "modified": "2020-04-22T09:46:18.729+0000",
         "name": "Polygenic Score Catalog",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PGS[0-9]{6}$",
@@ -38546,7 +38770,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:59.445+00:00",
+        "created": "2019-06-11T14:17:59.445+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38555,7 +38779,7 @@
         "id": 1666,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000600",
-        "modified": "2020-11-25T15:01:33.103+00:00",
+        "modified": "2020-11-25T15:01:33.103+0000",
         "name": "Progenetix",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{3,15}[-_]\\w[\\w.-]{3,128}$",
@@ -38602,7 +38826,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:57.258+00:00",
+        "created": "2019-06-11T14:15:57.258+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38611,7 +38835,7 @@
         "id": 300,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000090",
-        "modified": "2019-06-11T14:15:57.258+00:00",
+        "modified": "2019-06-11T14:15:57.258+0000",
         "name": "PharmGKB Disease",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PA\\d+$",
@@ -38658,7 +38882,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:57.451+00:00",
+        "created": "2019-06-11T14:15:57.451+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38667,7 +38891,7 @@
         "id": 302,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000091",
-        "modified": "2019-06-11T14:15:57.451+00:00",
+        "modified": "2019-06-11T14:15:57.451+0000",
         "name": "PharmGKB Drug",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PA\\d+$",
@@ -38714,7 +38938,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:36.222+00:00",
+        "created": "2019-06-11T14:16:36.222+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38723,7 +38947,7 @@
         "id": 728,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000245",
-        "modified": "2019-06-11T14:16:36.222+00:00",
+        "modified": "2019-06-11T14:16:36.222+0000",
         "name": "PharmGKB Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PA\\w+$",
@@ -38770,7 +38994,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:57.006+00:00",
+        "created": "2019-06-11T14:15:57.006+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38779,7 +39003,7 @@
         "id": 297,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000089",
-        "modified": "2019-06-11T14:15:57.006+00:00",
+        "modified": "2019-06-11T14:15:57.006+0000",
         "name": "PharmGKB Pathways",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PA\\d+$",
@@ -38826,7 +39050,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:40.928+00:00",
+        "created": "2019-06-11T14:16:40.928+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38835,7 +39059,7 @@
         "id": 785,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000268",
-        "modified": "2019-06-11T14:16:40.928+00:00",
+        "modified": "2019-06-11T14:16:40.928+0000",
         "name": "Phenol-Explorer",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -38882,7 +39106,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:08.222+00:00",
+        "created": "2019-06-11T14:17:08.222+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38891,7 +39115,7 @@
         "id": 1115,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000385",
-        "modified": "2019-06-11T14:17:08.222+00:00",
+        "modified": "2019-06-11T14:17:08.222+0000",
         "name": "PhosphoPoint Kinase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -38938,7 +39162,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:08.458+00:00",
+        "created": "2019-06-11T14:17:08.458+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -38947,7 +39171,7 @@
         "id": 1118,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000386",
-        "modified": "2019-06-11T14:17:08.458+00:00",
+        "modified": "2019-06-11T14:17:08.458+0000",
         "name": "PhosphoPoint Phosphoprotein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -38994,7 +39218,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:00.712+00:00",
+        "created": "2019-06-11T14:16:00.712+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39003,7 +39227,7 @@
         "id": 338,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000105",
-        "modified": "2019-06-11T14:16:00.712+00:00",
+        "modified": "2019-06-11T14:16:00.712+0000",
         "name": "PhosphoSite Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{5}$",
@@ -39050,7 +39274,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:06.208+00:00",
+        "created": "2019-06-11T14:16:06.208+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39059,7 +39283,7 @@
         "id": 396,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000125",
-        "modified": "2019-06-11T14:16:06.208+00:00",
+        "modified": "2019-06-11T14:16:06.208+0000",
         "name": "PhosphoSite Residue",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -39106,7 +39330,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:30.326+00:00",
+        "created": "2019-06-11T14:16:30.326+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39115,7 +39339,7 @@
         "id": 663,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000223",
-        "modified": "2019-06-11T14:16:30.326+00:00",
+        "modified": "2019-06-11T14:16:30.326+0000",
         "name": "PhylomeDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -39162,7 +39386,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:19.049+00:00",
+        "created": "2019-06-11T14:17:19.049+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39171,7 +39395,7 @@
         "id": 1241,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000432",
-        "modified": "2019-06-11T14:17:19.049+00:00",
+        "modified": "2019-06-11T14:17:19.049+0000",
         "name": "Phytozome Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -39218,7 +39442,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:08.872+00:00",
+        "created": "2019-06-11T14:16:08.872+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39227,7 +39451,7 @@
         "id": 424,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000133",
-        "modified": "2019-06-11T14:16:08.872+00:00",
+        "modified": "2019-06-11T14:16:08.872+0000",
         "name": "NCI Pathway Interaction Database: Pathway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -39274,7 +39498,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:35.969+00:00",
+        "created": "2019-06-11T14:17:35.969+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39283,7 +39507,7 @@
         "id": 1433,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000506",
-        "modified": "2019-06-11T14:17:35.969+00:00",
+        "modified": "2019-06-11T14:17:35.969+0000",
         "name": "Animal Genome Pig QTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -39330,7 +39554,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:01.276+00:00",
+        "created": "2019-06-11T14:17:01.276+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39339,7 +39563,7 @@
         "id": 1030,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000359",
-        "modified": "2019-06-11T14:17:01.276+00:00",
+        "modified": "2019-06-11T14:17:01.276+0000",
         "name": "PINA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])$",
@@ -39386,7 +39610,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:59.494+00:00",
+        "created": "2019-06-11T14:16:59.494+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39395,7 +39619,7 @@
         "id": 1009,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000351",
-        "modified": "2019-06-11T14:16:59.494+00:00",
+        "modified": "2019-06-11T14:16:59.494+0000",
         "name": "PiroplasmaDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TA\\d+$",
@@ -39442,7 +39666,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:34.294+00:00",
+        "created": "2019-06-11T14:15:34.294+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39451,7 +39675,7 @@
         "id": 69,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000017",
-        "modified": "2019-06-11T14:15:34.294+00:00",
+        "modified": "2019-06-11T14:15:34.294+0000",
         "name": "PIRSF",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PIRSF\\d{6}$",
@@ -39498,7 +39722,7 @@
         "successor": null
       },
       {
-        "created": "2020-10-07T10:25:14.491+00:00",
+        "created": "2020-10-07T10:25:14.491+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39507,7 +39731,7 @@
         "id": 2370,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000708",
-        "modified": "2020-10-07T10:25:14.491+00:00",
+        "modified": "2020-10-07T10:25:14.491+0000",
         "name": "PK-DB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PKDB[0-9]{5}$",
@@ -39554,7 +39778,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:53.641+00:00",
+        "created": "2019-06-11T14:17:53.641+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39563,7 +39787,7 @@
         "id": 1611,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000579",
-        "modified": "2019-06-11T14:17:53.641+00:00",
+        "modified": "2019-06-11T14:17:53.641+0000",
         "name": "Plant Transcription Factor Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z][a-z]{2}_([A-Za-z]{3}[0-9]{6})|([A-Za-z0-9\\._\\-#]*)$",
@@ -39610,7 +39834,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:13.221+00:00",
+        "created": "2019-06-11T14:16:13.221+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39619,7 +39843,7 @@
         "id": 471,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000150",
-        "modified": "2019-06-11T14:16:13.221+00:00",
+        "modified": "2019-06-11T14:16:13.221+0000",
         "name": "PlasmoDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -39666,7 +39890,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:30.793+00:00",
+        "created": "2019-06-11T14:16:30.793+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39675,7 +39899,7 @@
         "id": 669,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000225",
-        "modified": "2019-06-11T14:16:30.793+00:00",
+        "modified": "2019-06-11T14:16:30.793+0000",
         "name": "CutDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -39722,7 +39946,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:30.547+00:00",
+        "created": "2019-06-11T14:16:30.547+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39731,7 +39955,7 @@
         "id": 666,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000224",
-        "modified": "2019-06-11T14:16:30.547+00:00",
+        "modified": "2019-06-11T14:16:30.547+0000",
         "name": "SubstrateDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -39778,7 +40002,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:12.446+00:00",
+        "created": "2019-06-11T14:16:12.446+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39787,7 +40011,7 @@
         "id": 462,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000147",
-        "modified": "2019-06-11T14:16:12.446+00:00",
+        "modified": "2019-06-11T14:16:12.446+0000",
         "name": "PMC International",
         "namespaceEmbeddedInLui": false,
         "pattern": "PMC\\d+",
@@ -39869,7 +40093,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:22.644+00:00",
+        "created": "2019-06-11T14:16:22.644+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39878,7 +40102,7 @@
         "id": 578,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000190",
-        "modified": "2019-06-11T14:16:22.644+00:00",
+        "modified": "2019-06-11T14:16:22.644+0000",
         "name": "Protein Model Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PM\\d{7}",
@@ -39925,7 +40149,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:31.282+00:00",
+        "created": "2019-06-11T14:16:31.282+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39934,7 +40158,7 @@
         "id": 673,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000227",
-        "modified": "2019-06-11T14:16:31.282+00:00",
+        "modified": "2019-06-11T14:16:31.282+0000",
         "name": "PMP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])$",
@@ -39945,7 +40169,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2020-03-03T06:27:49.602+00:00",
+            "deprecationDate": "2020-03-03T06:27:49.602+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "PMP at University of Basel",
@@ -39981,7 +40205,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:39:33.533+00:00",
+        "created": "2021-08-08T09:39:33.533+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -39990,7 +40214,7 @@
         "id": 2796,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000845",
-        "modified": "2021-08-08T09:39:33.533+00:00",
+        "modified": "2021-08-08T09:39:33.533+0000",
         "name": "Physiome Model Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z0-9]{32,32}$",
@@ -40037,7 +40261,7 @@
         "successor": null
       },
       {
-        "created": "2022-02-27T20:41:50.311+00:00",
+        "created": "2022-02-27T20:41:50.311+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40046,7 +40270,7 @@
         "id": 3196,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000948",
-        "modified": "2022-02-27T20:41:50.311+00:00",
+        "modified": "2022-02-27T20:41:50.311+0000",
         "name": "Physiome Model Repository workspace",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z0-9_\\-]+(/.*?)?$",
@@ -40093,7 +40317,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:49.830+00:00",
+        "created": "2019-06-11T14:16:49.830+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40102,7 +40326,7 @@
         "id": 895,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000307",
-        "modified": "2019-06-11T14:16:49.830+00:00",
+        "modified": "2019-06-11T14:16:49.830+0000",
         "name": "Plant Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^PO:\\d+$",
@@ -40219,7 +40443,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:12.099+00:00",
+        "created": "2019-06-11T14:17:12.099+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40228,7 +40452,7 @@
         "id": 1161,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000400",
-        "modified": "2019-06-11T14:17:12.099+00:00",
+        "modified": "2019-06-11T14:17:12.099+0000",
         "name": "Pocketome",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z_0-9]+",
@@ -40275,7 +40499,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:00.403+00:00",
+        "created": "2019-06-11T14:17:00.403+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40284,7 +40508,7 @@
         "id": 1020,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000355",
-        "modified": "2019-06-11T14:17:00.403+00:00",
+        "modified": "2019-06-11T14:17:00.403+0000",
         "name": "PolBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z-0-9]+$",
@@ -40331,7 +40555,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:55.438+00:00",
+        "created": "2019-06-11T14:16:55.438+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40340,7 +40564,7 @@
         "id": 961,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000335",
-        "modified": "2019-06-11T14:16:55.438+00:00",
+        "modified": "2019-06-11T14:16:55.438+0000",
         "name": "PomBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^S\\w+(\\.)?\\w+(\\.)?$",
@@ -40387,7 +40611,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:11.083+00:00",
+        "created": "2019-06-11T14:16:11.083+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40396,7 +40620,7 @@
         "id": 447,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000141",
-        "modified": "2020-03-16T08:35:08.949+00:00",
+        "modified": "2020-03-16T08:35:08.949+0000",
         "name": "Protein Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^PR:P?\\d+$",
@@ -40513,7 +40737,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:50.454+00:00",
+        "created": "2019-06-11T14:15:50.454+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40522,7 +40746,7 @@
         "id": 228,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000065",
-        "modified": "2019-06-11T14:15:50.454+00:00",
+        "modified": "2019-06-11T14:15:50.454+0000",
         "name": "PRIDE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -40569,7 +40793,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:38.030+00:00",
+        "created": "2019-06-11T14:17:38.030+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40578,7 +40802,7 @@
         "id": 1453,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000515",
-        "modified": "2019-06-11T14:17:38.030+00:00",
+        "modified": "2019-06-11T14:17:38.030+0000",
         "name": "PRIDE Project",
         "namespaceEmbeddedInLui": false,
         "pattern": "^P(X|R)D\\d{6}$",
@@ -40660,7 +40884,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:49.123+00:00",
+        "created": "2019-06-11T14:15:49.123+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40669,7 +40893,7 @@
         "id": 214,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000061",
-        "modified": "2019-06-11T14:15:49.123+00:00",
+        "modified": "2019-06-11T14:15:49.123+0000",
         "name": "PRINTS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PR\\d{5}$",
@@ -40716,7 +40940,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:52.483+00:00",
+        "created": "2019-06-11T14:17:52.483+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40725,7 +40949,7 @@
         "id": 1601,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000575",
-        "modified": "2019-06-11T14:17:52.483+00:00",
+        "modified": "2019-06-11T14:17:52.483+0000",
         "name": "ProbOnto",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PROB_c\\d+$",
@@ -40772,7 +40996,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:03.923+00:00",
+        "created": "2019-06-11T14:16:03.923+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40781,7 +41005,7 @@
         "id": 371,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000117",
-        "modified": "2019-06-11T14:16:03.923+00:00",
+        "modified": "2019-06-11T14:16:03.923+0000",
         "name": "ProDom",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PD\\d+$",
@@ -40828,7 +41052,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:00.162+00:00",
+        "created": "2019-06-11T14:17:00.162+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40837,7 +41061,7 @@
         "id": 1017,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000354",
-        "modified": "2019-06-11T14:17:00.162+00:00",
+        "modified": "2019-06-11T14:17:00.162+0000",
         "name": "ProGlycProt",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z]C\\d{1,3}$",
@@ -40884,7 +41108,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:40.983+00:00",
+        "created": "2019-06-11T14:15:40.983+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40893,7 +41117,7 @@
         "id": 133,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000032",
-        "modified": "2019-06-11T14:15:40.983+00:00",
+        "modified": "2019-06-11T14:15:40.983+0000",
         "name": "PROSITE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PS\\d{5}$",
@@ -40940,7 +41164,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:31.086+00:00",
+        "created": "2019-06-11T14:16:31.086+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -40949,7 +41173,7 @@
         "id": 671,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000226",
-        "modified": "2019-06-11T14:16:31.086+00:00",
+        "modified": "2019-06-11T14:16:31.086+0000",
         "name": "ProtClustDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -40996,7 +41220,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:40.583+00:00",
+        "created": "2019-06-11T14:17:40.583+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41005,7 +41229,7 @@
         "id": 1478,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000525",
-        "modified": "2019-06-11T14:17:40.583+00:00",
+        "modified": "2019-06-11T14:17:40.583+0000",
         "name": "ProteomicsDB Peptide",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41052,7 +41276,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:40.344+00:00",
+        "created": "2019-06-11T14:17:40.344+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41061,7 +41285,7 @@
         "id": 1475,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000524",
-        "modified": "2019-06-11T14:17:40.344+00:00",
+        "modified": "2019-06-11T14:17:40.344+0000",
         "name": "ProteomicsDB Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41108,7 +41332,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:31.786+00:00",
+        "created": "2019-06-11T14:16:31.786+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41117,7 +41341,7 @@
         "id": 679,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000229",
-        "modified": "2019-06-11T14:16:31.786+00:00",
+        "modified": "2019-06-11T14:16:31.786+0000",
         "name": "ProtoNet Cluster",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41164,7 +41388,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:31.529+00:00",
+        "created": "2019-06-11T14:16:31.529+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41173,7 +41397,7 @@
         "id": 676,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000228",
-        "modified": "2019-06-11T14:16:31.529+00:00",
+        "modified": "2019-06-11T14:16:31.529+0000",
         "name": "ProtoNet ProteinCard",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41220,7 +41444,7 @@
         "successor": null
       },
       {
-        "created": "2022-03-15T08:27:12.699+00:00",
+        "created": "2022-03-15T08:27:12.699+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41229,7 +41453,7 @@
         "id": 3203,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000951",
-        "modified": "2022-03-15T08:27:12.699+00:00",
+        "modified": "2022-03-15T08:27:12.699+0000",
         "name": "Pennsieve",
         "namespaceEmbeddedInLui": false,
         "pattern": "N:package:[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}",
@@ -41276,7 +41500,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:03.650+00:00",
+        "created": "2019-06-11T14:17:03.650+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41285,7 +41509,7 @@
         "id": 1060,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000370",
-        "modified": "2019-06-11T14:17:03.650+00:00",
+        "modified": "2019-06-11T14:17:03.650+0000",
         "name": "PSCDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41332,7 +41556,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:20.362+00:00",
+        "created": "2019-06-11T14:16:20.362+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41341,7 +41565,7 @@
         "id": 552,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000180",
-        "modified": "2019-06-11T14:16:20.362+00:00",
+        "modified": "2019-06-11T14:16:20.362+0000",
         "name": "Pseudomonas Genome Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^P\\w+$",
@@ -41388,7 +41612,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:42.461+00:00",
+        "created": "2019-06-11T14:17:42.461+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41397,7 +41621,7 @@
         "id": 1497,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000533",
-        "modified": "2019-06-11T14:17:42.461+00:00",
+        "modified": "2019-06-11T14:17:42.461+0000",
         "name": "Protein Affinity Reagents",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PAR:\\d+$",
@@ -41444,7 +41668,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:52.227+00:00",
+        "created": "2019-06-11T14:15:52.227+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41453,7 +41677,7 @@
         "id": 247,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000072",
-        "modified": "2019-06-11T14:15:52.227+00:00",
+        "modified": "2019-06-11T14:15:52.227+0000",
         "name": "PubChem-bioassay",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41500,7 +41724,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:41.493+00:00",
+        "created": "2019-06-11T14:15:41.493+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41509,7 +41733,7 @@
         "id": 138,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000034",
-        "modified": "2019-06-11T14:15:41.493+00:00",
+        "modified": "2019-06-11T14:15:41.493+0000",
         "name": "PubChem-compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41591,7 +41815,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:41.269+00:00",
+        "created": "2019-06-11T14:15:41.269+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41600,7 +41824,7 @@
         "id": 136,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000033",
-        "modified": "2019-06-11T14:15:41.269+00:00",
+        "modified": "2019-06-11T14:15:41.269+0000",
         "name": "PubChem-substance",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41647,7 +41871,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:33.142+00:00",
+        "created": "2019-06-11T14:15:33.142+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41656,7 +41880,7 @@
         "id": 57,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000015",
-        "modified": "2019-06-11T14:15:33.142+00:00",
+        "modified": "2019-06-11T14:15:33.142+0000",
         "name": "PubMed",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -41843,7 +42067,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:35.052+00:00",
+        "created": "2019-06-11T14:16:35.052+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41852,7 +42076,7 @@
         "id": 715,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000242",
-        "modified": "2019-06-11T14:16:35.052+00:00",
+        "modified": "2019-06-11T14:16:35.052+0000",
         "name": "Pathway Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^PW:\\d{7}$",
@@ -41969,7 +42193,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:37.549+00:00",
+        "created": "2019-06-11T14:17:37.549+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -41978,7 +42202,7 @@
         "id": 1447,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000513",
-        "modified": "2019-06-11T14:17:37.549+00:00",
+        "modified": "2019-06-11T14:17:37.549+0000",
         "name": "ProteomeXchange",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(R)?PXD\\d{6}$",
@@ -42025,7 +42249,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-05T17:54:24.640+00:00",
+        "created": "2021-09-05T17:54:24.640+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42034,7 +42258,7 @@
         "id": 2852,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000863",
-        "modified": "2021-09-05T17:54:24.640+00:00",
+        "modified": "2021-09-05T17:54:24.640+0000",
         "name": "PyPI",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-zA-Z_][a-zA-Z0-9\\-_]+$",
@@ -42081,7 +42305,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-26T10:27:01.032+00:00",
+        "created": "2021-02-26T10:27:01.032+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42090,7 +42314,7 @@
         "id": 2559,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000798",
-        "modified": "2021-02-26T10:27:01.032+00:00",
+        "modified": "2021-02-26T10:27:01.032+0000",
         "name": "Animal Genome QTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -42137,7 +42361,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-24T06:41:41.433+00:00",
+        "created": "2020-03-24T06:41:41.433+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42146,7 +42370,7 @@
         "id": 2187,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000702",
-        "modified": "2020-03-24T06:41:41.433+00:00",
+        "modified": "2020-03-24T06:41:41.433+0000",
         "name": "RAP-DB Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Os\\S+g\\d{7}$",
@@ -42193,7 +42417,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-24T06:40:28.546+00:00",
+        "created": "2020-03-24T06:40:28.546+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42202,7 +42426,7 @@
         "id": 2184,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000762",
-        "modified": "2020-03-24T06:40:28.546+00:00",
+        "modified": "2020-03-24T06:40:28.546+0000",
         "name": "RAP-DB Transcript",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Os\\S+t\\d{7}-\\d{2}$",
@@ -42249,7 +42473,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:13.721+00:00",
+        "created": "2019-06-11T14:18:13.721+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42258,7 +42482,7 @@
         "id": 1828,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000659",
-        "modified": "2019-06-11T14:18:13.721+00:00",
+        "modified": "2019-06-11T14:18:13.721+0000",
         "name": "Rebuilding a Kidney",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[-0-9a-zA-Z]+(@[-0-9a-zA-Z]+)?$",
@@ -42305,7 +42529,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-05T17:53:47.458+00:00",
+        "created": "2021-09-05T17:53:47.458+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42314,7 +42538,7 @@
         "id": 2848,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000861",
-        "modified": "2021-09-05T17:53:47.458+00:00",
+        "modified": "2021-09-05T17:53:47.458+0000",
         "name": "re3data",
         "namespaceEmbeddedInLui": false,
         "pattern": "^r3d\\d{9,9}$",
@@ -42361,7 +42585,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:34.555+00:00",
+        "created": "2019-06-11T14:15:34.555+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42370,7 +42594,7 @@
         "id": 72,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000018",
-        "modified": "2019-06-11T14:15:34.555+00:00",
+        "modified": "2019-06-11T14:15:34.555+0000",
         "name": "Reactome",
         "namespaceEmbeddedInLui": false,
         "pattern": "(^R-[A-Z]{3}-\\d+(-\\d+)?(\\.\\d+)?$)|(^REACT_\\d+(\\.\\d+)?$)",
@@ -42417,7 +42641,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:32.004+00:00",
+        "created": "2019-06-11T14:16:32.004+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42426,7 +42650,7 @@
         "id": 681,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000230",
-        "modified": "2019-06-11T14:16:32.004+00:00",
+        "modified": "2019-06-11T14:16:32.004+0000",
         "name": "REBASE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -42473,7 +42697,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:43.085+00:00",
+        "created": "2019-06-11T14:15:43.085+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42482,7 +42706,7 @@
         "id": 153,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000039",
-        "modified": "2023-01-04T19:52:50.191+00:00",
+        "modified": "2023-01-04T19:52:50.191+0000",
         "name": "RefSeq",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(((WP|AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\\d+)|(NZ\\_[A-Z]{2,4}\\d+))(\\.\\d+)?$",
@@ -42529,7 +42753,7 @@
         "successor": null
       },
       {
-        "created": "2023-10-30T09:39:26.272+00:00",
+        "created": "2023-10-30T09:39:26.272+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42538,7 +42762,7 @@
         "id": 3719,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001030",
-        "modified": "2023-10-30T10:34:56.198+00:00",
+        "modified": "2023-10-30T10:34:56.198+0000",
         "name": "Genome assembly database - RefSeq accessions",
         "namespaceEmbeddedInLui": false,
         "pattern": "^GCF_[0-9]{9}(\\.[0-9]+)?$",
@@ -42585,7 +42809,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-17T18:11:07.592+00:00",
+        "created": "2021-02-17T18:11:07.592+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42594,7 +42818,7 @@
         "id": 2532,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000792",
-        "modified": "2021-02-17T18:11:07.592+00:00",
+        "modified": "2021-02-17T18:11:07.592+0000",
         "name": "RepeatsDB Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[OPQopq][0-9][A-Za-z0-9]{3}[0-9]|[A-Na-nR-Zr-z][0-9]([A-Za-z][A-Za-z0-9]{2}[0-9]){1,2}$",
@@ -42641,7 +42865,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-17T18:09:04.420+00:00",
+        "created": "2021-02-17T18:09:04.420+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42650,7 +42874,7 @@
         "id": 2527,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000764",
-        "modified": "2021-02-17T18:09:04.420+00:00",
+        "modified": "2021-02-17T18:09:04.420+0000",
         "name": "RepeatsDB Structure",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9][A-Za-z0-9]{3}[A-Za-z0-9][A-Za-z0-9]?[0-9]?[0-9]?$",
@@ -42697,7 +42921,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:44.821+00:00",
+        "created": "2019-06-11T14:15:44.821+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42706,7 +42930,7 @@
         "id": 172,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000046",
-        "modified": "2019-06-11T14:15:44.821+00:00",
+        "modified": "2019-06-11T14:15:44.821+0000",
         "name": "RESID",
         "namespaceEmbeddedInLui": false,
         "pattern": "^AA\\d{4}$",
@@ -42753,7 +42977,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:14.331+00:00",
+        "created": "2019-06-11T14:17:14.331+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42762,7 +42986,7 @@
         "id": 1187,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000409",
-        "modified": "2019-06-11T14:17:14.331+00:00",
+        "modified": "2019-06-11T14:17:14.331+0000",
         "name": "RFAM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^RF\\d{5}$",
@@ -42809,7 +43033,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:45.062+00:00",
+        "created": "2019-06-11T14:15:45.062+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42818,7 +43042,7 @@
         "id": 175,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000047",
-        "modified": "2019-06-11T14:15:45.062+00:00",
+        "modified": "2019-06-11T14:15:45.062+0000",
         "name": "Rat Genome Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{4,}$",
@@ -42900,7 +43124,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:23.659+00:00",
+        "created": "2019-06-11T14:17:23.659+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42909,7 +43133,7 @@
         "id": 1294,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000451",
-        "modified": "2019-06-11T14:17:23.659+00:00",
+        "modified": "2019-06-11T14:17:23.659+0000",
         "name": "Rat Genome Database qTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -42956,7 +43180,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:23.876+00:00",
+        "created": "2019-06-11T14:17:23.876+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -42965,7 +43189,7 @@
         "id": 1297,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000452",
-        "modified": "2019-06-11T14:17:23.876+00:00",
+        "modified": "2019-06-11T14:17:23.876+0000",
         "name": "Rat Genome Database strain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -43012,7 +43236,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:55.126+00:00",
+        "created": "2019-06-11T14:15:55.126+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43021,7 +43245,7 @@
         "id": 278,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000082",
-        "modified": "2021-05-30T10:38:10.762+00:00",
+        "modified": "2021-05-30T10:38:10.762+0000",
         "name": "Rhea",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{5}$",
@@ -43032,7 +43256,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2021-05-30T10:47:40.110+00:00",
+            "deprecationDate": "2021-05-30T10:47:40.110+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "Rhea",
@@ -43103,7 +43327,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:01.041+00:00",
+        "created": "2019-06-11T14:17:01.041+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43112,7 +43336,7 @@
         "id": 1028,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000358",
-        "modified": "2019-06-11T14:17:01.041+00:00",
+        "modified": "2019-06-11T14:17:01.041+0000",
         "name": "Rice Genome Annotation Project",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LOC\\_Os\\d{1,2}g\\d{5}$",
@@ -43159,7 +43383,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:15.639+00:00",
+        "created": "2019-06-11T14:18:15.639+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43168,7 +43392,7 @@
         "id": 1847,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000666",
-        "modified": "2019-06-11T14:18:15.639+00:00",
+        "modified": "2019-06-11T14:18:15.639+0000",
         "name": "RiceNetDB Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^OSC\\d{4}$",
@@ -43215,7 +43439,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:15.139+00:00",
+        "created": "2019-06-11T14:18:15.139+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43224,7 +43448,7 @@
         "id": 1842,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000664",
-        "modified": "2019-06-11T14:18:15.139+00:00",
+        "modified": "2019-06-11T14:18:15.139+0000",
         "name": "RiceNetDB Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LOC\\_Os\\d{1,2}g\\d{5}\\.\\d$",
@@ -43271,7 +43495,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:16.076+00:00",
+        "created": "2019-06-11T14:18:16.076+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43280,7 +43504,7 @@
         "id": 1851,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000668",
-        "modified": "2019-06-11T14:18:16.076+00:00",
+        "modified": "2019-06-11T14:18:16.076+0000",
         "name": "RiceNetDB miRNA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^osa-miR\\d{3,5}[a-z]{0,1}$",
@@ -43327,7 +43551,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:15.429+00:00",
+        "created": "2019-06-11T14:18:15.429+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43336,7 +43560,7 @@
         "id": 1845,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000665",
-        "modified": "2019-06-11T14:18:15.429+00:00",
+        "modified": "2019-06-11T14:18:15.429+0000",
         "name": "RiceNetDB Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^LOC\\_Os\\d{1,2}g\\d{5}$",
@@ -43383,7 +43607,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:15.856+00:00",
+        "created": "2019-06-11T14:18:15.856+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43392,7 +43616,7 @@
         "id": 1849,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000667",
-        "modified": "2019-06-11T14:18:15.856+00:00",
+        "modified": "2019-06-11T14:18:15.856+0000",
         "name": "RiceNetDB Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^OSR\\d{4}$",
@@ -43439,7 +43663,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-29T10:51:36.384+00:00",
+        "created": "2022-01-29T10:51:36.384+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43448,7 +43672,7 @@
         "id": 3047,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000911",
-        "modified": "2022-01-31T08:57:14.676+00:00",
+        "modified": "2022-01-31T08:57:14.676+0000",
         "name": "RISM Online",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z]+/[0-9]+$",
@@ -43495,7 +43719,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:06.653+00:00",
+        "created": "2019-06-11T14:18:06.653+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43504,7 +43728,7 @@
         "id": 1750,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000630",
-        "modified": "2019-06-11T14:18:06.653+00:00",
+        "modified": "2019-06-11T14:18:06.653+0000",
         "name": "RNAcentral",
         "namespaceEmbeddedInLui": false,
         "pattern": "^URS[0-9A-F]{10}(\\_\\d+)?$",
@@ -43551,7 +43775,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:50.326+00:00",
+        "created": "2019-06-11T14:16:50.326+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43560,7 +43784,7 @@
         "id": 900,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000308",
-        "modified": "2019-06-11T14:16:50.326+00:00",
+        "modified": "2019-06-11T14:16:50.326+0000",
         "name": "RNA Modification Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{3}$",
@@ -43607,7 +43831,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:04.654+00:00",
+        "created": "2019-06-11T14:16:04.654+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43616,7 +43840,7 @@
         "id": 380,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000120",
-        "modified": "2019-06-11T14:16:04.654+00:00",
+        "modified": "2019-06-11T14:16:04.654+0000",
         "name": "Relation Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^RO_\\d{7}$",
@@ -43698,7 +43922,7 @@
         "successor": null
       },
       {
-        "created": "2022-08-15T19:28:35.707+00:00",
+        "created": "2022-08-15T19:28:35.707+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43707,7 +43931,7 @@
         "id": 3271,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000961",
-        "modified": "2022-08-18T13:14:34.725+00:00",
+        "modified": "2022-08-18T13:14:34.725+0000",
         "name": "ROR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$",
@@ -43754,7 +43978,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:46.721+00:00",
+        "created": "2019-06-11T14:16:46.721+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43763,7 +43987,7 @@
         "id": 858,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000293",
-        "modified": "2019-06-11T14:16:46.721+00:00",
+        "modified": "2019-06-11T14:16:46.721+0000",
         "name": "Rouge",
         "namespaceEmbeddedInLui": false,
         "pattern": "^m\\w+$",
@@ -43810,7 +44034,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:48.275+00:00",
+        "created": "2019-06-11T14:17:48.275+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43819,7 +44043,7 @@
         "id": 1559,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000558",
-        "modified": "2020-03-11T14:52:15.242+00:00",
+        "modified": "2020-03-11T14:52:15.242+0000",
         "name": "RRID",
         "namespaceEmbeddedInLui": true,
         "pattern": "^RRID:[a-zA-Z]+.+$",
@@ -43866,7 +44090,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-28T15:53:07.380+00:00",
+        "created": "2021-02-28T15:53:07.380+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43875,7 +44099,7 @@
         "id": 2565,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000897",
-        "modified": "2021-02-28T15:53:07.380+00:00",
+        "modified": "2021-02-28T15:53:07.380+0000",
         "name": "runBioSimulations",
         "namespaceEmbeddedInLui": false,
         "pattern": "[0-9a-z]{24,24}",
@@ -43922,7 +44146,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:21.119+00:00",
+        "created": "2019-06-11T14:18:21.119+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43931,7 +44155,7 @@
         "id": 1907,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000688",
-        "modified": "2019-06-11T14:18:21.119+00:00",
+        "modified": "2019-06-11T14:18:21.119+0000",
         "name": "SABIO-RK Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -43978,7 +44202,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:07.366+00:00",
+        "created": "2019-06-11T14:16:07.366+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -43987,7 +44211,7 @@
         "id": 407,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000128",
-        "modified": "2019-06-11T14:16:07.366+00:00",
+        "modified": "2019-06-11T14:16:07.366+0000",
         "name": "SABIO-RK EC Record",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((\\d+)|(\\d+\\.\\d+)|(\\d+\\.\\d+\\.\\d+)|(\\d+\\.\\d+\\.\\d+\\.\\d+))$",
@@ -44034,7 +44258,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:56.334+00:00",
+        "created": "2019-06-11T14:15:56.334+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44043,7 +44267,7 @@
         "id": 290,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000086",
-        "modified": "2019-06-11T14:15:56.334+00:00",
+        "modified": "2019-06-11T14:15:56.334+0000",
         "name": "SABIO-RK Kinetic Record",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -44090,7 +44314,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:42.838+00:00",
+        "created": "2019-06-11T14:15:42.838+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44099,7 +44323,7 @@
         "id": 150,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000038",
-        "modified": "2019-06-11T14:15:42.838+00:00",
+        "modified": "2019-06-11T14:15:42.838+0000",
         "name": "SABIO-RK Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -44146,7 +44370,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:51.650+00:00",
+        "created": "2019-06-11T14:17:51.650+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44155,7 +44379,7 @@
         "id": 1593,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000572",
-        "modified": "2019-06-11T14:17:51.650+00:00",
+        "modified": "2019-06-11T14:17:51.650+0000",
         "name": "SASBDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[Ss][Aa][Ss][A-Za-z0-9]{3}[0-9]$",
@@ -44202,7 +44426,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:37.756+00:00",
+        "created": "2019-06-11T14:15:37.756+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44211,7 +44435,7 @@
         "id": 105,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000024",
-        "modified": "2019-06-11T14:15:37.756+00:00",
+        "modified": "2019-06-11T14:15:37.756+0000",
         "name": "Systems Biology Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^SBO:\\d{7}$",
@@ -44257,7 +44481,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2022-11-10T10:15:12.911+00:00",
+            "deprecationDate": "2022-11-10T10:15:12.911+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "SBO",
@@ -44328,7 +44552,7 @@
         "successor": null
       },
       {
-        "created": "2022-11-29T12:03:56.649+00:00",
+        "created": "2022-11-29T12:03:56.649+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44337,7 +44561,7 @@
         "id": 3355,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000973",
-        "modified": "2022-11-29T12:03:56.649+00:00",
+        "modified": "2022-11-29T12:03:56.649+0000",
         "name": "Sciflection",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -44384,7 +44608,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:03.870+00:00",
+        "created": "2019-06-11T14:17:03.870+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44393,7 +44617,7 @@
         "id": 1063,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000371",
-        "modified": "2019-06-11T14:17:03.870+00:00",
+        "modified": "2019-06-11T14:17:03.870+0000",
         "name": "SCOP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -44475,7 +44699,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:35.987+00:00",
+        "created": "2019-06-11T14:16:35.987+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44484,7 +44708,7 @@
         "id": 725,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000244",
-        "modified": "2019-06-11T14:16:35.987+00:00",
+        "modified": "2019-06-11T14:16:35.987+0000",
         "name": "ScerTF",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -44531,7 +44755,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:51.940+00:00",
+        "created": "2019-06-11T14:16:51.940+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44540,7 +44764,7 @@
         "id": 920,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000319",
-        "modified": "2019-06-11T14:16:51.940+00:00",
+        "modified": "2019-06-11T14:16:51.940+0000",
         "name": "Spectral Database for Organic Compounds",
         "namespaceEmbeddedInLui": false,
         "pattern": "\\d+$",
@@ -44587,7 +44811,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:33:59.109+00:00",
+        "created": "2021-08-08T09:33:59.109+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44596,7 +44820,7 @@
         "id": 2789,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000841",
-        "modified": "2021-08-08T09:33:59.109+00:00",
+        "modified": "2021-08-08T09:33:59.109+0000",
         "name": "SED-ML data format",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z]+(\\..*?)?$",
@@ -44643,7 +44867,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:34:23.184+00:00",
+        "created": "2021-08-08T09:34:23.184+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44652,7 +44876,7 @@
         "id": 2792,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000843",
-        "modified": "2021-08-08T09:34:23.184+00:00",
+        "modified": "2021-08-08T09:34:23.184+0000",
         "name": "SED-ML model format",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z]+(\\..*?)?$",
@@ -44699,7 +44923,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:46.875+00:00",
+        "created": "2019-06-11T14:17:46.875+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44708,7 +44932,7 @@
         "id": 1545,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000552",
-        "modified": "2019-06-11T14:17:46.875+00:00",
+        "modified": "2019-06-11T14:17:46.875+0000",
         "name": "SEED Subsystem",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -44719,7 +44943,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2019-10-08T08:49:23.021+00:00",
+            "deprecationDate": "2019-10-08T08:49:23.021+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "SEED Subsystem at Argonne National Laboratory",
@@ -44755,7 +44979,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:47.133+00:00",
+        "created": "2019-06-11T14:17:47.133+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44764,7 +44988,7 @@
         "id": 1548,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000553",
-        "modified": "2019-06-11T14:17:47.133+00:00",
+        "modified": "2019-06-11T14:17:47.133+0000",
         "name": "SEED Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^cpd\\d+$",
@@ -44811,7 +45035,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:21.981+00:00",
+        "created": "2019-06-11T14:18:21.981+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44820,7 +45044,7 @@
         "id": 1916,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000692",
-        "modified": "2019-06-11T14:18:21.981+00:00",
+        "modified": "2019-06-11T14:18:21.981+0000",
         "name": "SEED Reactions",
         "namespaceEmbeddedInLui": false,
         "pattern": "^rxn\\d+$",
@@ -44867,7 +45091,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:37.056+00:00",
+        "created": "2019-06-11T14:15:37.056+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -44876,7 +45100,7 @@
         "id": 97,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000023",
-        "modified": "2019-06-11T14:15:37.056+00:00",
+        "modified": "2019-06-11T14:15:37.056+0000",
         "name": "SGD",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((S\\d+$)|(Y[A-Z]{2}\\d{3}[a-zA-Z](\\-[A-Z])?))$",
@@ -45028,7 +45252,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:48.132+00:00",
+        "created": "2019-06-11T14:15:48.132+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45037,7 +45261,7 @@
         "id": 203,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000057",
-        "modified": "2019-06-11T14:15:48.132+00:00",
+        "modified": "2019-06-11T14:15:48.132+0000",
         "name": "Saccharomyces genome database pathways",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PWY\\w{2}\\-\\d{3}$",
@@ -45084,7 +45308,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:21.425+00:00",
+        "created": "2019-06-11T14:16:21.425+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45093,7 +45317,7 @@
         "id": 564,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000185",
-        "modified": "2019-06-11T14:16:21.425+00:00",
+        "modified": "2019-06-11T14:16:21.425+0000",
         "name": "Sol Genomics Network",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -45140,7 +45364,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:36.183+00:00",
+        "created": "2019-06-11T14:17:36.183+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45149,7 +45373,7 @@
         "id": 1435,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000507",
-        "modified": "2019-06-11T14:17:36.183+00:00",
+        "modified": "2019-06-11T14:17:36.183+0000",
         "name": "Animal Genome Sheep QTL",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -45196,7 +45420,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:19.846+00:00",
+        "created": "2019-06-11T14:17:19.846+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45205,7 +45429,7 @@
         "id": 1250,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000435",
-        "modified": "2019-06-11T14:17:19.846+00:00",
+        "modified": "2019-06-11T14:17:19.846+0000",
         "name": "SIDER Drug",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -45252,7 +45476,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:20.079+00:00",
+        "created": "2019-06-11T14:17:20.079+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45261,7 +45485,7 @@
         "id": 1253,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000436",
-        "modified": "2019-06-11T14:17:20.079+00:00",
+        "modified": "2019-06-11T14:17:20.079+0000",
         "name": "SIDER Side Effect",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C\\d+$",
@@ -45308,7 +45532,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:44.579+00:00",
+        "created": "2019-06-11T14:15:44.579+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45317,7 +45541,7 @@
         "id": 169,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000045",
-        "modified": "2019-06-11T14:15:44.579+00:00",
+        "modified": "2019-06-11T14:15:44.579+0000",
         "name": "Signaling Gateway",
         "namespaceEmbeddedInLui": false,
         "pattern": "A\\d{6}$",
@@ -45364,7 +45588,7 @@
         "successor": null
       },
       {
-        "created": "2021-04-12T18:19:18.033+00:00",
+        "created": "2021-04-12T18:19:18.033+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45373,7 +45597,7 @@
         "id": 2605,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000808",
-        "modified": "2021-04-12T18:19:18.033+00:00",
+        "modified": "2021-04-12T18:19:18.033+0000",
         "name": "SIGNOR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SIGNOR\\-[A-Z]+\\d+$",
@@ -45420,7 +45644,7 @@
         "successor": null
       },
       {
-        "created": "2021-08-08T09:47:01.408+00:00",
+        "created": "2021-08-08T09:47:01.408+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45429,7 +45653,7 @@
         "id": 2807,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000851",
-        "modified": "2021-08-08T09:47:01.408+00:00",
+        "modified": "2021-08-08T09:47:01.408+0000",
         "name": "Semanticscience Integrated Ontology",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SIO_\\d{6,6}$",
@@ -45476,7 +45700,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:05.215+00:00",
+        "created": "2019-06-11T14:18:05.215+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45485,7 +45709,7 @@
         "id": 1732,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000624",
-        "modified": "2019-06-11T14:18:05.215+00:00",
+        "modified": "2019-06-11T14:18:05.215+0000",
         "name": "SISu",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+:[0-9]+$",
@@ -45532,7 +45756,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:37.867+00:00",
+        "created": "2019-06-11T14:16:37.867+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45541,7 +45765,7 @@
         "id": 748,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000252",
-        "modified": "2019-06-11T14:16:37.867+00:00",
+        "modified": "2019-06-11T14:16:37.867+0000",
         "name": "SitEx",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -45588,7 +45812,7 @@
         "successor": null
       },
       {
-        "created": "2022-11-04T12:17:30.200+00:00",
+        "created": "2022-11-04T12:17:30.200+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45597,7 +45821,7 @@
         "id": 3307,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000968",
-        "modified": "2022-11-04T12:17:30.200+00:00",
+        "modified": "2022-11-04T12:17:30.200+0000",
         "name": "Stress Knowledge Map",
         "namespaceEmbeddedInLui": false,
         "pattern": "^rx[0-9]{5}$",
@@ -45644,7 +45868,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:46.314+00:00",
+        "created": "2019-06-11T14:17:46.314+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45653,7 +45877,7 @@
         "id": 1539,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000550",
-        "modified": "2020-05-01T09:59:44.482+00:00",
+        "modified": "2020-05-01T09:59:44.482+0000",
         "name": "SwissLipids",
         "namespaceEmbeddedInLui": true,
         "pattern": "^SLM:\\d+$",
@@ -45700,7 +45924,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:04.151+00:00",
+        "created": "2019-06-11T14:16:04.151+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45709,7 +45933,7 @@
         "id": 374,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000118",
-        "modified": "2019-06-11T14:16:04.151+00:00",
+        "modified": "2019-06-11T14:16:04.151+0000",
         "name": "SMART",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SM\\d{5}$",
@@ -45756,7 +45980,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:00.499+00:00",
+        "created": "2019-06-11T14:16:00.499+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45765,7 +45989,7 @@
         "id": 336,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000104",
-        "modified": "2019-06-11T14:16:00.499+00:00",
+        "modified": "2019-06-11T14:16:00.499+0000",
         "name": "Small Molecule Pathway Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^SMP\\d+$",
@@ -45812,7 +46036,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:41.184+00:00",
+        "created": "2019-06-11T14:16:41.184+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45821,7 +46045,7 @@
         "id": 788,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000269",
-        "modified": "2019-06-11T14:16:41.184+00:00",
+        "modified": "2019-06-11T14:16:41.184+0000",
         "name": "SNOMED CT",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(\\w+)?\\d+$",
@@ -45868,7 +46092,7 @@
         "successor": null
       },
       {
-        "created": "2020-03-20T12:58:53.045+00:00",
+        "created": "2020-03-20T12:58:53.045+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45877,7 +46101,7 @@
         "id": 2152,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000766",
-        "modified": "2020-03-20T12:58:53.045+00:00",
+        "modified": "2020-03-20T12:58:53.045+0000",
         "name": "SNP2TFBS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^rs[0-9]+$",
@@ -45924,7 +46148,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:54.604+00:00",
+        "created": "2019-06-11T14:15:54.604+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -45933,7 +46157,7 @@
         "id": 273,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000081",
-        "modified": "2019-06-11T14:15:54.604+00:00",
+        "modified": "2019-06-11T14:15:54.604+0000",
         "name": "Sequence Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^SO:\\d{7}$",
@@ -46050,7 +46274,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:46.310+00:00",
+        "created": "2019-06-11T14:16:46.310+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46059,7 +46283,7 @@
         "id": 853,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000291",
-        "modified": "2019-06-11T14:16:46.310+00:00",
+        "modified": "2019-06-11T14:16:46.310+0000",
         "name": "SoyBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\-)?\\w+(\\-)?\\w+$",
@@ -46106,7 +46330,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:20.855+00:00",
+        "created": "2019-06-11T14:18:20.855+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46115,7 +46339,7 @@
         "id": 1904,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000687",
-        "modified": "2019-06-11T14:18:20.855+00:00",
+        "modified": "2019-06-11T14:18:20.855+0000",
         "name": "SPDX License List",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9A-Za-z\\-.]+$",
@@ -46162,7 +46386,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:52.396+00:00",
+        "created": "2019-06-11T14:16:52.396+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46171,7 +46395,7 @@
         "id": 926,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000321",
-        "modified": "2019-06-11T14:16:52.396+00:00",
+        "modified": "2019-06-11T14:16:52.396+0000",
         "name": "SPIKE Map",
         "namespaceEmbeddedInLui": false,
         "pattern": "^spike\\d{5}$",
@@ -46218,7 +46442,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:50.083+00:00",
+        "created": "2019-06-11T14:17:50.083+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46227,7 +46451,7 @@
         "id": 1577,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000566",
-        "modified": "2019-06-11T14:17:50.083+00:00",
+        "modified": "2019-06-11T14:17:50.083+0000",
         "name": "SPLASH",
         "namespaceEmbeddedInLui": false,
         "pattern": "^splash\\d[A-Z-a-z0-9]-[A-Za-z0-9]+-[A-Za-z0-9]+$",
@@ -46274,7 +46498,7 @@
         "successor": null
       },
       {
-        "created": "2019-11-07T10:59:42.032+00:00",
+        "created": "2019-11-07T10:59:42.032+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46283,7 +46507,7 @@
         "id": 2037,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000726",
-        "modified": "2019-11-07T10:59:42.032+00:00",
+        "modified": "2019-11-07T10:59:42.032+0000",
         "name": "Signaling Pathways Project",
         "namespaceEmbeddedInLui": false,
         "pattern": "^10.\\w{4}/\\w{10}$",
@@ -46330,7 +46554,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:11.871+00:00",
+        "created": "2019-06-11T14:17:11.871+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46339,7 +46563,7 @@
         "id": 1158,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000399",
-        "modified": "2019-06-11T14:17:11.871+00:00",
+        "modified": "2019-06-11T14:17:11.871+0000",
         "name": "STAP",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9][A-Za-z0-9]{3}$",
@@ -46386,7 +46610,63 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:40.524+00:00",
+        "created": "2024-03-20T11:10:30.918+0000",
+        "deprecated": false,
+        "deprecationDate": null,
+        "deprecationOfflineDate": null,
+        "deprecationStatement": null,
+        "description": "STATO is the statistical methods ontology. It contains concepts and properties related to statistical methods, probability distributions and other concepts related to statistical analysis, including relationships to study designs and plots.",
+        "id": 3842,
+        "infoOnPostmortemAccess": null,
+        "mirId": "MIR:00001051",
+        "modified": "2024-03-20T11:10:30.918+0000",
+        "name": "Statistical Ontology",
+        "namespaceEmbeddedInLui": true,
+        "pattern": "^STATO:\\d+$",
+        "prefix": "stato",
+        "renderDeprecatedLanding": false,
+        "resources": [
+          {
+            "authHelpDescription": null,
+            "authHelpUrl": null,
+            "deprecated": false,
+            "deprecationDate": null,
+            "deprecationOfflineDate": null,
+            "deprecationStatement": null,
+            "description": "At EMBL-EBI, we make the world’s public biological data freely available to the scientific community via a range of services and tools, perform basic research and provide professional training in bioinformatics. \nWe are part of the European Molecular Biology Laboratory (EMBL), an international, innovative and interdisciplinary research organisation funded by 26 member states and two associate member states.",
+            "id": 3843,
+            "institution": {
+              "description": "At EMBL-EBI, we make the world’s public biological data freely available to the scientific community via a range of services and tools, perform basic research and provide professional training in bioinformatics. \nWe are part of the European Molecular Biology Laboratory (EMBL), an international, innovative and interdisciplinary research organisation funded by 26 member states and two associate member states.",
+              "homeUrl": "https://www.ebi.ac.uk",
+              "id": 2,
+              "location": {
+                "countryCode": "GB",
+                "countryName": "United Kingdom"
+              },
+              "name": "European Bioinformatics Institute",
+              "rorId": "https://ror.org/02catss52"
+            },
+            "location": {
+              "countryCode": "GB",
+              "countryName": "United Kingdom"
+            },
+            "mirId": "MIR:00001050",
+            "name": "European Bioinformatics Institute",
+            "official": true,
+            "protectedUrls": false,
+            "providerCode": "ols",
+            "renderDeprecatedLanding": false,
+            "renderProtectedLanding": false,
+            "resourceHomeUrl": "https://www.ebi.ac.uk",
+            "sampleId": "0000138",
+            "urlPattern": "https://www.ebi.ac.uk/ols4/ontologies/stato/classes?obo_id=STATO:{$id}"
+          }
+        ],
+        "sampleId": "0000138",
+        "successor": null
+      },
+      {
+        "created": "2019-06-11T14:16:40.524+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46395,7 +46675,7 @@
         "id": 781,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000266",
-        "modified": "2019-06-11T14:16:40.524+00:00",
+        "modified": "2019-06-11T14:16:40.524+0000",
         "name": "STITCH",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{14}$",
@@ -46442,7 +46722,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:53.021+00:00",
+        "created": "2019-06-11T14:17:53.021+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46451,7 +46731,7 @@
         "id": 1606,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000577",
-        "modified": "2019-06-11T14:17:53.021+00:00",
+        "modified": "2019-06-11T14:17:53.021+0000",
         "name": "STOREDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^STOREDB:(STUDY|FILE|DATASET)\\d+$",
@@ -46498,7 +46778,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:40.213+00:00",
+        "created": "2019-06-11T14:16:40.213+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46507,7 +46787,7 @@
         "id": 778,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000265",
-        "modified": "2019-06-11T14:16:40.213+00:00",
+        "modified": "2019-06-11T14:16:40.213+0000",
         "name": "STRING",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])|([0-9][A-Za-z0-9]{3})$",
@@ -46589,7 +46869,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:19.310+00:00",
+        "created": "2019-06-11T14:17:19.310+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46598,7 +46878,7 @@
         "id": 1244,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000433",
-        "modified": "2019-06-11T14:17:19.310+00:00",
+        "modified": "2019-06-11T14:17:19.310+0000",
         "name": "SubtiList",
         "namespaceEmbeddedInLui": false,
         "pattern": "^BG\\d+$",
@@ -46645,7 +46925,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:08.635+00:00",
+        "created": "2019-06-11T14:16:08.635+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46654,7 +46934,7 @@
         "id": 421,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000132",
-        "modified": "2019-06-11T14:16:08.635+00:00",
+        "modified": "2019-06-11T14:16:08.635+0000",
         "name": "SubtiWiki",
         "namespaceEmbeddedInLui": false,
         "pattern": "^BSU\\d{5}$",
@@ -46701,7 +46981,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:06.412+00:00",
+        "created": "2019-06-11T14:18:06.412+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46710,7 +46990,7 @@
         "id": 1747,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000629",
-        "modified": "2019-06-11T14:18:06.412+00:00",
+        "modified": "2019-06-11T14:18:06.412+0000",
         "name": "SugarBind",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z]+\\/[0-9]+$",
@@ -46757,7 +47037,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:00.815+00:00",
+        "created": "2019-06-11T14:17:00.815+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46766,7 +47046,7 @@
         "id": 1025,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000357",
-        "modified": "2019-06-11T14:17:00.815+00:00",
+        "modified": "2019-06-11T14:17:00.815+0000",
         "name": "SUPFAM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -46813,7 +47093,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:12.760+00:00",
+        "created": "2019-06-11T14:18:12.760+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46822,7 +47102,7 @@
         "id": 1817,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000655",
-        "modified": "2020-11-27T10:57:55.228+00:00",
+        "modified": "2020-11-27T10:57:55.228+0000",
         "name": "Software Heritage",
         "namespaceEmbeddedInLui": true,
         "pattern": "^swh:[1-9]:(cnt|dir|rel|rev|snp):[0-9a-f]+(;(origin|visit|anchor|path|lines)=\\S+)*$",
@@ -46869,7 +47149,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:32.267+00:00",
+        "created": "2019-06-11T14:16:32.267+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46878,7 +47158,7 @@
         "id": 684,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000231",
-        "modified": "2019-06-11T14:16:32.267+00:00",
+        "modified": "2019-06-11T14:16:32.267+0000",
         "name": "SWISS-MODEL Repository",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -46925,7 +47205,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:07.113+00:00",
+        "created": "2019-06-11T14:18:07.113+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46934,7 +47214,7 @@
         "id": 1755,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000632",
-        "modified": "2019-06-11T14:18:07.113+00:00",
+        "modified": "2019-06-11T14:18:07.113+0000",
         "name": "SwissRegulon",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9]+$",
@@ -46981,7 +47261,63 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:00.251+00:00",
+        "created": "2024-03-20T10:13:27.272+0000",
+        "deprecated": false,
+        "deprecationDate": null,
+        "deprecationOfflineDate": null,
+        "deprecationStatement": null,
+        "description": "Synapse is a collaborative, open-source research platform that allows teams to share data, track analyses, and collaborate.",
+        "id": 3808,
+        "infoOnPostmortemAccess": null,
+        "mirId": "MIR:00001043",
+        "modified": "2024-03-20T10:13:27.272+0000",
+        "name": "Synapse Data Repository",
+        "namespaceEmbeddedInLui": false,
+        "pattern": "[0-9]*\\.*[0-9]*",
+        "prefix": "synapse",
+        "renderDeprecatedLanding": false,
+        "resources": [
+          {
+            "authHelpDescription": null,
+            "authHelpUrl": null,
+            "deprecated": false,
+            "deprecationDate": null,
+            "deprecationOfflineDate": null,
+            "deprecationStatement": null,
+            "description": "Sage Bionetworks is a trusted leader in data sharing and reuse, enabling a rapid acceleration in biomedical discoveries and the transformation of medicine.",
+            "id": 3809,
+            "institution": {
+              "description": "Sage Bionetworks is a trusted leader in data sharing and reuse, enabling a rapid acceleration in biomedical discoveries and the transformation of medicine.",
+              "homeUrl": "https://www.sagebionetworks.org",
+              "id": 3807,
+              "location": {
+                "countryCode": "US",
+                "countryName": "United States"
+              },
+              "name": "Sage Bionetworks",
+              "rorId": null
+            },
+            "location": {
+              "countryCode": "US",
+              "countryName": "United States"
+            },
+            "mirId": "MIR:00001042",
+            "name": "Sage Bionetworks",
+            "official": true,
+            "protectedUrls": false,
+            "providerCode": "synapse",
+            "renderDeprecatedLanding": false,
+            "renderProtectedLanding": false,
+            "resourceHomeUrl": "https://sagebionetworks.org",
+            "sampleId": "41455251.1",
+            "urlPattern": "https://repo-prod.prod.sagebase.org/ga4gh/drs/v1/objects/syn{$id}"
+          }
+        ],
+        "sampleId": "41455251.1",
+        "successor": null
+      },
+      {
+        "created": "2019-06-11T14:16:00.251+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -46990,7 +47326,7 @@
         "id": 333,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000103",
-        "modified": "2019-06-11T14:16:00.251+00:00",
+        "modified": "2019-06-11T14:16:00.251+0000",
         "name": "T3DB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^T3D\\d+$",
@@ -47037,7 +47373,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:46.061+00:00",
+        "created": "2019-06-11T14:15:46.061+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47046,7 +47382,7 @@
         "id": 182,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000049",
-        "modified": "2019-06-11T14:15:46.061+00:00",
+        "modified": "2019-06-11T14:15:46.061+0000",
         "name": "TAIR Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Gene:\\d{7}$",
@@ -47093,7 +47429,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:46.274+00:00",
+        "created": "2019-06-11T14:15:46.274+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47102,7 +47438,7 @@
         "id": 184,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000050",
-        "modified": "2019-06-11T14:15:46.274+00:00",
+        "modified": "2019-06-11T14:15:46.274+0000",
         "name": "TAIR Locus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{7}$",
@@ -47149,7 +47485,7 @@
         "successor": null
       },
       {
-        "created": "2023-01-12T10:08:07.976+00:00",
+        "created": "2023-01-12T10:08:07.976+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47158,7 +47494,7 @@
         "id": 3369,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000976",
-        "modified": "2023-01-12T10:08:07.976+00:00",
+        "modified": "2023-01-12T10:08:07.976+0000",
         "name": "TAIR gene name",
         "namespaceEmbeddedInLui": false,
         "pattern": "^AT.G[0-9]{5}$",
@@ -47205,7 +47541,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:45.813+00:00",
+        "created": "2019-06-11T14:15:45.813+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47214,7 +47550,7 @@
         "id": 179,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000048",
-        "modified": "2019-06-11T14:15:45.813+00:00",
+        "modified": "2019-06-11T14:15:45.813+0000",
         "name": "TAIR Protein",
         "namespaceEmbeddedInLui": false,
         "pattern": "^AASequence:\\d{10}$",
@@ -47261,7 +47597,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:56.599+00:00",
+        "created": "2019-06-11T14:16:56.599+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47270,7 +47606,7 @@
         "id": 976,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000340",
-        "modified": "2019-06-11T14:16:56.599+00:00",
+        "modified": "2019-06-11T14:16:56.599+0000",
         "name": "TarBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[a-z]{3}\\-(mir|let|lin)\\-\\w+(\\-\\w+\\-\\w+)?",
@@ -47317,7 +47653,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:29.882+00:00",
+        "created": "2019-06-11T14:15:29.882+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47326,7 +47662,7 @@
         "id": 28,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000006",
-        "modified": "2019-06-11T14:15:29.882+00:00",
+        "modified": "2019-06-11T14:15:29.882+0000",
         "name": "Taxonomy",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -47548,7 +47884,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:43.342+00:00",
+        "created": "2019-06-11T14:15:43.342+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47557,7 +47893,7 @@
         "id": 156,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000040",
-        "modified": "2019-06-11T14:15:43.342+00:00",
+        "modified": "2019-06-11T14:15:43.342+0000",
         "name": "Transport Classification Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+(\\.[A-Z])?(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?$",
@@ -47604,7 +47940,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:50.779+00:00",
+        "created": "2019-06-11T14:16:50.779+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47613,7 +47949,7 @@
         "id": 906,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000313",
-        "modified": "2019-06-11T14:16:50.779+00:00",
+        "modified": "2019-06-11T14:16:50.779+0000",
         "name": "Tetrahymena Genome Database",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TTHERM\\_\\d+$",
@@ -47660,7 +47996,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:50.975+00:00",
+        "created": "2019-06-11T14:16:50.975+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47669,7 +48005,7 @@
         "id": 908,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000315",
-        "modified": "2019-06-11T14:16:50.975+00:00",
+        "modified": "2019-06-11T14:16:50.975+0000",
         "name": "TIGRFAMS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TIGR\\d+$",
@@ -47716,7 +48052,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:01.500+00:00",
+        "created": "2019-06-11T14:17:01.500+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47725,7 +48061,7 @@
         "id": 1033,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000360",
-        "modified": "2019-06-11T14:17:01.500+00:00",
+        "modified": "2019-06-11T14:17:01.500+0000",
         "name": "Tissue List",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TS-\\d{4}$",
@@ -47772,7 +48108,7 @@
         "successor": null
       },
       {
-        "created": "2023-05-02T09:41:15.113+00:00",
+        "created": "2023-05-02T09:41:15.113+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47781,7 +48117,7 @@
         "id": 3527,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001006",
-        "modified": "2023-05-02T09:41:15.113+00:00",
+        "modified": "2023-05-02T09:41:15.113+0000",
         "name": "TogoVar",
         "namespaceEmbeddedInLui": false,
         "pattern": "^tgv[0-9]+$",
@@ -47828,7 +48164,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:13.167+00:00",
+        "created": "2019-06-11T14:17:13.167+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47837,7 +48173,7 @@
         "id": 1174,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000405",
-        "modified": "2019-06-11T14:17:13.167+00:00",
+        "modified": "2019-06-11T14:17:13.167+0000",
         "name": "Tree of Life",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -47884,7 +48220,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:35.217+00:00",
+        "created": "2019-06-11T14:17:35.217+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47893,7 +48229,7 @@
         "id": 1425,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000503",
-        "modified": "2019-06-11T14:17:35.217+00:00",
+        "modified": "2019-06-11T14:17:35.217+0000",
         "name": "TOPDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -47940,7 +48276,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:38.521+00:00",
+        "created": "2019-06-11T14:16:38.521+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -47949,7 +48285,7 @@
         "id": 756,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000255",
-        "modified": "2019-06-11T14:16:38.521+00:00",
+        "modified": "2019-06-11T14:16:38.521+0000",
         "name": "TopFind",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])$",
@@ -47996,7 +48332,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:13.817+00:00",
+        "created": "2019-06-11T14:16:13.817+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48005,7 +48341,7 @@
         "id": 477,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000153",
-        "modified": "2019-06-11T14:16:13.817+00:00",
+        "modified": "2019-06-11T14:16:13.817+0000",
         "name": "ToxoDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -48052,7 +48388,7 @@
         "successor": null
       },
       {
-        "created": "2020-02-28T10:48:52.126+00:00",
+        "created": "2020-02-28T10:48:52.126+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48061,7 +48397,7 @@
         "id": 2096,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000736",
-        "modified": "2020-03-03T05:45:40.200+00:00",
+        "modified": "2020-03-03T05:45:40.200+0000",
         "name": "TranSyT",
         "namespaceEmbeddedInLui": false,
         "pattern": "T[A-Z]\\d{7}",
@@ -48108,7 +48444,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:50.556+00:00",
+        "created": "2019-06-11T14:16:50.556+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48117,7 +48453,7 @@
         "id": 903,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000312",
-        "modified": "2019-06-11T14:16:50.556+00:00",
+        "modified": "2019-06-11T14:16:50.556+0000",
         "name": "TreeBASE",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TB[1,2]?:[A-Z][a-z]?\\d+$",
@@ -48164,7 +48500,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:10.973+00:00",
+        "created": "2019-06-11T14:17:10.973+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48173,7 +48509,7 @@
         "id": 1146,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000395",
-        "modified": "2019-06-11T14:17:10.973+00:00",
+        "modified": "2019-06-11T14:17:10.973+0000",
         "name": "TreeFam",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w{1,2}\\d+$",
@@ -48220,7 +48556,7 @@
         "successor": null
       },
       {
-        "created": "2023-11-27T09:57:23.517+00:00",
+        "created": "2023-11-27T09:57:23.517+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48229,7 +48565,7 @@
         "id": 3756,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00001036",
-        "modified": "2023-11-27T09:57:23.517+00:00",
+        "modified": "2023-11-27T09:57:23.517+0000",
         "name": "tricdb",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -48276,7 +48612,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:14.019+00:00",
+        "created": "2019-06-11T14:16:14.019+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48285,7 +48621,7 @@
         "id": 479,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000154",
-        "modified": "2019-06-11T14:16:14.019+00:00",
+        "modified": "2019-06-11T14:16:14.019+0000",
         "name": "TrichDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -48332,7 +48668,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:14.213+00:00",
+        "created": "2019-06-11T14:16:14.213+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48341,7 +48677,7 @@
         "id": 481,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000155",
-        "modified": "2019-06-11T14:16:14.213+00:00",
+        "modified": "2019-06-11T14:16:14.213+0000",
         "name": "TriTrypDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\.)?\\w+(\\.)?\\w+",
@@ -48388,7 +48724,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:57.654+00:00",
+        "created": "2019-06-11T14:15:57.654+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48397,7 +48733,7 @@
         "id": 304,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000092",
-        "modified": "2019-06-11T14:15:57.654+00:00",
+        "modified": "2019-06-11T14:15:57.654+0000",
         "name": "TTD Drug",
         "namespaceEmbeddedInLui": false,
         "pattern": "^DAP\\d+$",
@@ -48444,7 +48780,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:57.896+00:00",
+        "created": "2019-06-11T14:15:57.896+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48453,7 +48789,7 @@
         "id": 307,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000093",
-        "modified": "2019-06-11T14:15:57.896+00:00",
+        "modified": "2019-06-11T14:15:57.896+0000",
         "name": "TTD Target",
         "namespaceEmbeddedInLui": false,
         "pattern": "^TTDS\\d+$",
@@ -48500,7 +48836,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:22.433+00:00",
+        "created": "2019-06-11T14:17:22.433+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48509,7 +48845,7 @@
         "id": 1280,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000446",
-        "modified": "2021-02-27T10:19:43.666+00:00",
+        "modified": "2021-02-27T10:19:43.666+0000",
         "name": "UBERON",
         "namespaceEmbeddedInLui": true,
         "pattern": "^UBERON:\\d+$",
@@ -48591,7 +48927,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:56.122+00:00",
+        "created": "2019-06-11T14:16:56.122+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48600,7 +48936,7 @@
         "id": 970,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000338",
-        "modified": "2019-06-11T14:16:56.122+00:00",
+        "modified": "2019-06-11T14:16:56.122+0000",
         "name": "uBio NameBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -48647,7 +48983,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:42.994+00:00",
+        "created": "2019-06-11T14:16:42.994+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48656,7 +48992,7 @@
         "id": 811,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000276",
-        "modified": "2019-06-11T14:16:42.994+00:00",
+        "modified": "2019-06-11T14:16:42.994+0000",
         "name": "UM-BBD Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^c\\d+$",
@@ -48703,7 +49039,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:53.546+00:00",
+        "created": "2019-06-11T14:16:53.546+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48712,7 +49048,7 @@
         "id": 940,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000326",
-        "modified": "2019-06-11T14:16:53.546+00:00",
+        "modified": "2019-06-11T14:16:53.546+0000",
         "name": "UM-BBD Enzyme",
         "namespaceEmbeddedInLui": false,
         "pattern": "^e\\d+$",
@@ -48759,7 +49095,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:53.741+00:00",
+        "created": "2019-06-11T14:16:53.741+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48768,7 +49104,7 @@
         "id": 942,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000327",
-        "modified": "2019-06-11T14:16:53.741+00:00",
+        "modified": "2019-06-11T14:16:53.741+0000",
         "name": "UM-BBD Pathway",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -48815,7 +49151,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:53.335+00:00",
+        "created": "2019-06-11T14:16:53.335+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48824,7 +49160,7 @@
         "id": 938,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000325",
-        "modified": "2019-06-11T14:16:53.335+00:00",
+        "modified": "2019-06-11T14:16:53.335+0000",
         "name": "UM-BBD Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^r\\d+$",
@@ -48871,7 +49207,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:53.927+00:00",
+        "created": "2019-06-11T14:16:53.927+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48880,7 +49216,7 @@
         "id": 944,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000328",
-        "modified": "2019-06-11T14:16:53.927+00:00",
+        "modified": "2019-06-11T14:16:53.927+0000",
         "name": "UM-BBD Biotransformation Rule",
         "namespaceEmbeddedInLui": false,
         "pattern": "^bt\\d+$",
@@ -48927,7 +49263,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:48.502+00:00",
+        "created": "2019-06-11T14:17:48.502+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48936,7 +49272,7 @@
         "id": 1561,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000559",
-        "modified": "2019-06-11T14:17:48.502+00:00",
+        "modified": "2019-06-11T14:17:48.502+0000",
         "name": "UMLS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^C\\d+$",
@@ -48983,7 +49319,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:57.856+00:00",
+        "created": "2019-06-11T14:16:57.856+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -48992,7 +49328,7 @@
         "id": 991,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000346",
-        "modified": "2019-06-11T14:16:57.856+00:00",
+        "modified": "2019-06-11T14:16:57.856+0000",
         "name": "UniGene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -49039,7 +49375,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:41.988+00:00",
+        "created": "2019-06-11T14:17:41.988+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49048,7 +49384,7 @@
         "id": 1493,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000531",
-        "modified": "2019-06-11T14:17:41.988+00:00",
+        "modified": "2019-06-11T14:17:41.988+0000",
         "name": "UNII",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -49130,7 +49466,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:22.748+00:00",
+        "created": "2019-06-11T14:17:22.748+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49139,7 +49475,7 @@
         "id": 1283,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000447",
-        "modified": "2019-06-11T14:17:22.748+00:00",
+        "modified": "2019-06-11T14:17:22.748+0000",
         "name": "Unimod",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -49186,7 +49522,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:43.590+00:00",
+        "created": "2019-06-11T14:15:43.590+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49195,7 +49531,7 @@
         "id": 159,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000041",
-        "modified": "2019-06-11T14:15:43.590+00:00",
+        "modified": "2019-06-11T14:15:43.590+0000",
         "name": "UniParc",
         "namespaceEmbeddedInLui": false,
         "pattern": "^UPI[A-F0-9]{10}$",
@@ -49277,7 +49613,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:46.612+00:00",
+        "created": "2019-06-11T14:17:46.612+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49286,7 +49622,7 @@
         "id": 1542,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000551",
-        "modified": "2019-06-11T14:17:46.612+00:00",
+        "modified": "2019-06-11T14:17:46.612+0000",
         "name": "UniPathway Compound",
         "namespaceEmbeddedInLui": false,
         "pattern": "^UPC\\d{5}$",
@@ -49297,7 +49633,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2019-10-01T12:10:54.792+00:00",
+            "deprecationDate": "2019-10-01T12:10:54.792+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "UniPathway Compound at Swiss Institute of Bioinformatics (SIB)",
@@ -49333,7 +49669,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:51.017+00:00",
+        "created": "2019-06-11T14:17:51.017+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49342,7 +49678,7 @@
         "id": 1587,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000570",
-        "modified": "2019-06-11T14:17:51.017+00:00",
+        "modified": "2019-06-11T14:17:51.017+0000",
         "name": "UniPathway Reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "^UCR\\d{5}$",
@@ -49353,7 +49689,7 @@
             "authHelpDescription": null,
             "authHelpUrl": null,
             "deprecated": true,
-            "deprecationDate": "2019-10-01T12:11:20.049+00:00",
+            "deprecationDate": "2019-10-01T12:11:20.049+0000",
             "deprecationOfflineDate": null,
             "deprecationStatement": null,
             "description": "UniPathway Reaction at Swiss Institute of Bioinformatics (SIB)",
@@ -49389,7 +49725,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:29.457+00:00",
+        "created": "2019-06-11T14:15:29.457+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49398,7 +49734,7 @@
         "id": 23,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000005",
-        "modified": "2019-06-11T14:15:29.457+00:00",
+        "modified": "2019-06-11T14:15:29.457+0000",
         "name": "UniProt Knowledgebase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\\.\\d+)?$",
@@ -49480,7 +49816,7 @@
         "successor": null
       },
       {
-        "created": "2020-06-09T20:12:07.077+00:00",
+        "created": "2020-06-09T20:12:07.077+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49489,7 +49825,7 @@
         "id": 2265,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000739",
-        "modified": "2020-06-26T08:48:10.292+00:00",
+        "modified": "2020-06-26T08:48:10.292+0000",
         "name": "UniProt Chain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^PRO_[0-9]{10}$",
@@ -49536,7 +49872,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:08.943+00:00",
+        "created": "2019-06-11T14:17:08.943+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49545,7 +49881,7 @@
         "id": 1123,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000388",
-        "modified": "2019-06-11T14:17:08.943+00:00",
+        "modified": "2019-06-11T14:17:08.943+0000",
         "name": "UniProt Isoform",
         "namespaceEmbeddedInLui": false,
         "pattern": "^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\\-\\d+)$",
@@ -49662,7 +49998,7 @@
         "successor": null
       },
       {
-        "created": "2021-09-29T19:13:56.614+00:00",
+        "created": "2021-09-29T19:13:56.614+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49671,7 +50007,7 @@
         "id": 2896,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000878",
-        "modified": "2021-09-29T19:13:56.614+00:00",
+        "modified": "2021-09-29T19:13:56.614+0000",
         "name": "UniRef",
         "namespaceEmbeddedInLui": false,
         "pattern": "^UniRef(100|90|50)_([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}|UPI[A-F0-9]{10})$",
@@ -49718,7 +50054,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:16.225+00:00",
+        "created": "2019-06-11T14:16:16.225+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49727,7 +50063,7 @@
         "id": 503,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000162",
-        "modified": "2019-06-11T14:16:16.225+00:00",
+        "modified": "2019-06-11T14:16:16.225+0000",
         "name": "UniSTS",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -49774,7 +50110,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:59.723+00:00",
+        "created": "2019-06-11T14:16:59.723+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49783,7 +50119,7 @@
         "id": 1012,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000352",
-        "modified": "2019-06-11T14:16:59.723+00:00",
+        "modified": "2019-06-11T14:16:59.723+0000",
         "name": "Unite",
         "namespaceEmbeddedInLui": false,
         "pattern": "^UDB\\d{6}$",
@@ -49830,7 +50166,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:09.596+00:00",
+        "created": "2019-06-11T14:16:09.596+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49839,7 +50175,7 @@
         "id": 432,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000136",
-        "modified": "2019-06-11T14:16:09.596+00:00",
+        "modified": "2019-06-11T14:16:09.596+0000",
         "name": "Unit Ontology",
         "namespaceEmbeddedInLui": true,
         "pattern": "^UO:\\d{7}?",
@@ -49921,7 +50257,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:43.583+00:00",
+        "created": "2019-06-11T14:17:43.583+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49930,7 +50266,7 @@
         "id": 1510,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000538",
-        "modified": "2019-06-11T14:17:43.583+00:00",
+        "modified": "2019-06-11T14:17:43.583+0000",
         "name": "USPTO",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(D|PP|R|T|H|X|AI)?\\d+$",
@@ -49977,7 +50313,7 @@
         "successor": null
       },
       {
-        "created": "2023-02-23T11:08:58.437+00:00",
+        "created": "2023-02-23T11:08:58.437+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -49986,7 +50322,7 @@
         "id": 3467,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000993",
-        "modified": "2023-02-23T11:21:10.786+00:00",
+        "modified": "2023-02-23T11:21:10.786+0000",
         "name": "UTRdb",
         "namespaceEmbeddedInLui": false,
         "pattern": "([3-5][A-Z])\\w+[^A-Z][0-9]",
@@ -50033,7 +50369,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:07.321+00:00",
+        "created": "2019-06-11T14:18:07.321+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50042,7 +50378,7 @@
         "id": 1757,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000633",
-        "modified": "2019-06-11T14:18:07.321+00:00",
+        "modified": "2019-06-11T14:18:07.321+0000",
         "name": "ValidatorDB",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z0-9\\/]+$",
@@ -50089,7 +50425,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:13.429+00:00",
+        "created": "2019-06-11T14:17:13.429+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50098,7 +50434,7 @@
         "id": 1177,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000406",
-        "modified": "2019-06-11T14:17:13.429+00:00",
+        "modified": "2019-06-11T14:17:13.429+0000",
         "name": "VariO",
         "namespaceEmbeddedInLui": true,
         "pattern": "^VariO:\\d+$",
@@ -50215,7 +50551,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:52.167+00:00",
+        "created": "2019-06-11T14:16:52.167+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50224,7 +50560,7 @@
         "id": 923,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000320",
-        "modified": "2019-06-11T14:16:52.167+00:00",
+        "modified": "2019-06-11T14:16:52.167+0000",
         "name": "Vbase2",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -50271,7 +50607,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:22.962+00:00",
+        "created": "2019-06-11T14:17:22.962+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50280,7 +50616,7 @@
         "id": 1286,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000448",
-        "modified": "2019-06-11T14:17:22.962+00:00",
+        "modified": "2019-06-11T14:17:22.962+0000",
         "name": "VBRC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -50327,7 +50663,7 @@
         "successor": null
       },
       {
-        "created": "2022-01-09T18:57:18.476+00:00",
+        "created": "2022-01-09T18:57:18.476+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50336,7 +50672,7 @@
         "id": 2995,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000893",
-        "modified": "2022-01-09T18:57:18.476+00:00",
+        "modified": "2022-01-09T18:57:18.476+0000",
         "name": "VCell Published Models",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d{5,}$",
@@ -50383,7 +50719,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:32.515+00:00",
+        "created": "2019-06-11T14:16:32.515+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50392,7 +50728,7 @@
         "id": 687,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000232",
-        "modified": "2024-01-12T10:30:39.284+00:00",
+        "modified": "2024-01-12T10:30:39.284+0000",
         "name": "VectorBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\D{4}\\d{6}(\\-\\D{2})?$",
@@ -50439,7 +50775,7 @@
         "successor": null
       },
       {
-        "created": "2020-01-24T13:57:43.399+00:00",
+        "created": "2020-01-24T13:57:43.399+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50448,7 +50784,7 @@
         "id": 2072,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000723",
-        "modified": "2020-01-24T13:57:43.399+00:00",
+        "modified": "2020-01-24T13:57:43.399+0000",
         "name": "VegBank",
         "namespaceEmbeddedInLui": false,
         "pattern": "^VB\\.[A-Za-z][A-Za-z]\\..*$",
@@ -50495,7 +50831,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:19.150+00:00",
+        "created": "2019-06-11T14:18:19.150+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50504,7 +50840,7 @@
         "id": 1884,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000680",
-        "modified": "2019-06-11T14:18:19.150+00:00",
+        "modified": "2019-06-11T14:18:19.150+0000",
         "name": "Virtual Fly Brain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9a-zA-Z]{8}$",
@@ -50551,7 +50887,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:28.027+00:00",
+        "created": "2019-06-11T14:17:28.027+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50560,7 +50896,7 @@
         "id": 1347,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000472",
-        "modified": "2019-06-11T14:17:28.027+00:00",
+        "modified": "2019-06-11T14:17:28.027+0000",
         "name": "VFDB Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -50607,7 +50943,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:27.811+00:00",
+        "created": "2019-06-11T14:17:27.811+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50616,7 +50952,7 @@
         "id": 1344,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000471",
-        "modified": "2019-06-11T14:17:27.811+00:00",
+        "modified": "2019-06-11T14:17:27.811+0000",
         "name": "VFDB Genus",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+$",
@@ -50663,7 +50999,7 @@
         "successor": null
       },
       {
-        "created": "2020-05-12T14:08:31.024+00:00",
+        "created": "2020-05-12T14:08:31.024+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50672,7 +51008,7 @@
         "id": 2222,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000765",
-        "modified": "2020-05-12T14:08:31.024+00:00",
+        "modified": "2020-05-12T14:08:31.024+0000",
         "name": "VGNC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^((VGNC|vgnc):)?\\d{1,9}$",
@@ -50719,7 +51055,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:20.364+00:00",
+        "created": "2019-06-11T14:18:20.364+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50728,7 +51064,7 @@
         "id": 1898,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000685",
-        "modified": "2019-06-11T14:18:20.364+00:00",
+        "modified": "2019-06-11T14:18:20.364+0000",
         "name": "Virtual International Authority File",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -50775,7 +51111,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:13.893+00:00",
+        "created": "2019-06-11T14:17:13.893+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50784,7 +51120,7 @@
         "id": 1182,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000407",
-        "modified": "2019-06-11T14:17:13.893+00:00",
+        "modified": "2019-06-11T14:17:13.893+0000",
         "name": "ViPR Strain",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z 0-9]+$",
@@ -50831,7 +51167,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:23.207+00:00",
+        "created": "2019-06-11T14:17:23.207+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50840,7 +51176,7 @@
         "id": 1289,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000449",
-        "modified": "2019-06-11T14:17:23.207+00:00",
+        "modified": "2019-06-11T14:17:23.207+0000",
         "name": "ViralZone",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -50887,7 +51223,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:37.163+00:00",
+        "created": "2019-06-11T14:16:37.163+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50896,7 +51232,7 @@
         "id": 739,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000249",
-        "modified": "2019-06-11T14:16:37.163+00:00",
+        "modified": "2019-06-11T14:16:37.163+0000",
         "name": "VIRsiRNA",
         "namespaceEmbeddedInLui": false,
         "pattern": "^virsi\\d+$",
@@ -50943,7 +51279,7 @@
         "successor": null
       },
       {
-        "created": "2021-02-01T15:47:59.756+00:00",
+        "created": "2021-02-01T15:47:59.756+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -50952,7 +51288,7 @@
         "id": 2497,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000774",
-        "modified": "2021-02-01T15:47:59.756+00:00",
+        "modified": "2021-02-01T15:47:59.756+0000",
         "name": "VMH Gene",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[0-9]+\\.[0-9]+",
@@ -50999,7 +51335,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:07.981+00:00",
+        "created": "2019-06-11T14:18:07.981+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51008,7 +51344,7 @@
         "id": 1765,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000636",
-        "modified": "2019-06-11T14:18:07.981+00:00",
+        "modified": "2019-06-11T14:18:07.981+0000",
         "name": "VMH metabolite",
         "namespaceEmbeddedInLui": false,
         "pattern": "[a-zA-Z0-9_\\(\\_\\)\\[\\]]+",
@@ -51055,7 +51391,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:18:08.921+00:00",
+        "created": "2019-06-11T14:18:08.921+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51064,7 +51400,7 @@
         "id": 1775,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000640",
-        "modified": "2019-06-11T14:18:08.921+00:00",
+        "modified": "2019-06-11T14:18:08.921+0000",
         "name": "VMH reaction",
         "namespaceEmbeddedInLui": false,
         "pattern": "[a-zA-Z0-9_\\(\\_\\)\\[\\]]+",
@@ -51111,7 +51447,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:38.790+00:00",
+        "created": "2019-06-11T14:15:38.790+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51120,7 +51456,7 @@
         "id": 113,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000027",
-        "modified": "2019-06-11T14:15:38.790+00:00",
+        "modified": "2019-06-11T14:15:38.790+0000",
         "name": "WormBase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^WB[A-Z][a-z]+\\d+$",
@@ -51237,7 +51573,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:26.886+00:00",
+        "created": "2019-06-11T14:17:26.886+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51246,7 +51582,7 @@
         "id": 1333,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000466",
-        "modified": "2019-06-11T14:17:26.886+00:00",
+        "modified": "2019-06-11T14:17:26.886+0000",
         "name": "WormBase RNAi",
         "namespaceEmbeddedInLui": false,
         "pattern": "^WBRNAi\\d{8}$",
@@ -51293,7 +51629,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:46.087+00:00",
+        "created": "2019-06-11T14:17:46.087+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51302,7 +51638,7 @@
         "id": 1537,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000549",
-        "modified": "2020-11-30T14:15:44.647+00:00",
+        "modified": "2020-11-30T14:15:44.647+0000",
         "name": "Wikidata",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(Q|P)\\d+$",
@@ -51349,7 +51685,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:20.303+00:00",
+        "created": "2019-06-11T14:17:20.303+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51358,7 +51694,7 @@
         "id": 1255,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000437",
-        "modified": "2019-06-11T14:17:20.303+00:00",
+        "modified": "2019-06-11T14:17:20.303+0000",
         "name": "WikiGenes",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -51405,7 +51741,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:53.125+00:00",
+        "created": "2019-06-11T14:15:53.125+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51414,7 +51750,7 @@
         "id": 258,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000076",
-        "modified": "2023-01-05T18:26:05.922+00:00",
+        "modified": "2023-01-05T18:26:05.922+0000",
         "name": "WikiPathways",
         "namespaceEmbeddedInLui": false,
         "pattern": "WP\\d{1,5}(\\_r\\d+)?$",
@@ -51496,7 +51832,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:07.845+00:00",
+        "created": "2019-06-11T14:17:07.845+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51505,7 +51841,7 @@
         "id": 1110,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000384",
-        "modified": "2019-06-11T14:17:07.845+00:00",
+        "modified": "2019-06-11T14:17:07.845+0000",
         "name": "Wikipedia (En)",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Za-z-0-9_]+$",
@@ -51587,7 +51923,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:45.846+00:00",
+        "created": "2019-06-11T14:16:45.846+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51596,7 +51932,7 @@
         "id": 847,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000288",
-        "modified": "2019-06-11T14:16:45.846+00:00",
+        "modified": "2019-06-11T14:16:45.846+0000",
         "name": "Worfdb",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+(\\.\\d+)?",
@@ -51643,7 +51979,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:40.709+00:00",
+        "created": "2019-06-11T14:15:40.709+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51652,7 +51988,7 @@
         "id": 130,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000031",
-        "modified": "2019-06-11T14:15:40.709+00:00",
+        "modified": "2019-06-11T14:15:40.709+0000",
         "name": "Wormpep",
         "namespaceEmbeddedInLui": false,
         "pattern": "^CE\\d{5}$",
@@ -51699,7 +52035,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:54.476+00:00",
+        "created": "2019-06-11T14:17:54.476+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51708,7 +52044,7 @@
         "id": 1618,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000581",
-        "modified": "2019-06-11T14:17:54.476+00:00",
+        "modified": "2019-06-11T14:17:54.476+0000",
         "name": "World Register of Marine Species",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -51755,7 +52091,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:21.651+00:00",
+        "created": "2019-06-11T14:16:21.651+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51764,7 +52100,7 @@
         "id": 567,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000186",
-        "modified": "2020-06-09T19:30:57.158+00:00",
+        "modified": "2020-06-09T19:30:57.158+0000",
         "name": "Xenbase",
         "namespaceEmbeddedInLui": false,
         "pattern": "^XB\\-\\w+\\-\\d+$",
@@ -51811,7 +52147,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:26.654+00:00",
+        "created": "2019-06-11T14:17:26.654+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51820,7 +52156,7 @@
         "id": 1330,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000465",
-        "modified": "2019-06-11T14:17:26.654+00:00",
+        "modified": "2019-06-11T14:17:26.654+0000",
         "name": "YDPM",
         "namespaceEmbeddedInLui": false,
         "pattern": "^Y[A-Z]{2}\\d+[CW]$",
@@ -51867,7 +52203,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:39.906+00:00",
+        "created": "2019-06-11T14:17:39.906+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51876,7 +52212,7 @@
         "id": 1470,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000521",
-        "modified": "2019-06-11T14:17:39.906+00:00",
+        "modified": "2019-06-11T14:17:39.906+0000",
         "name": "Yeast Intron Database v4.3",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -51923,7 +52259,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:16:56.366+00:00",
+        "created": "2019-06-11T14:16:56.366+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51932,7 +52268,7 @@
         "id": 973,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000339",
-        "modified": "2019-06-11T14:16:56.366+00:00",
+        "modified": "2019-06-11T14:16:56.366+0000",
         "name": "YeTFasCo",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\w+\\_\\d+(\\.\\d+)?$",
@@ -51979,7 +52315,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:25.610+00:00",
+        "created": "2019-06-11T14:17:25.610+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -51988,7 +52324,7 @@
         "id": 1318,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000460",
-        "modified": "2019-06-11T14:17:25.610+00:00",
+        "modified": "2019-06-11T14:17:25.610+0000",
         "name": "Yeast Intron Database v3",
         "namespaceEmbeddedInLui": false,
         "pattern": "^[A-Z0-9]+$",
@@ -52035,7 +52371,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:25.397+00:00",
+        "created": "2019-06-11T14:17:25.397+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -52044,7 +52380,7 @@
         "id": 1315,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000459",
-        "modified": "2019-06-11T14:17:25.397+00:00",
+        "modified": "2019-06-11T14:17:25.397+0000",
         "name": "YRC PDR",
         "namespaceEmbeddedInLui": false,
         "pattern": "^\\d+$",
@@ -52091,7 +52427,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:15:53.859+00:00",
+        "created": "2019-06-11T14:15:53.859+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -52100,7 +52436,7 @@
         "id": 266,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000079",
-        "modified": "2019-06-11T14:15:53.859+00:00",
+        "modified": "2019-06-11T14:15:53.859+0000",
         "name": "ZFIN Bioentity",
         "namespaceEmbeddedInLui": false,
         "pattern": "^ZDB\\-\\w+\\-\\d+\\-\\d+$",
@@ -52217,7 +52553,7 @@
         "successor": null
       },
       {
-        "created": "2019-06-11T14:17:41.559+00:00",
+        "created": "2019-06-11T14:17:41.559+0000",
         "deprecated": false,
         "deprecationDate": null,
         "deprecationOfflineDate": null,
@@ -52226,7 +52562,7 @@
         "id": 1488,
         "infoOnPostmortemAccess": null,
         "mirId": "MIR:00000529",
-        "modified": "2019-06-11T14:17:41.559+00:00",
+        "modified": "2019-06-11T14:17:41.559+0000",
         "name": "ZINC",
         "namespaceEmbeddedInLui": false,
         "pattern": "^(ZINC)?\\d+$",


### PR DESCRIPTION
The ORDO license is stated as CC BY 4.0 in the ontology

The OBO Foundry patterns need updating since MCRO decided to submit information with a banana to identifiers.org