### PR TITLE
Improve provider section of resource page on web app

### DIFF
--- a/.github/ISSUE_TEMPLATE/merge.yml
+++ b/.github/ISSUE_TEMPLATE/merge.yml
@@ -2,8 +2,6 @@ name: Merge two resources
 description: When two prefixes are redundant and shoud be merged
 title: Merge resource [X] into [Y]
 labels: [ Merge, Update ]
-assignees:
-  - cthoyt
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-prefix.yml
+++ b/.github/ISSUE_TEMPLATE/new-prefix.yml
@@ -3,8 +3,6 @@ description: Add metadata about a database, ontology, or other authority that is
   identifiers.
 title: Add prefix [X]
 labels: [ New, Prefix ]
-assignees:
-  - "biopragmatics/bioregistry-reviewers"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-provider.yml
+++ b/.github/ISSUE_TEMPLATE/new-provider.yml
@@ -31,3 +31,10 @@ body:
       placeholder: ex. 0000-0003-4423-4370
     validations:
       required: true
+  - type: textarea
+    id: explanation
+    attributes:
+      label: Explanation
+      description: Please add any additional explanation, if desired
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-provider.yml
+++ b/.github/ISSUE_TEMPLATE/new-provider.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out the new provider form!
+        Thanks for taking the time to fill out the new provider form! A curation guide for new providers can be found here: https://biopragmatics.github.io/bioregistry/curation/providers.
   - type: input
     id: prefix
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-provider.yml
+++ b/.github/ISSUE_TEMPLATE/new-provider.yml
@@ -2,8 +2,6 @@ name: Add provider for resource
 description: Add a URL for resolving identifiers in a given resource
 title: Add provider for [X]
 labels: [ Provider, New ]
-assignees:
-  - cthoyt
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/update-misc.yml
+++ b/.github/ISSUE_TEMPLATE/update-misc.yml
@@ -1,8 +1,6 @@
 name: Update resource
 description: Use this to request an update to a prefix that does not fit in one of the other templates.
 labels: [ Update ]
-assignees:
-  - cthoyt
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/update-regex.yml
+++ b/.github/ISSUE_TEMPLATE/update-regex.yml
@@ -2,8 +2,6 @@ name: Update regular expression pattern
 description: Use this to request an update to a regular expression pattern for a given resource
 title: Update regular expression pattern for [X]
 labels: [ Regex, Update ]
-assignees:
-  - cthoyt
 body:
   - type: markdown
     attributes:

--- a/docs/_data/curation.yml
+++ b/docs/_data/curation.yml
@@ -120,9 +120,6 @@ example:
   name: Yeast Phenotype Ontology
   prefix: ypo
 formatter:
-- homepage: https://www.allotrope.org/
-  name: Allotrope Merged Ontology Suite
-  prefix: afo
 - homepage: https://www.ebi.ac.uk/arrayexpress/files/A-MEXP-2320/A-MEXP-2320.adf.txt
   name: Agilent Probe
   prefix: agilent.probe
@@ -141,9 +138,6 @@ formatter:
 - homepage: https://www.ebi.ac.uk/arrayexpress/files/A-GEHB-1/A-GEHB-1.adf.txt
   name: GE Healthcare/Amersham Biosciences CodeLink Human Whole Genome Bioarray
   prefix: codelink
-- homepage: https://github.com/MIT-LCP/mimic-omop
-  name: MIMIC III Database
-  prefix: cohd
 - homepage: null
   name: Cellular Phenotypes
   prefix: cp
@@ -204,9 +198,6 @@ formatter:
 - homepage: http://genecards.weizmann.ac.il/geneannot/
   name: 'GeneAnnot: Microarray Gene Annotation'
   prefix: genecards.geneannot
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Gene Expression Ontology
-  prefix: gexo
 - homepage: https://link.springer.com/bookseries/562
   name: Gmelins Handbuch der anorganischen Chemie
   prefix: gmelin
@@ -219,9 +210,6 @@ formatter:
 - homepage: https://www.canada.ca/en/health-canada/services/drugs-health-products/drug-products/fact-sheets/drug-identification-number.html
   name: Health Canada Drug Identification Number
   prefix: hc.din
-- homepage: https://www.humancellatlas.org
-  name: Human Cell Atlas Ontology
-  prefix: hcao
 - homepage: https://www.hesa.ac.uk
   name: UK Higher Education Statistics Agency
   prefix: hesa
@@ -237,9 +225,6 @@ formatter:
 - homepage: https://www.ebi.ac.uk/arrayexpress/files/A-GEOD-6790/A-GEOD-6790.adf.txt
   name: Illumina Probe Identifier
   prefix: illumina.probe
-- homepage: http://www.imdrf.org/
-  name: International Medical Device Regulators Forum
-  prefix: imdrf
 - homepage: https://www.goreni.org/gr3_nomenclature.php
   name: The International Harmonization of Nomenclature and Diagnostic criteria
   prefix: inhand
@@ -294,9 +279,6 @@ formatter:
 - homepage: https://zenodo.org/record/5237774#.YXq72hxCRGo
   name: Ontology for simulation, modelling, and optimization
   prefix: nfdi4chem.osmo
-- homepage: https://webbook.nist.gov/chemistry/
-  name: NIST Chemistry WebBook
-  prefix: nist
 - homepage: http://bidd.group/NPASS/
   name: Natural Product Activity and Species Source Database
   prefix: npass
@@ -327,12 +309,6 @@ formatter:
 - homepage: https://www.reaxys.com
   name: Reaxys
   prefix: reaxys
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Regulation of Transcription Ontology
-  prefix: reto
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Regulation of Gene Expression Ontology
-  prefix: rexo
 - homepage: https://www.cdc.gov/niosh/rtecs/
   name: Registry of Toxic Effects of Chemical Substances
   prefix: rtecs
@@ -396,9 +372,6 @@ formatter:
 - homepage: https://www.va.gov/health
   name: Veterans Health Administration (VHA) unique identifier
   prefix: vuid
-- homepage: https://como.ceb.cam.ac.uk/preprints/223/
-  name: Computational Chemistry Ontology
-  prefix: worldavatar.compchem
 - homepage: http://www.psidev.info/groups/controlled-vocabularies
   name: Cross-linker reagents ontology
   prefix: xl
@@ -430,9 +403,6 @@ pattern:
 - homepage: http://www.w3.org/ns/adms
   name: Asset Description Metadata Schema Vocabulary
   prefix: adms
-- homepage: https://www.allotrope.org/
-  name: Allotrope Merged Ontology Suite
-  prefix: afo
 - homepage: https://aftol.umn.edu
   name: Assembling the Fungal Tree of Life - Category
   prefix: aftol.category
@@ -545,9 +515,6 @@ pattern:
 - homepage: https://chemkg.github.io/chemrof/
   name: Chemical Entity Materials and Reactions Ontological Framework
   prefix: chemrof
-- homepage: https://github.com/obophenotype/chiro
-  name: ChEBI Integrated Role Ontology
-  prefix: chiro
 - homepage: https://www.ebi.ac.uk/citexplore/
   name: CiteXplore
   prefix: citexplore
@@ -566,9 +533,6 @@ pattern:
 - homepage: https://www.ncbi.nlm.nih.gov/research/cog/pathways
   name: COG Pathways
   prefix: cog.pathway
-- homepage: https://github.com/MIT-LCP/mimic-omop
-  name: MIMIC III Database
-  prefix: cohd
 - homepage: http://www.le.ac.uk/genetics/collagen/
   name: Collagen Mutation Database
   prefix: collagenmutdb
@@ -656,9 +620,6 @@ pattern:
 - homepage: http://www.loa.istc.cnr.it/dolce/overview.html
   name: Descriptive Ontology for Linguistic and Cognitive Engineering
   prefix: dolce
-- homepage: http://purl.obolibrary.org/obo/fbcv
-  name: Drosophila Phenotype Ontology
-  prefix: dpo
 - homepage: https://phytochem.nal.usda.gov/phytochem/search/list
   name: Dr. Duke's Phytochemical and Ethnobotanical Databases chemical
   prefix: drduke
@@ -773,9 +734,6 @@ pattern:
 - homepage: https://www.geonames.org/export/codes.html
   name: GeoNames Feature Code
   prefix: geonames.feature
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Gene Expression Ontology
-  prefix: gexo
 - homepage: https://www.onto-med.de/ontologies/gfo
   name: General Formal Ontology
   prefix: gfo
@@ -842,9 +800,6 @@ pattern:
 - homepage: http://globin.cse.psu.edu/globin/hbvar
   name: A Database of Human Hemoglobin Variants and Thalassemias
   prefix: hbvar
-- homepage: https://www.humancellatlas.org
-  name: Human Cell Atlas Ontology
-  prefix: hcao
 - homepage: https://www.cms.gov/Medicare/Coding/MedHCPCSGenInfo
   name: Healthcare Common Procedure Coding System
   prefix: hcpcs
@@ -879,9 +834,6 @@ pattern:
 - homepage: https://www.imanislife.com/collections/cell-lines/
   name: Imanis Life Sciences cell line products
   prefix: imanis
-- homepage: http://www.imdrf.org/
-  name: International Medical Device Regulators Forum
-  prefix: imdrf
 - homepage: http://imgt.org/IMGTPrimerDB/
   name: IMGT/PRIMER-DB
   prefix: imgt.primerdb
@@ -1059,9 +1011,6 @@ pattern:
 - homepage: https://grants.nih.gov/stem_cells/registry/current.htm
   name: NIH Human Embryonic Stem Cell Registry
   prefix: nihhesc
-- homepage: https://webbook.nist.gov/chemistry/
-  name: NIST Chemistry WebBook
-  prefix: nist
 - homepage: http://physics.nist.gov/cuu/Constants/index.html
   name: NIST/CODATA ID
   prefix: nist.codata
@@ -1206,12 +1155,6 @@ pattern:
 - homepage: https://w3id.org/reproduceme/research
   name: REPRODUCE-ME Ontology
   prefix: reproduceme
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Regulation of Transcription Ontology
-  prefix: reto
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Regulation of Gene Expression Ontology
-  prefix: rexo
 - homepage: http://rice.plantbiology.msu.edu/
   name: Rice Genome Annotation Project
   prefix: rgap
@@ -1377,9 +1320,6 @@ pattern:
 - homepage: http://pkuxxj.pku.edu.cn/UNPD/
   name: Universal Natural Products Database
   prefix: unpd
-- homepage: https://github.com/obophenotype/upheno
-  name: Unified Phenotype Ontology
-  prefix: upheno
 - homepage: https://vocab.org/vann/
   name: A vocabulary for annotating vocabulary descriptions
   prefix: vann
@@ -1425,9 +1365,6 @@ pattern:
 - homepage: http://world-2dpage.expasy.org/repository/
   name: The World-2DPAGE database
   prefix: world2dpage
-- homepage: https://como.ceb.cam.ac.uk/preprints/223/
-  name: Computational Chemistry Ontology
-  prefix: worldavatar.compchem
 - homepage: http://www.theworldavatar.com/ontokin/
   name: Ontology for Chemical Kinetic Reaction Mechanisms
   prefix: worldavatar.kin
@@ -1473,8 +1410,6 @@ prefix_xrefs:
   name: BioPortal
 - metaprefix: cellosaurus
   name: Cellosaurus
-- metaprefix: cheminf
-  name: CHEMINF
 - metaprefix: cropoct
   name: CropOCT
 - metaprefix: ecoportal
@@ -1564,9 +1499,6 @@ wikidata:
 - homepage: http://www.affymetrix.com/
   name: Affymetrix Probeset
   prefix: affy.probeset
-- homepage: https://www.allotrope.org/
-  name: Allotrope Merged Ontology Suite
-  prefix: afo
 - homepage: https://aftol.umn.edu
   name: Assembling the Fungal Tree of Life - Category
   prefix: aftol.category
@@ -2174,9 +2106,6 @@ wikidata:
 - homepage: https://www.chictr.org.cn
   name: Chinese Clinical Trial Registry
   prefix: chictr
-- homepage: https://github.com/obophenotype/chiro
-  name: ChEBI Integrated Role Ontology
-  prefix: chiro
 - homepage: https://github.com/rsc-ontologies/rsc-cmo
   name: Chemical Methods Ontology
   prefix: chmo
@@ -2396,9 +2325,6 @@ wikidata:
 - homepage: https://www.ncbi.nlm.nih.gov/research/cog/pathways
   name: COG Pathways
   prefix: cog.pathway
-- homepage: https://github.com/MIT-LCP/mimic-omop
-  name: MIMIC III Database
-  prefix: cohd
 - homepage: https://www.checklistbank.org
   name: Catalogue of Life
   prefix: col
@@ -2792,9 +2718,6 @@ wikidata:
 - homepage: http://doqcs.ncbs.res.in/
   name: 'Database of Quantitative Cellular Signaling: Pathway'
   prefix: doqcs.pathway
-- homepage: http://purl.obolibrary.org/obo/fbcv
-  name: Drosophila Phenotype Ontology
-  prefix: dpo
 - homepage: http://www.dpvweb.net/
   name: Description of Plant Viruses
   prefix: dpv
@@ -3390,9 +3313,6 @@ wikidata:
 - homepage: https://www.geonames.org/export/codes.html
   name: GeoNames Feature Code
   prefix: geonames.feature
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Gene Expression Ontology
-  prefix: gexo
 - homepage: https://www.onto-med.de/ontologies/gfo
   name: General Formal Ontology
   prefix: gfo
@@ -3645,9 +3565,6 @@ wikidata:
 - homepage: https://health-products.canada.ca/ctdb-bdec
   name: Health Canada Clinical Trials Database
   prefix: hc.trial
-- homepage: https://www.humancellatlas.org
-  name: Human Cell Atlas Ontology
-  prefix: hcao
 - homepage: https://dbcls.rois.ac.jp/
   name: Human Chromosome Ontology
   prefix: hco
@@ -3904,9 +3821,6 @@ wikidata:
 - homepage: https://www.imanislife.com/collections/cell-lines/
   name: Imanis Life Sciences cell line products
   prefix: imanis
-- homepage: http://www.imdrf.org/
-  name: International Medical Device Regulators Forum
-  prefix: imdrf
 - homepage: https://www.imexconsortium.org/
   name: International Molecular Exchange
   prefix: imex
@@ -4810,9 +4724,6 @@ wikidata:
 - homepage: https://reporter.nih.gov/
   name: NIH RePORTER
   prefix: nihreporter.project
-- homepage: https://webbook.nist.gov/chemistry/
-  name: NIST Chemistry WebBook
-  prefix: nist
 - homepage: http://physics.nist.gov/cuu/Constants/index.html
   name: NIST/CODATA ID
   prefix: nist.codata
@@ -5644,15 +5555,9 @@ wikidata:
 - homepage: https://proteininformationresource.org/resid/
   name: Protein covalent bond
   prefix: resid
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Regulation of Transcription Ontology
-  prefix: reto
 - homepage: https://www.ebi.ac.uk/chebi/
   name: Physico-chemical process
   prefix: rex
-- homepage: http://www.semantic-systems-biology.org/apo
-  name: Regulation of Gene Expression Ontology
-  prefix: rexo
 - homepage: https://rfam.org/
   name: Rfam database of RNA families
   prefix: rfam
@@ -6391,9 +6296,6 @@ wikidata:
 - homepage: https://github.com/bio-ontology-research-group/unit-ontology
   name: Units of measurement ontology
   prefix: uo
-- homepage: https://github.com/obophenotype/upheno
-  name: Unified Phenotype Ontology
-  prefix: upheno
 - homepage: http://patft.uspto.gov/netahtml/PTO/index.html
   name: United States Patent and Trademark Office
   prefix: uspto
@@ -6578,9 +6480,6 @@ wikidata:
 - homepage: http://world-2dpage.expasy.org/repository/
   name: The World-2DPAGE database
   prefix: world2dpage
-- homepage: https://como.ceb.cam.ac.uk/preprints/223/
-  name: Computational Chemistry Ontology
-  prefix: worldavatar.compchem
 - homepage: http://www.theworldavatar.com/ontokin/
   name: Ontology for Chemical Kinetic Reaction Mechanisms
   prefix: worldavatar.kin

--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -543,7 +543,6 @@
 
     {% if resource.get_rdf_uri_format() %}
         <div class="card" style="margin-top: 20px">
-            <a id="mappings"></a>
             <h5 class="card-header">RDF Information</h5>
             <div class="card-body">
                 <p>
@@ -556,51 +555,89 @@
         </div>
     {% endif %}
 
-    {% if providers %}
+    {% if not resource.no_own_terms %}
         <div class="card" style="margin-top: 20px">
-            <a id="mappings"></a>
-            <h5 class="card-header">Providers</h5>
+            <a id="providers"></a>
+            <div class="card-header">
+                <div class="row align-items-center">
+                    <div class="col-8">
+                        <h5 style="margin: 0">Providers</h5>
+                    </div>
+                    <div class="col-4 text-right">
+                        <div class="d-flex flex-row-reverse">
+                        <a class="btn btn-sm btn-outline-dark" target="_blank"
+                           href="https://github.com/biopragmatics/bioregistry/issues/new?labels=Provider%2CNew&projects=&template=new-provider.yml&prefix={{ prefix }}&title=Add+provider+for+{{ name }}">
+                            Suggest
+                        </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="card-body">
                 <p>
-                    Providers are various services that resolve CURIEs to URLs. The example CURIE
-                    {{ utils.code_curie(resource.get_preferred_prefix() or resource.prefix, example) }} is used to demonstrate the provides available for
-                    this resource. Generation of OLS and BioPortal URLs requires additional programmatic
-                    logic beyond string formatting.
+                    A provider turns a local unique identifiers from a resource into a URI. Many providers are
+                    also resolvable as URLs (i.e., they can be used in a web browser).
                 </p>
+                <!--<ol>
+                    <li>
+                        <strong>Metaregistry Mappings</strong> When a Bioregistry prefix is mapped to an external
+                        registry that is able to resolve CURIEs, then a provider can be automatically generated.
+                        For example, this is true for Identifiers.org, Name-to-Thing, and the OBO Foundry.
+                    </li>
+                    <li>
+                        <strong>Manual Curation</strong> Additional providers can be curated to cover both
+                        resolvable URIs and semantic web-flavored URIs.
+                    </li>
+                </ol>-->
+                {% if providers %}
+                <p>
+                    The local unique identifier <code>{{ example }}</code> is used to demonstrate the providers
+                    available for {{ name }}. A guide for curating additional providers can be found
+                    <a href="https://biopragmatics.github.io/bioregistry/curation/providers">here</a>.
+                </p>
+                {% else %}
+                <p>
+                    This resource does not have any providers. Please consider contributing one after
+                    reading the
+                    <a href="https://biopragmatics.github.io/bioregistry/curation/providers">curation guide</a>.
+                </p>
+                {% endif %}
             </div>
-            {{ utils.render_provider_table(prefix=prefix, identifier=example, providers=providers) }}
+            {% if providers %}{{ utils.render_provider_table(prefix=prefix, identifier=example, providers=providers) }}{% endif %}
         </div>
-    {% endif %}
-    {% set extra_providers = resource.get_extra_providers() %}
-    {% if extra_providers %}
-        <div class="card" style="margin-top: 20px">
-            <a id="mappings"></a>
-            <h5 class="card-header">Extra Providers</h5>
-            <div class="card-body">
-                <p>
-                    Additional providers curated in the Bioregistry are listed here.
-                </p>
-            </div>
-            <table class="table table-hover table-striped">
-                <thead class="table-">
-                <tr>
-                    <th scope="col">Code</th>
-                    <th scope="col">Name</th>
-                    <th scope="col">URL</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for provider in extra_providers %}
+
+        {% set extra_providers = resource.get_extra_providers() %}
+        {% if extra_providers %}
+            <div class="card" style="margin-top: 20px">
+                <a id="mappings"></a>
+                <h5 class="card-header">Extra Providers</h5>
+                <div class="card-body">
+                    <p>
+                        Additional providers curated in the Bioregistry are listed here.
+                        These are typically inherited from Identifiers.org or Prefix Commons, and need extra curation.
+                    </p>
+                </div>
+                <table class="table table-hover table-striped">
+                    <thead class="table-">
                     <tr>
-                        <td><code>{{ provider.code }}</code></td>
-                        <td>{{ provider.name }}</td>
-                        {% set url = provider.resolve(example) %}
-                        <td><a href="{{ url }}">{{ url }}</a></td>
+                        <th scope="col">Code</th>
+                        <th scope="col">Name</th>
+                        <th scope="col">URL</th>
                     </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                    {% for provider in extra_providers %}
+                        <tr>
+                            <td><code>{{ provider.code }}</code></td>
+                            <td>{{ provider.name }}</td>
+                            {% set url = provider.resolve(example) %}
+                            <td><a href="{{ url }}">{{ url }}</a></td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
     {% endif %}
 
     {% if synonyms %}

--- a/src/bioregistry/export/warnings_export.py
+++ b/src/bioregistry/export/warnings_export.py
@@ -62,9 +62,16 @@ def export_warnings():
     # unparsable = get_unparsable_uris()
     missing_wikidata_database = _g(
         lambda prefix: get_external(prefix, "wikidata").get("database") is None
+        and not bioregistry.has_no_terms(prefix)
     )
-    missing_pattern = _g(lambda prefix: bioregistry.get_pattern(prefix) is None)
-    missing_format_url = _g(lambda prefix: bioregistry.get_uri_format(prefix) is None)
+    missing_pattern = _g(
+        lambda prefix: bioregistry.get_pattern(prefix) is None
+        and not bioregistry.has_no_terms(prefix)
+    )
+    missing_format_url = _g(
+        lambda prefix: bioregistry.get_uri_format(prefix) is None
+        and not bioregistry.has_no_terms(prefix)
+    )
     missing_example = _g(
         lambda prefix: bioregistry.get_example(prefix) is None
         and not bioregistry.has_no_terms(prefix)


### PR DESCRIPTION
1. Add suggest button to providers section
2. Add additional text and link to curation guidelines
3. Update assignees on all issue templates (remove myself - ideally, this should let you specify a team but that doesn't actually work)
4. Don't show providers box on resources with no own terms (e.g., `afo`). This is true even if a URI format exists (e.g., `chiro`)