### PR TITLE
Don't display Twitter handles

### DIFF
--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -21,7 +21,6 @@
 
 {% set mastodon = resource.get_mastodon() %}
 {% set mastodon_url = resource.get_mastodon_url() %}
-{% set twitter = resource.get_twitter() %}
 {% set keywords = resource.get_keywords() %}
 
 {% macro get_banana_text() %}
@@ -215,11 +214,6 @@
                     {% if mastodon %}
                         <a class="badge badge-pill badge-light" href="{{ mastodon_url }}">
                             <i class="fab fa-mastodon"></i> @{{ mastodon }}
-                        </a>
-                    {% endif %}
-                    {% if twitter %}
-                        <a class="badge badge-pill badge-light" href="https://twitter.com/{{ twitter }}">
-                            <i class="fab fa-twitter"></i> @{{ twitter }}
                         </a>
                     {% endif %}
                 </dd>


### PR DESCRIPTION
Twitter/X no longer reflects the values of an inclusive and open scientific community, so the Bioregistry isn't going to display organizations' Twitter handles anymore. This PR doesn't delete those from the underlying data - they still might be useful for historical purposes.