### PR TITLE
Add URI parsing endpoint

### DIFF
--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -494,10 +494,17 @@ def get_reference(request: Request, prefix: str, identifier: str):
 class URIResponse(BaseModel):
     """A response for looking up a reference."""
 
-    uri: str = Field(..., examples=["http://id.nlm.nih.gov/mesh/C063233"])
-    reference: Reference = Field(..., examples=[Reference(prefix="mesh", identifier="C063233")])
+    uri: str = Field(
+        ..., description="The query URI", examples=["http://id.nlm.nih.gov/mesh/C063233"]
+    )
+    reference: Reference = Field(
+        ...,
+        description="The compact URI (CURIE)",
+        examples=[Reference(prefix="mesh", identifier="C063233")],
+    )
     providers: Mapping[str, str] = Field(
         ...,
+        description="Equivalent URIs",
         examples=[
             {
                 "default": "https://meshb.nlm.nih.gov/record/ui?ui=C063233",
@@ -510,10 +517,12 @@ class URIResponse(BaseModel):
 class URIQuery(BaseModel):
     """A query for parsing a URI."""
 
-    uri: str
+    uri: str = Field(..., examples=["http://id.nlm.nih.gov/mesh/C063233"])
 
 
-@api_router.post("/parse/", response_model=URIResponse, tags=["reference"], summary="Parse a URI")
+@api_router.post(
+    "/uri/parse/", response_model=URIResponse, tags=["reference"], summary="Parse a URI"
+)
 def post_parse_uri(
     request: Request,
     query: URIQuery = Body(..., examples=[URIQuery(uri="http://id.nlm.nih.gov/mesh/C063233")]),

--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -505,7 +505,7 @@ class URIQuery(BaseModel):
     uri: str
 
 
-@api_router.post("/parse/", response_model=URIResponse, tags=["uri"])
+@api_router.post("/parse/", response_model=URIResponse, tags=["reference"])
 def get_parse_reference(request: Request, query: URIQuery):
     """Parse a URI, return a CURIE, and all equivalent URIs."""
     manager = request.app.manager
@@ -516,7 +516,7 @@ def get_parse_reference(request: Request, query: URIQuery):
     if not providers:
         raise HTTPException(404, "no providers available")
     return URIResponse(
-        query=query.uri,
+        uri=query.uri,
         reference=Reference(prefix=prefix, identifier=identifier),
         providers=providers,
     )

--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -513,8 +513,8 @@ class URIQuery(BaseModel):
     uri: str
 
 
-@api_router.post("/parse/", response_model=URIResponse, tags=["reference"])
-def get_parse_reference(
+@api_router.post("/parse/", response_model=URIResponse, tags=["reference"], summary="Parse a URI")
+def post_parse_uri(
     request: Request,
     query: URIQuery = Body(..., examples=[URIQuery(uri="http://id.nlm.nih.gov/mesh/C063233")]),
 ):
@@ -523,13 +523,11 @@ def get_parse_reference(
     prefix, identifier = manager.parse_uri(query.uri)
     if prefix is None:
         raise HTTPException(404, f"can't parse URI: {query.uri}")
-    providers = manager.get_providers(prefix, identifier)
-    if not providers:
-        raise HTTPException(404, "no providers available")
     return URIResponse(
         uri=query.uri,
         reference=Reference(prefix=prefix, identifier=identifier),
-        providers=providers,
+        # Given the fact that we're able to parse the URI, there must be at least one provider
+        providers=manager.get_providers(prefix, identifier),
     )
 
 

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -246,7 +246,7 @@ class TestWeb(unittest.TestCase):
         .. seealso:: https://github.com/biopragmatics/bioregistry/issues/1065
         """
         uri = "http://id.nlm.nih.gov/mesh/C063233"
-        res = self.client.post("/api/parse/", json={"uri": uri})
+        res = self.client.post("/api/uri/parse/", json={"uri": uri})
         self.assertEqual(200, res.status_code)
         data = URIResponse.parse_obj(res.json())
         self.assertEqual(uri, data.uri)
@@ -254,5 +254,5 @@ class TestWeb(unittest.TestCase):
 
         # Bad URI
         uri = "xxxx"
-        res = self.client.post("/api/parse/", json={"uri": uri})
+        res = self.client.post("/api/uri/parse/", json={"uri": uri})
         self.assertEqual(404, res.status_code)

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from bioregistry import Resource
-from bioregistry.app.api import MappingResponse
+from bioregistry.app.api import MappingResponse, URIResponse
 from bioregistry.app.impl import get_app
 
 
@@ -239,3 +239,15 @@ class TestWeb(unittest.TestCase):
         self.assertIn("loggerhead", res_parsed.meta.source_only)
         # This is a non-ontology so it won't get in OBO Foundry
         self.assertIn("DCTERMS", res_parsed.meta.target_only)
+
+    def test_iri_mapping(self):
+        """Test IRI mappings.
+
+        .. seealso:: https://github.com/biopragmatics/bioregistry/issues/1065
+        """
+        uri = "http://id.nlm.nih.gov/mesh/C063233"
+        res = self.client.post("/api/parse/", json={"uri": uri})
+        self.assertEqual(200, res.status_code)
+        data = URIResponse.parse_obj(res.json())
+        self.assertEqual(uri, data.uri)
+        self.assertIn("https://meshb.nlm.nih.gov/record/ui?ui=C063233", data.providers.values())

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -251,3 +251,8 @@ class TestWeb(unittest.TestCase):
         data = URIResponse.parse_obj(res.json())
         self.assertEqual(uri, data.uri)
         self.assertIn("https://meshb.nlm.nih.gov/record/ui?ui=C063233", data.providers.values())
+
+        # Bad URI
+        uri = "xxxx"
+        res = self.client.post("/api/parse/", json={"uri": uri})
+        self.assertEqual(404, res.status_code)


### PR DESCRIPTION
Closes #1065

This PR adds the `/api/uri/parse` endpoint that takes in a `uri` body parameter, and returns some useful information in return

```python
import requests

uri = "http://id.nlm.nih.gov/mesh/C063233"
res = requests.get("http://localhost:5000/api/uri/parse", json={"uri": uri}).json()
```

gives the following:

```json
{
    "uri": "http://id.nlm.nih.gov/mesh/C063233",
    "reference": {"prefix": "mesh", "identifier": "C063233"},
    "providers": {
        "default": "https://meshb.nlm.nih.gov/record/ui?ui=C063233",
        "rdf": "http://id.nlm.nih.gov/mesh/C063233",
        ...
    }
}
```

cc @rombaum 