### PR TITLE
Broken icon for BioPortal

### DIFF
--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -291,7 +291,7 @@
       },
       "homepage": "https://bioportal.bioontology.org/",
       "license": "See https://github.com/biopragmatics/bioregistry/issues/337",
-      "logo_url": "https://ontoportal.org/wp-content/uploads/2020/02/bioportal-logo.png",
+      "logo_url": "https://ontoportal.org/images/alliance_member_logos/bioportal.png",
       "name": "BioPortal Prefixes",
       "prefix": "bioportal",
       "provider_uri_format": "https://bioportal.bioontology.org/ontologies/$1",


### PR DESCRIPTION
The URL for the BioPortal's icon on bioregistry.io is broken. This PR updates it to a working one.