### PR TITLE
Bioregistry update visualization script

### DIFF
--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -1,4 +1,4 @@
-"""Module for comparing different versions of the bioregistry data and visualizing changes."""
+"""Given two dates, analyzes and visualizes changes in the Bioregistry."""
 
 import json
 import logging
@@ -25,14 +25,11 @@ def get_commit_before_date(date, owner, name, branch):
     """
     Get the commit before a given date.
 
-    Parameters:
-        date (datetime): The date to get the commit before.
-        owner (str): The repository owner.
-        name (str): The repository name.
-        branch (str): The branch name.
-
-    Returns:
-        str: The SHA of the commit before the given date, or None if no commit is found.
+    :param date: The date to get the commit before.
+    :param owner: The repository owner.
+    :param name: The repository name.
+    :param branch: The branch name.
+    :returns: The SHA of the commit before the given date, or None if no commit is found.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/commits"
     params = {"sha": branch, "until": date.isoformat()}
@@ -54,14 +51,11 @@ def get_file_at_commit(owner, name, file_path, commit_sha):
     """
     Get the file content at a specific commit.
 
-    Parameters:
-        owner (str): The repository owner.
-        name (str): The repository name.
-        file_path (str): The file path in the repository.
-        commit_sha (str): The commit SHA.
-
-    Returns:
-        dict: The file content as a dictionary.
+    :param owner: The repository owner.
+    :param name: The repository name.
+    :param file_path: The file path in the repository.
+    :param commit_sha: The commit SHA.
+    :returns: The file content as a dictionary.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/contents/{file_path}"
     params = {"ref": commit_sha}
@@ -78,12 +72,9 @@ def compare_bioregistry(old_data, new_data):
     """
     Compare two versions of the bioregistry data.
 
-    Parameters:
-        old_data (dict): The old bioregistry data.
-        new_data (dict): The new bioregistry data.
-
-    Returns:
-        tuple: Sets of added prefixes, deleted prefixes, and a count of updated prefixes, along with update details.
+    :param old_data: The old bioregistry data.
+    :param new_data: The new bioregistry data.
+    :returns: Sets of added prefixes, deleted prefixes, and a count of updated prefixes, along with update details.
     """
     old_prefixes = set(old_data.keys())
     new_prefixes = set(new_data.keys())
@@ -106,12 +97,9 @@ def compare_entries(old_entry, new_entry):
     """
     Compare individual entries for detailed changes.
 
-    Parameters:
-        old_entry (dict): The old entry data.
-        new_entry (dict): The new entry data.
-
-    Returns:
-        dict: A dictionary of changes.
+    :param old_entry: The old entry data.
+    :param new_entry: The new entry data.
+    :returns: A dictionary of changes.
     """
     changes = {}
     for key in old_entry.keys() | new_entry.keys():
@@ -124,11 +112,8 @@ def get_all_mapping_keys(data):
     """
     Get all unique mapping keys from the bioregistry data.
 
-    Parameters:
-        data (dict): The bioregistry data.
-
-    Returns:
-        set: A set of all unique mapping keys.
+    :param data: The bioregistry data.
+    :returns: A set of all unique mapping keys.
     """
     mapping_keys = set()
     for prefix in data:
@@ -141,12 +126,9 @@ def get_data(date1, date2):
     """
     Retrieve and compare bioregistry data between two dates.
 
-    Parameters:
-        date1 (str): The starting date in ISO format.
-        date2 (str): The ending date in ISO format.
-
-    Returns:
-        tuple: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
+    :param date1: The starting date in ISO format.
+    :param date2: The ending date in ISO format.
+    :returns: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
     """
     date1 = isoparse(date1).astimezone(tz.tzutc())
     date2 = isoparse(date2).astimezone(tz.tzutc())
@@ -186,37 +168,29 @@ def summarize_changes(added, deleted, updated, update_details):
     """
     Summarize changes in the bioregistry data.
 
-    Parameters:
-        added (set): Set of added prefixes.
-        deleted (set): Set of deleted prefixes.
-        updated (int): Count of updated prefixes.
-        update_details (list): List of update details.
-
-    Returns:
-        None
+    :param added: Set of added prefixes.
+    :param deleted: Set of deleted prefixes.
+    :param updated: Count of updated prefixes.
+    :param update_details: List of update details.
+    :returns: None
     """
     logger.info(f"Total Added Prefixes: {len(added)}")
     logger.info(f"Total Deleted Prefixes: {len(deleted)}")
     logger.info(f"Total Updated Prefixes: {updated}")
 
 
-def visualize_changes(
-    added, deleted, updated, update_details, start_date, end_date, all_mapping_keys
-):
+def visualize_changes(added, deleted, updated, update_details, start_date, end_date, all_mapping_keys):
     """
     Visualize changes in the bioregistry data.
 
-    Parameters:
-        added (set): Set of added prefixes.
-        deleted (set): Set of deleted prefixes.
-        updated (int): Count of updated prefixes.
-        update_details (list): List of update details.
-        start_date (str): The starting date.
-        end_date (str): The ending date.
-        all_mapping_keys (set): Set of all mapping keys.
-
-    Returns:
-        None
+    :param added: Set of added prefixes.
+    :param deleted: Set of deleted prefixes.
+    :param updated: Count of updated prefixes.
+    :param update_details: List of update details.
+    :param start_date: The starting date.
+    :param end_date: The ending date.
+    :param all_mapping_keys: Set of all mapping keys.
+    :returns: None
     """
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}
@@ -247,7 +221,7 @@ def visualize_changes(
         # Plot for main fields
         if main_fields:
             main_fields_df = pd.DataFrame(list(main_fields.items()), columns=["Field", "Count"])
-            main_fields_df = main_fields_df.sort_values(by="Count", ascending=False)
+            main_fields_df = sorted(main_fields_df.items(), key=lambda x: x[1], reverse=True)
 
             plt.figure(figsize=(15, 8))
             plt.bar(main_fields_df["Field"], main_fields_df["Count"], color="green")
@@ -261,10 +235,8 @@ def visualize_changes(
 
         # Plot for mapping fields
         if mapping_fields:
-            mapping_fields_df = pd.DataFrame(
-                list(mapping_fields.items()), columns=["Field", "Count"]
-            )
-            mapping_fields_df = mapping_fields_df.sort_values(by="Count", ascending=False)
+            mapping_fields_df = pd.DataFrame(list(mapping_fields.items()), columns=["Field", "Count"])
+            mapping_fields_df = sorted(mapping_fields_df.items(), key=lambda x: x[1], reverse=True)
 
             plt.figure(figsize=(15, 8))
             plt.bar(mapping_fields_df["Field"], mapping_fields_df["Count"], color="blue")
@@ -284,16 +256,11 @@ def final(date1, date2):
     """
     Process and visualize changes in Bioregistry data between two dates.
 
-    Parameters:
-        date1 (str): The starting date in the format YYYY-MM-DD.
-        date2 (str): The ending date in the format YYYY-MM-DD.
-
-    Returns:
-        None
+    :param date1: The starting date in the format YYYY-MM-DD.
+    :param date2: The ending date in the format YYYY-MM-DD.
+    :returns: None
     """
-    added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
-        date1, date2
-    )
+    added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(date1, date2)
     if added is not None and updated is not None:
         summarize_changes(added, deleted, updated, update_details)
         visualize_changes(added, deleted, updated, update_details, date1, date2, all_mapping_keys)

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -25,14 +25,21 @@ def get_commit_before_date(date, owner, name, branch):
     """
     Get the commit before a given date.
 
-    Parameters:
-    date (datetime): The date to get the commit before.
-    owner (str): The repository owner.
-    name (str): The repository name.
-    branch (str): The branch name.
+    Parameters
+    ----------
+    date : datetime
+        The date to get the commit before.
+    owner : str
+        The repository owner.
+    name : str
+        The repository name.
+    branch : str
+        The branch name.
 
-    Returns:
-    str: The SHA of the commit before the given date, or None if no commit is found.
+    Returns
+    -------
+    str
+        The SHA of the commit before the given date, or None if no commit is found.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/commits"
     params = {"sha": branch, "until": date.isoformat()}
@@ -55,13 +62,13 @@ def get_file_at_commit(owner, name, file_path, commit_sha):
     Get the file content at a specific commit.
 
     Parameters:
-    owner (str): The repository owner.
-    name (str): The repository name.
-    file_path (str): The file path in the repository.
-    commit_sha (str): The commit SHA.
+        owner (str): The repository owner.
+        name (str): The repository name.
+        file_path (str): The file path in the repository.
+        commit_sha (str): The commit SHA.
 
     Returns:
-    dict: The file content as a dictionary.
+        dict: The file content as a dictionary.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/contents/{file_path}"
     params = {"ref": commit_sha}
@@ -79,11 +86,11 @@ def compare_bioregistry(old_data, new_data):
     Compare two versions of the bioregistry data.
 
     Parameters:
-    old_data (dict): The old bioregistry data.
-    new_data (dict): The new bioregistry data.
+        old_data (dict): The old bioregistry data.
+        new_data (dict): The new bioregistry data.
 
     Returns:
-    tuple: Sets of added prefixes, deleted prefixes, and a count of updated prefixes, along with update details.
+        tuple: Sets of added prefixes, deleted prefixes, and a count of updated prefixes, along with update details.
     """
     old_prefixes = set(old_data.keys())
     new_prefixes = set(new_data.keys())
@@ -107,11 +114,11 @@ def compare_entries(old_entry, new_entry):
     Compare individual entries for detailed changes.
 
     Parameters:
-    old_entry (dict): The old entry data.
-    new_entry (dict): The new entry data.
+        old_entry (dict): The old entry data.
+        new_entry (dict): The new entry data.
 
     Returns:
-    dict: A dictionary of changes.
+        dict: A dictionary of changes.
     """
     changes = {}
     for key in old_entry.keys() | new_entry.keys():
@@ -125,10 +132,10 @@ def get_all_mapping_keys(data):
     Get all unique mapping keys from the bioregistry data.
 
     Parameters:
-    data (dict): The bioregistry data.
+        data (dict): The bioregistry data.
 
     Returns:
-    set: A set of all unique mapping keys.
+        set: A set of all unique mapping keys.
     """
     mapping_keys = set()
     for prefix in data:
@@ -142,11 +149,11 @@ def get_data(date1, date2):
     Retrieve and compare bioregistry data between two dates.
 
     Parameters:
-    date1 (str): The starting date in ISO format.
-    date2 (str): The ending date in ISO format.
+        date1 (str): The starting date in ISO format.
+        date2 (str): The ending date in ISO format.
 
     Returns:
-    tuple: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
+        tuple: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
     """
     date1 = isoparse(date1).astimezone(tz.tzutc())
     date2 = isoparse(date2).astimezone(tz.tzutc())
@@ -187,13 +194,13 @@ def summarize_changes(added, deleted, updated, update_details):
     Summarize changes in the bioregistry data.
 
     Parameters:
-    added (set): Set of added prefixes.
-    deleted (set): Set of deleted prefixes.
-    updated (int): Count of updated prefixes.
-    update_details (list): List of update details.
+        added (set): Set of added prefixes.
+        deleted (set): Set of deleted prefixes.
+        updated (int): Count of updated prefixes.
+        update_details (list): List of update details.
 
     Returns:
-    None
+        None
     """
     logger.info(f"Total Added Prefixes: {len(added)}")
     logger.info(f"Total Deleted Prefixes: {len(deleted)}")
@@ -207,16 +214,16 @@ def visualize_changes(
     Visualize changes in the bioregistry data.
 
     Parameters:
-    added (set): Set of added prefixes.
-    deleted (set): Set of deleted prefixes.
-    updated (int): Count of updated prefixes.
-    update_details (list): List of update details.
-    start_date (str): The starting date.
-    end_date (str): The ending date.
-    all_mapping_keys (set): Set of all mapping keys.
+        added (set): Set of added prefixes.
+        deleted (set): Set of deleted prefixes.
+        updated (int): Count of updated prefixes.
+        update_details (list): List of update details.
+        start_date (str): The starting date.
+        end_date (str): The ending date.
+        all_mapping_keys (set): Set of all mapping keys.
 
     Returns:
-    None
+        None
     """
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}
@@ -285,11 +292,11 @@ def final(date1, date2):
     Process and visualize changes in Bioregistry data between two dates.
 
     Parameters:
-    date1 (str): The starting date in the format YYYY-MM-DD.
-    date2 (str): The ending date in the format YYYY-MM-DD.
+        date1 (str): The starting date in the format YYYY-MM-DD.
+        date2 (str): The ending date in the format YYYY-MM-DD.
 
     Returns:
-    None
+        None
     """
     added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
         date1, date2

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -8,7 +8,7 @@ from dateutil import tz
 
 # Constants for the GitHub repository information and API URL
 GITHUB_API_URL = 'https://api.github.com'
-REPO_OWNER = 'tanayshah2'
+REPO_OWNER = 'biopragmatics'
 REPO_NAME = 'bioregistry'
 BRANCH = 'main'
 FILE_PATH = 'src/bioregistry/data/bioregistry.json'
@@ -66,6 +66,7 @@ def compare_bioregistry(old_data, new_data):
             changes = compare_entries(old_data[prefix], new_data[prefix])
             update_details.append((prefix, changes))
 
+    return added_prefixes, deleted_prefixes, updated_prefixes, update_details
     return added_prefixes, deleted_prefixes, updated_prefixes, update_details
 
 

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -26,13 +26,13 @@ def get_commit_before_date(date, owner, name, branch):
     Get the commit before a given date.
 
     Parameters:
-        date (datetime): The date to get the commit before.
-        owner (str): The repository owner.
-        name (str): The repository name.
-        branch (str): The branch name.
+    date (datetime): The date to get the commit before.
+    owner (str): The repository owner.
+    name (str): The repository name.
+    branch (str): The branch name.
 
     Returns:
-        str: The SHA of the commit before the given date, or None if no commit is found.
+    str: The SHA of the commit before the given date, or None if no commit is found.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/commits"
     params = {"sha": branch, "until": date.isoformat()}
@@ -55,13 +55,13 @@ def get_file_at_commit(owner, name, file_path, commit_sha):
     Get the file content at a specific commit.
 
     Parameters:
-        owner (str): The repository owner.
-        name (str): The repository name.
-        file_path (str): The file path in the repository.
-        commit_sha (str): The commit SHA.
+    owner (str): The repository owner.
+    name (str): The repository name.
+    file_path (str): The file path in the repository.
+    commit_sha (str): The commit SHA.
 
     Returns:
-        dict: The file content as a dictionary.
+    dict: The file content as a dictionary.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/contents/{file_path}"
     params = {"ref": commit_sha}
@@ -79,11 +79,11 @@ def compare_bioregistry(old_data, new_data):
     Compare two versions of the bioregistry data.
 
     Parameters:
-        old_data (dict): The old bioregistry data.
-        new_data (dict): The new bioregistry data.
+    old_data (dict): The old bioregistry data.
+    new_data (dict): The new bioregistry data.
 
     Returns:
-        tuple: Sets of added prefixes, deleted prefixes, and a count of updated prefixes, along with update details.
+    tuple: Sets of added prefixes, deleted prefixes, and a count of updated prefixes, along with update details.
     """
     old_prefixes = set(old_data.keys())
     new_prefixes = set(new_data.keys())
@@ -107,11 +107,11 @@ def compare_entries(old_entry, new_entry):
     Compare individual entries for detailed changes.
 
     Parameters:
-        old_entry (dict): The old entry data.
-        new_entry (dict): The new entry data.
+    old_entry (dict): The old entry data.
+    new_entry (dict): The new entry data.
 
     Returns:
-        dict: A dictionary of changes.
+    dict: A dictionary of changes.
     """
     changes = {}
     for key in old_entry.keys() | new_entry.keys():
@@ -125,10 +125,10 @@ def get_all_mapping_keys(data):
     Get all unique mapping keys from the bioregistry data.
 
     Parameters:
-        data (dict): The bioregistry data.
+    data (dict): The bioregistry data.
 
     Returns:
-        set: A set of all unique mapping keys.
+    set: A set of all unique mapping keys.
     """
     mapping_keys = set()
     for prefix in data:
@@ -142,11 +142,11 @@ def get_data(date1, date2):
     Retrieve and compare bioregistry data between two dates.
 
     Parameters:
-        date1 (str): The starting date in ISO format.
-        date2 (str): The ending date in ISO format.
+    date1 (str): The starting date in ISO format.
+    date2 (str): The ending date in ISO format.
 
     Returns:
-        tuple: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
+    tuple: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
     """
     date1 = isoparse(date1).astimezone(tz.tzutc())
     date2 = isoparse(date2).astimezone(tz.tzutc())
@@ -187,13 +187,13 @@ def summarize_changes(added, deleted, updated, update_details):
     Summarize changes in the bioregistry data.
 
     Parameters:
-        added (set): Set of added prefixes.
-        deleted (set): Set of deleted prefixes.
-        updated (int): Count of updated prefixes.
-        update_details (list): List of update details.
+    added (set): Set of added prefixes.
+    deleted (set): Set of deleted prefixes.
+    updated (int): Count of updated prefixes.
+    update_details (list): List of update details.
 
     Returns:
-        None
+    None
     """
     logger.info(f"Total Added Prefixes: {len(added)}")
     logger.info(f"Total Deleted Prefixes: {len(deleted)}")
@@ -207,16 +207,16 @@ def visualize_changes(
     Visualize changes in the bioregistry data.
 
     Parameters:
-        added (set): Set of added prefixes.
-        deleted (set): Set of deleted prefixes.
-        updated (int): Count of updated prefixes.
-        update_details (list): List of update details.
-        start_date (str): The starting date.
-        end_date (str): The ending date.
-        all_mapping_keys (set): Set of all mapping keys.
+    added (set): Set of added prefixes.
+    deleted (set): Set of deleted prefixes.
+    updated (int): Count of updated prefixes.
+    update_details (list): List of update details.
+    start_date (str): The starting date.
+    end_date (str): The ending date.
+    all_mapping_keys (set): Set of all mapping keys.
 
     Returns:
-        None
+    None
     """
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}
@@ -285,11 +285,11 @@ def final(date1, date2):
     Process and visualize changes in Bioregistry data between two dates.
 
     Parameters:
-        date1 (str): The starting date in the format YYYY-MM-DD.
-        date2 (str): The ending date in the format YYYY-MM-DD.
+    date1 (str): The starting date in the format YYYY-MM-DD.
+    date2 (str): The ending date in the format YYYY-MM-DD.
 
     Returns:
-        None
+    None
     """
     added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
         date1, date2

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -1,15 +1,14 @@
-"""
-Module for comparing different versions of the bioregistry data and visualizing changes.
-"""
+"""Module for comparing different versions of the bioregistry data and visualizing changes."""
 
 import json
 import logging
-import requests
+
 import click
-import pandas as pd
 import matplotlib.pyplot as plt
-from dateutil.parser import isoparse
+import pandas as pd
+import requests
 from dateutil import tz
+from dateutil.parser import isoparse
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -21,9 +21,8 @@ BRANCH = "main"
 FILE_PATH = "src/bioregistry/data/bioregistry.json"
 
 
-def get_commit_before_date(date, owner, name, branch):
-    """
-    Get the commit before a given date.
+def get_commit_before_date(date, owner=REPO_OWNER, name=REPO_NAME, branch=BRANCH):
+    """Return the last commit before a given date.
 
     :param date: The date to get the commit before.
     :param owner: The repository owner.
@@ -47,14 +46,13 @@ def get_commit_before_date(date, owner, name, branch):
     return None
 
 
-def get_file_at_commit(owner, name, file_path, commit_sha):
-    """
-    Get the file content at a specific commit.
+def get_file_at_commit(file_path, commit_sha, owner=REPO_OWNER, name=REPO_NAME):
+    """Return the content of a given file at a specific commit.
 
-    :param owner: The repository owner.
-    :param name: The repository name.
     :param file_path: The file path in the repository.
     :param commit_sha: The commit SHA.
+    :param owner: The repository owner.
+    :param name: The repository name.
     :returns: The file content as a dictionary.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/contents/{file_path}"
@@ -69,8 +67,7 @@ def get_file_at_commit(owner, name, file_path, commit_sha):
 
 
 def compare_bioregistry(old_data, new_data):
-    """
-    Compare two versions of the bioregistry data.
+    """Return comparison of two versions of the bioregistry data.
 
     :param old_data: The old bioregistry data.
     :param new_data: The new bioregistry data.
@@ -94,8 +91,7 @@ def compare_bioregistry(old_data, new_data):
 
 
 def compare_entries(old_entry, new_entry):
-    """
-    Compare individual entries for detailed changes.
+    """Return detailed changes within individual entries.
 
     :param old_entry: The old entry data.
     :param new_entry: The new entry data.
@@ -109,8 +105,7 @@ def compare_entries(old_entry, new_entry):
 
 
 def get_all_mapping_keys(data):
-    """
-    Get all unique mapping keys from the bioregistry data.
+    """Return all unique mapping keys from the bioregistry data.
 
     :param data: The bioregistry data.
     :returns: A set of all unique mapping keys.
@@ -123,8 +118,7 @@ def get_all_mapping_keys(data):
 
 
 def get_data(date1, date2):
-    """
-    Retrieve and compare bioregistry data between two dates.
+    """Retrieve and compare bioregistry data between two dates.
 
     :param date1: The starting date in ISO format.
     :param date2: The ending date in ISO format.
@@ -144,8 +138,8 @@ def get_data(date1, date2):
         logger.error(f"Couldn't find commit before {date2}")
         return None, None, None, None, None
 
-    old_bioregistry = get_file_at_commit(REPO_OWNER, REPO_NAME, FILE_PATH, old_commit)
-    new_bioregistry = get_file_at_commit(REPO_OWNER, REPO_NAME, FILE_PATH, new_commit)
+    old_bioregistry = get_file_at_commit(FILE_PATH, old_commit, REPO_OWNER, REPO_NAME)
+    new_bioregistry = get_file_at_commit(FILE_PATH, new_commit, REPO_OWNER, REPO_NAME)
 
     added, deleted, updated, update_details = compare_bioregistry(old_bioregistry, new_bioregistry)
 
@@ -165,8 +159,7 @@ def get_data(date1, date2):
 
 
 def summarize_changes(added, deleted, updated):
-    """
-    Summarize changes in the bioregistry data.
+    """Log a summary of changes in the bioregistry data.
 
     :param added: Set of added prefixes.
     :param deleted: Set of deleted prefixes.
@@ -178,8 +171,7 @@ def summarize_changes(added, deleted, updated):
 
 
 def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
-    """
-    Visualizes changes in the bioregistry data.
+    """Display plots of changes in the bioregistry data.
 
     :param update_details: List of update details.
     :param start_date: The starting date.
@@ -248,9 +240,8 @@ def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
 @click.command()
 @click.argument("date1")
 @click.argument("date2")
-def final(date1, date2):
-    """
-    Process and visualize changes in Bioregistry data between two dates.
+def compare_dates(date1, date2):
+    """Process and visualize changes in Bioregistry data between two dates.
 
     :param date1: The starting date in the format YYYY-MM-DD.
     :param date2: The ending date in the format YYYY-MM-DD.
@@ -264,4 +255,4 @@ def final(date1, date2):
 
 
 if __name__ == "__main__":
-    final()
+    compare_dates()

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -180,7 +180,7 @@ def summarize_changes(added, deleted, updated):
 def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
     """
         Visualizes changes in the bioregistry data.
-    .
+
         :param update_details: List of update details.
         :param start_date: The starting date.
         :param end_date: The ending date.
@@ -192,7 +192,7 @@ def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
 
     if update_details:
         # Process mappings fields to exclude them
-        for prefix, changes in update_details:
+        for _prefix, changes in update_details:
             for field, change in changes.items():
                 if field == "mappings":
                     mappings = change[1] if isinstance(change[1], dict) else change[0]
@@ -202,8 +202,8 @@ def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
                                 mapping_fields[mapping_key] += 1
 
         # Process other fields, excluding mappings
-        for prefix, changes in update_details:
-            for field, change in changes.items():
+        for _prefix, changes in update_details:
+            for field, _change in changes.items():
                 if field in mapping_fields or field == "mappings":
                     continue
                 if field == "contributor" or field == "contributor_extras":
@@ -255,7 +255,6 @@ def final(date1, date2):
 
     :param date1: The starting date in the format YYYY-MM-DD.
     :param date2: The ending date in the format YYYY-MM-DD.
-    :returns: None
     """
     added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
         date1, date2

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -1,5 +1,8 @@
 import requests
 import json
+import click
+import pandas as pd
+import matplotlib.pyplot as plt
 from dateutil.parser import isoparse
 from dateutil import tz
 
@@ -53,16 +56,29 @@ def compare_bioregistry(old_data, new_data):
     new_prefixes = set(new_data.keys())
 
     added_prefixes = new_prefixes - old_prefixes
+    deleted_prefixes = old_prefixes - new_prefixes
     updated_prefixes = 0
+    update_details = []
+
     for prefix in old_prefixes & new_prefixes:
         if old_data[prefix] != new_data[prefix]:
             updated_prefixes += 1
+            changes = compare_entries(old_data[prefix], new_data[prefix])
+            update_details.append((prefix, changes))
 
-    return added_prefixes, updated_prefixes
+    return added_prefixes, deleted_prefixes, updated_prefixes, update_details
 
 
-# Main function
-def main(date1, date2):
+# Function to compare individual entries for detailed changes
+def compare_entries(old_entry, new_entry):
+    changes = {}
+    for key in old_entry.keys() | new_entry.keys():
+        if old_entry.get(key) != new_entry.get(key):
+            changes[key] = (old_entry.get(key), new_entry.get(key))
+    return changes
+
+
+def get_data(date1, date2):
     date1 = isoparse(date1).astimezone(tz.tzutc())
     date2 = isoparse(date2).astimezone(tz.tzutc())
 
@@ -71,21 +87,96 @@ def main(date1, date2):
 
     if not old_commit:
         print(f"Couldn't find commit before {date1}")
-        return
+        return None, None, None, None, None
 
     if not new_commit:
         print(f"Couldn't find commit before {date2}")
-        return
+        return None, None, None, None, None
 
     old_bioregistry = get_file_at_commit(REPO_OWNER, REPO_NAME, FILE_PATH, old_commit)
     new_bioregistry = get_file_at_commit(REPO_OWNER, REPO_NAME, FILE_PATH, new_commit)
 
-    added, updated = compare_bioregistry(old_bioregistry, new_bioregistry)
+    added, deleted, updated, update_details = compare_bioregistry(old_bioregistry, new_bioregistry)
 
-    print(f"Added {len(added)} entries, updated {updated} entries")
+    return added, deleted, updated, update_details, old_bioregistry, new_bioregistry
 
+
+def summarize_changes(added, deleted, updated, update_details):
+    print(f"Total Added Prefixes: {len(added)}")
+    print(f"Total Deleted Prefixes: {len(deleted)}")
+    print(f"Total Updated Prefixes: {updated}")
+
+
+def visualize_changes(added, deleted, updated, update_details, start_date, end_date):
+    main_fields = {}
+    mapping_fields = {}
+
+    if update_details:
+        for prefix, changes in update_details:
+            for field, change in changes.items():
+                if field == "mappings":
+                    mappings = change[1] if isinstance(change[1], dict) else change[0]
+                    if mappings:
+                        for mapping_key in mappings.keys():
+                            if mapping_key in mapping_fields:
+                                mapping_fields[mapping_key] += 1
+                            else:
+                                mapping_fields[mapping_key] = 1
+                else:
+                    if field in mapping_fields:
+                        continue
+                    if field in main_fields:
+                        main_fields[field] += 1
+                    else:
+                        main_fields[field] = 1
+
+        # # Debug output for main fields and mapping fields
+        # print("\nMain Fields:")
+        # for field, count in main_fields.items():
+        #     print(f"{field}: {count}")
+        #
+        # print("\nMapping Fields:")
+        # for field, count in mapping_fields.items():
+        #     print(f"{field}: {count}")
+
+        # Plot for main fields
+        if main_fields:
+            main_fields_df = pd.DataFrame(list(main_fields.items()), columns=['Field', 'Count'])
+            main_fields_df = main_fields_df.sort_values(by='Count', ascending=False)
+
+            plt.figure(figsize=(15, 8))
+            plt.bar(main_fields_df['Field'], main_fields_df['Count'], color='green')
+            plt.title(f'Main Fields Updated from {start_date} to {end_date}')
+            plt.ylabel('Count')
+            plt.xlabel('Field')
+            plt.xticks(rotation=45, ha='right')
+            plt.grid(axis='y', linestyle='--', alpha=0.7)
+            plt.tight_layout(pad=3.0)
+            plt.show()
+
+        # Plot for mapping fields
+        if mapping_fields:
+            mapping_fields_df = pd.DataFrame(list(mapping_fields.items()), columns=['Field', 'Count'])
+            mapping_fields_df = mapping_fields_df.sort_values(by='Count', ascending=False)
+
+            plt.figure(figsize=(15, 8))
+            plt.bar(mapping_fields_df['Field'], mapping_fields_df['Count'], color='blue')
+            plt.title(f'Mapping Fields Updated from {start_date} to {end_date}')
+            plt.ylabel('Count')
+            plt.xlabel('Field')
+            plt.xticks(rotation=45, ha='right')
+            plt.grid(axis='y', linestyle='--', alpha=0.7)
+            plt.tight_layout(pad=3.0)
+            plt.show()
+
+@click.command()
+@click.argument('date1')
+@click.argument('date2')
+def final(date1, date2):
+    added, deleted, updated, update_details, old_data, new_data = get_data(date1, date2)
+    if added is not None and updated is not None:
+        summarize_changes(added, deleted, updated, update_details)
+        visualize_changes(added, deleted, updated, update_details, date1, date2)
 
 if __name__ == '__main__':
-    date1 = input("Enter the first date (YYYY-MM-DD): ")
-    date2 = input("Enter the second date (YYYY-MM-DD): ")
-    main(date1, date2)
+    final()

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -179,13 +179,12 @@ def summarize_changes(added, deleted, updated):
 
 def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
     """
-        Visualizes changes in the bioregistry data.
+    Visualizes changes in the bioregistry data.
 
-        :param update_details: List of update details.
-        :param start_date: The starting date.
-        :param end_date: The ending date.
-        :param all_mapping_keys: Set of all mapping keys.
-        :returns: None
+    :param update_details: List of update details.
+    :param start_date: The starting date.
+    :param end_date: The ending date.
+    :param all_mapping_keys: Set of all mapping keys.
     """
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -171,7 +171,6 @@ def summarize_changes(added, deleted, updated):
     :param added: Set of added prefixes.
     :param deleted: Set of deleted prefixes.
     :param updated: Count of updated prefixes.
-    :returns: None
     """
     logger.info(f"Total Added Prefixes: {len(added)}")
     logger.info(f"Total Deleted Prefixes: {len(deleted)}")
@@ -180,7 +179,7 @@ def summarize_changes(added, deleted, updated):
 
 def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
     """
-        Visualize changes in the bioregistry data.
+        Visualizes changes in the bioregistry data.
     .
         :param update_details: List of update details.
         :param start_date: The starting date.

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -1,8 +1,12 @@
-import requests
+"""
+Module for comparing different versions of the bioregistry data and visualizing changes.
+"""
+
 import json
+import logging
+import requests
 import click
 import pandas as pd
-import logging
 import matplotlib.pyplot as plt
 from dateutil.parser import isoparse
 from dateutil import tz
@@ -215,13 +219,12 @@ def visualize_changes(
     Returns:
         None
     """
-
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}
 
     if update_details:
         # Process mappings fields to exclude them
-        for changes in update_details:
+        for prefix, changes in update_details:
             for field, change in changes.items():
                 if field == "mappings":
                     mappings = change[1] if isinstance(change[1], dict) else change[0]
@@ -231,8 +234,8 @@ def visualize_changes(
                                 mapping_fields[mapping_key] += 1
 
         # Process other fields, excluding mappings
-        for changes in update_details:
-            for field in changes.items():
+        for prefix, changes in update_details:
+            for field, change in changes.items():
                 if field in mapping_fields or field == "mappings":
                     continue
                 if field == "contributor" or field == "contributor_extras":
@@ -280,7 +283,7 @@ def visualize_changes(
 @click.argument("date2")
 def final(date1, date2):
     """
-    This function processes and visualizes changes in Bioregistry data between two dates.
+    Process and visualize changes in Bioregistry data between two dates.
 
     Args:
         date1 (str): The starting date in the format YYYY-MM-DD.

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -25,7 +25,7 @@ def get_commit_before_date(date, owner, name, branch):
     """
     Get the commit before a given date.
 
-    Args:
+    Parameters:
         date (datetime): The date to get the commit before.
         owner (str): The repository owner.
         name (str): The repository name.
@@ -54,7 +54,7 @@ def get_file_at_commit(owner, name, file_path, commit_sha):
     """
     Get the file content at a specific commit.
 
-    Args:
+    Parameters:
         owner (str): The repository owner.
         name (str): The repository name.
         file_path (str): The file path in the repository.
@@ -78,7 +78,7 @@ def compare_bioregistry(old_data, new_data):
     """
     Compare two versions of the bioregistry data.
 
-    Args:
+    Parameters:
         old_data (dict): The old bioregistry data.
         new_data (dict): The new bioregistry data.
 
@@ -106,7 +106,7 @@ def compare_entries(old_entry, new_entry):
     """
     Compare individual entries for detailed changes.
 
-    Args:
+    Parameters:
         old_entry (dict): The old entry data.
         new_entry (dict): The new entry data.
 
@@ -124,7 +124,7 @@ def get_all_mapping_keys(data):
     """
     Get all unique mapping keys from the bioregistry data.
 
-    Args:
+    Parameters:
         data (dict): The bioregistry data.
 
     Returns:
@@ -141,7 +141,7 @@ def get_data(date1, date2):
     """
     Retrieve and compare bioregistry data between two dates.
 
-    Args:
+    Parameters:
         date1 (str): The starting date in ISO format.
         date2 (str): The ending date in ISO format.
 
@@ -186,7 +186,7 @@ def summarize_changes(added, deleted, updated, update_details):
     """
     Summarize changes in the bioregistry data.
 
-    Args:
+    Parameters:
         added (set): Set of added prefixes.
         deleted (set): Set of deleted prefixes.
         updated (int): Count of updated prefixes.
@@ -206,7 +206,7 @@ def visualize_changes(
     """
     Visualize changes in the bioregistry data.
 
-    Args:
+    Parameters:
         added (set): Set of added prefixes.
         deleted (set): Set of deleted prefixes.
         updated (int): Count of updated prefixes.
@@ -284,7 +284,7 @@ def final(date1, date2):
     """
     Process and visualize changes in Bioregistry data between two dates.
 
-    Args:
+    Parameters:
         date1 (str): The starting date in the format YYYY-MM-DD.
         date2 (str): The ending date in the format YYYY-MM-DD.
 

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -131,7 +131,7 @@ def visualize_changes(
 
     if update_details:
         # Process mappings fields to exclude them
-        for prefix, changes in update_details:
+        for changes in update_details:
             for field, change in changes.items():
                 if field == "mappings":
                     mappings = change[1] if isinstance(change[1], dict) else change[0]
@@ -141,8 +141,8 @@ def visualize_changes(
                                 mapping_fields[mapping_key] += 1
 
         # Process other fields, excluding mappings
-        for prefix, changes in update_details:
-            for field, change in changes.items():
+        for changes in update_details:
+            for field in changes.items():
                 # print(f"Prefix: {prefix}, Field: {field}, Change: {change}")
                 if field in mapping_fields or field == "mappings":
                     # print(f"Skipping field: {field}")
@@ -200,6 +200,16 @@ def visualize_changes(
 @click.argument("date1")
 @click.argument("date2")
 def final(date1, date2):
+    """
+        This function processes and visualizes changes in Bioregistry data between two dates.
+
+        Args:
+            date1 (str): The starting date in the format YYYY-MM-DD.
+            date2 (str): The ending date in the format YYYY-MM-DD.
+
+        Returns:
+            None
+        """
     added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
         date1, date2
     )

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -25,21 +25,14 @@ def get_commit_before_date(date, owner, name, branch):
     """
     Get the commit before a given date.
 
-    Parameters
-    ----------
-    date : datetime
-        The date to get the commit before.
-    owner : str
-        The repository owner.
-    name : str
-        The repository name.
-    branch : str
-        The branch name.
+    Parameters:
+        date (datetime): The date to get the commit before.
+        owner (str): The repository owner.
+        name (str): The repository name.
+        branch (str): The branch name.
 
-    Returns
-    -------
-    str
-        The SHA of the commit before the given date, or None if no commit is found.
+    Returns:
+        str: The SHA of the commit before the given date, or None if no commit is found.
     """
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/commits"
     params = {"sha": branch, "until": date.isoformat()}

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -164,14 +164,13 @@ def get_data(date1, date2):
     )
 
 
-def summarize_changes(added, deleted, updated, update_details):
+def summarize_changes(added, deleted, updated):
     """
     Summarize changes in the bioregistry data.
 
     :param added: Set of added prefixes.
     :param deleted: Set of deleted prefixes.
     :param updated: Count of updated prefixes.
-    :param update_details: List of update details.
     :returns: None
     """
     logger.info(f"Total Added Prefixes: {len(added)}")
@@ -179,18 +178,15 @@ def summarize_changes(added, deleted, updated, update_details):
     logger.info(f"Total Updated Prefixes: {updated}")
 
 
-def visualize_changes(added, deleted, updated, update_details, start_date, end_date, all_mapping_keys):
+def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
     """
-    Visualize changes in the bioregistry data.
-
-    :param added: Set of added prefixes.
-    :param deleted: Set of deleted prefixes.
-    :param updated: Count of updated prefixes.
-    :param update_details: List of update details.
-    :param start_date: The starting date.
-    :param end_date: The ending date.
-    :param all_mapping_keys: Set of all mapping keys.
-    :returns: None
+        Visualize changes in the bioregistry data.
+    .
+        :param update_details: List of update details.
+        :param start_date: The starting date.
+        :param end_date: The ending date.
+        :param all_mapping_keys: Set of all mapping keys.
+        :returns: None
     """
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}
@@ -221,7 +217,7 @@ def visualize_changes(added, deleted, updated, update_details, start_date, end_d
         # Plot for main fields
         if main_fields:
             main_fields_df = pd.DataFrame(list(main_fields.items()), columns=["Field", "Count"])
-            main_fields_df = sorted(main_fields_df.items(), key=lambda x: x[1], reverse=True)
+            main_fields_df = main_fields_df.sort_values(by="Count", ascending=False)
 
             plt.figure(figsize=(15, 8))
             plt.bar(main_fields_df["Field"], main_fields_df["Count"], color="green")
@@ -235,8 +231,10 @@ def visualize_changes(added, deleted, updated, update_details, start_date, end_d
 
         # Plot for mapping fields
         if mapping_fields:
-            mapping_fields_df = pd.DataFrame(list(mapping_fields.items()), columns=["Field", "Count"])
-            mapping_fields_df = sorted(mapping_fields_df.items(), key=lambda x: x[1], reverse=True)
+            mapping_fields_df = pd.DataFrame(
+                list(mapping_fields.items()), columns=["Field", "Count"]
+            )
+            mapping_fields_df = mapping_fields_df.sort_values(by="Count", ascending=False)
 
             plt.figure(figsize=(15, 8))
             plt.bar(mapping_fields_df["Field"], mapping_fields_df["Count"], color="blue")
@@ -260,10 +258,12 @@ def final(date1, date2):
     :param date2: The ending date in the format YYYY-MM-DD.
     :returns: None
     """
-    added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(date1, date2)
+    added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
+        date1, date2
+    )
     if added is not None and updated is not None:
-        summarize_changes(added, deleted, updated, update_details)
-        visualize_changes(added, deleted, updated, update_details, date1, date2, all_mapping_keys)
+        summarize_changes(added, deleted, updated)
+        visualize_changes(update_details, date1, date2, all_mapping_keys)
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -1,0 +1,91 @@
+import requests
+import json
+from dateutil.parser import isoparse
+from dateutil import tz
+
+# Constants for the GitHub repository information and API URL
+GITHUB_API_URL = 'https://api.github.com'
+REPO_OWNER = 'tanayshah2'
+REPO_NAME = 'bioregistry'
+BRANCH = 'main'
+FILE_PATH = 'src/bioregistry/data/bioregistry.json'
+
+
+# Function to get the commit before a given date
+def get_commit_before_date(date, owner, name, branch):
+    url = f"{GITHUB_API_URL}/repos/{owner}/{name}/commits"
+    params = {
+        "sha": branch,
+        "until": date.isoformat()
+    }
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    commits = response.json()
+    if commits:
+        first_commit = commits[0]
+        if "sha" in first_commit:
+            return first_commit["sha"]
+        else:
+            print("No 'sha' field found in the first commit.")
+    else:
+        print(f"No commits found before {date}")
+    return None
+
+
+# Function to get the file content at a specific commit
+def get_file_at_commit(owner, name, file_path, commit_sha):
+    url = f"{GITHUB_API_URL}/repos/{owner}/{name}/contents/{file_path}"
+    params = {
+        "ref": commit_sha
+    }
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    file_info = response.json()
+    download_url = file_info["download_url"]
+    file_content_response = requests.get(download_url)
+    file_content_response.raise_for_status()
+    return json.loads(file_content_response.text)
+
+
+# Function to compare two versions of the bioregistry data
+def compare_bioregistry(old_data, new_data):
+    old_prefixes = set(old_data.keys())
+    new_prefixes = set(new_data.keys())
+
+    added_prefixes = new_prefixes - old_prefixes
+    updated_prefixes = 0
+    for prefix in old_prefixes & new_prefixes:
+        if old_data[prefix] != new_data[prefix]:
+            updated_prefixes += 1
+
+    return added_prefixes, updated_prefixes
+
+
+# Main function
+def main(date1, date2):
+    date1 = isoparse(date1).astimezone(tz.tzutc())
+    date2 = isoparse(date2).astimezone(tz.tzutc())
+
+    old_commit = get_commit_before_date(date1, REPO_OWNER, REPO_NAME, BRANCH)
+    new_commit = get_commit_before_date(date2, REPO_OWNER, REPO_NAME, BRANCH)
+
+    if not old_commit:
+        print(f"Couldn't find commit before {date1}")
+        return
+
+    if not new_commit:
+        print(f"Couldn't find commit before {date2}")
+        return
+
+    old_bioregistry = get_file_at_commit(REPO_OWNER, REPO_NAME, FILE_PATH, old_commit)
+    new_bioregistry = get_file_at_commit(REPO_OWNER, REPO_NAME, FILE_PATH, new_commit)
+
+    added, updated = compare_bioregistry(old_bioregistry, new_bioregistry)
+
+    print(f"Added {len(added)} entries, updated {updated} entries")
+
+
+if __name__ == '__main__':
+    date1 = input("Enter the first date (YYYY-MM-DD): ")
+    date2 = input("Enter the second date (YYYY-MM-DD): ")
+    main(date1, date2)

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -7,20 +7,17 @@ from dateutil.parser import isoparse
 from dateutil import tz
 
 # Constants for the GitHub repository information and API URL
-GITHUB_API_URL = 'https://api.github.com'
-REPO_OWNER = 'biopragmatics'
-REPO_NAME = 'bioregistry'
-BRANCH = 'main'
-FILE_PATH = 'src/bioregistry/data/bioregistry.json'
+GITHUB_API_URL = "https://api.github.com"
+REPO_OWNER = "biopragmatics"
+REPO_NAME = "bioregistry"
+BRANCH = "main"
+FILE_PATH = "src/bioregistry/data/bioregistry.json"
 
 
 # Function to get the commit before a given date
 def get_commit_before_date(date, owner, name, branch):
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/commits"
-    params = {
-        "sha": branch,
-        "until": date.isoformat()
-    }
+    params = {"sha": branch, "until": date.isoformat()}
     response = requests.get(url, params=params)
     response.raise_for_status()
     commits = response.json()
@@ -38,9 +35,7 @@ def get_commit_before_date(date, owner, name, branch):
 # Function to get the file content at a specific commit
 def get_file_at_commit(owner, name, file_path, commit_sha):
     url = f"{GITHUB_API_URL}/repos/{owner}/{name}/contents/{file_path}"
-    params = {
-        "ref": commit_sha
-    }
+    params = {"ref": commit_sha}
     response = requests.get(url, params=params)
     response.raise_for_status()
     file_info = response.json()
@@ -82,8 +77,8 @@ def compare_entries(old_entry, new_entry):
 def get_all_mapping_keys(data):
     mapping_keys = set()
     for prefix in data:
-        if 'mappings' in data[prefix]:
-            mapping_keys.update(data[prefix]['mappings'].keys())
+        if "mappings" in data[prefix]:
+            mapping_keys.update(data[prefix]["mappings"].keys())
     return mapping_keys
 
 
@@ -111,7 +106,15 @@ def get_data(date1, date2):
     new_mapping_keys = get_all_mapping_keys(new_bioregistry)
     all_mapping_keys = old_mapping_keys.union(new_mapping_keys)
 
-    return added, deleted, updated, update_details, old_bioregistry, new_bioregistry, all_mapping_keys
+    return (
+        added,
+        deleted,
+        updated,
+        update_details,
+        old_bioregistry,
+        new_bioregistry,
+        all_mapping_keys,
+    )
 
 
 def summarize_changes(added, deleted, updated, update_details):
@@ -120,7 +123,9 @@ def summarize_changes(added, deleted, updated, update_details):
     print(f"Total Updated Prefixes: {updated}")
 
 
-def visualize_changes(added, deleted, updated, update_details, start_date, end_date, all_mapping_keys):
+def visualize_changes(
+    added, deleted, updated, update_details, start_date, end_date, all_mapping_keys
+):
     main_fields = {}
     mapping_fields = {key: 0 for key in all_mapping_keys}
 
@@ -160,44 +165,48 @@ def visualize_changes(added, deleted, updated, update_details, start_date, end_d
 
         # Plot for main fields
         if main_fields:
-            main_fields_df = pd.DataFrame(list(main_fields.items()), columns=['Field', 'Count'])
-            main_fields_df = main_fields_df.sort_values(by='Count', ascending=False)
+            main_fields_df = pd.DataFrame(list(main_fields.items()), columns=["Field", "Count"])
+            main_fields_df = main_fields_df.sort_values(by="Count", ascending=False)
 
             plt.figure(figsize=(15, 8))
-            plt.bar(main_fields_df['Field'], main_fields_df['Count'], color='green')
-            plt.title(f'Main Fields Updated from {start_date} to {end_date}')
-            plt.ylabel('Count')
-            plt.xlabel('Field')
-            plt.xticks(rotation=45, ha='right')
-            plt.grid(axis='y', linestyle='--', alpha=0.7)
+            plt.bar(main_fields_df["Field"], main_fields_df["Count"], color="green")
+            plt.title(f"Main Fields Updated from {start_date} to {end_date}")
+            plt.ylabel("Count")
+            plt.xlabel("Field")
+            plt.xticks(rotation=45, ha="right")
+            plt.grid(axis="y", linestyle="--", alpha=0.7)
             plt.tight_layout(pad=3.0)
             plt.show()
 
         # Plot for mapping fields
         if mapping_fields:
-            mapping_fields_df = pd.DataFrame(list(mapping_fields.items()), columns=['Field', 'Count'])
-            mapping_fields_df = mapping_fields_df.sort_values(by='Count', ascending=False)
+            mapping_fields_df = pd.DataFrame(
+                list(mapping_fields.items()), columns=["Field", "Count"]
+            )
+            mapping_fields_df = mapping_fields_df.sort_values(by="Count", ascending=False)
 
             plt.figure(figsize=(15, 8))
-            plt.bar(mapping_fields_df['Field'], mapping_fields_df['Count'], color='blue')
-            plt.title(f'Mapping Fields Updated from {start_date} to {end_date}')
-            plt.ylabel('Count')
-            plt.xlabel('Field')
-            plt.xticks(rotation=45, ha='right')
-            plt.grid(axis='y', linestyle='--', alpha=0.7)
+            plt.bar(mapping_fields_df["Field"], mapping_fields_df["Count"], color="blue")
+            plt.title(f"Mapping Fields Updated from {start_date} to {end_date}")
+            plt.ylabel("Count")
+            plt.xlabel("Field")
+            plt.xticks(rotation=45, ha="right")
+            plt.grid(axis="y", linestyle="--", alpha=0.7)
             plt.tight_layout(pad=3.0)
             plt.show()
 
 
 @click.command()
-@click.argument('date1')
-@click.argument('date2')
+@click.argument("date1")
+@click.argument("date2")
 def final(date1, date2):
-    added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(date1, date2)
+    added, deleted, updated, update_details, old_data, new_data, all_mapping_keys = get_data(
+        date1, date2
+    )
     if added is not None and updated is not None:
         summarize_changes(added, deleted, updated, update_details)
         visualize_changes(added, deleted, updated, update_details, date1, date2, all_mapping_keys)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     final()

--- a/tests/test_identifiers_org.py
+++ b/tests/test_identifiers_org.py
@@ -123,14 +123,14 @@ class TestIdentifiersOrg(unittest.TestCase):
             ("chebi", "1234", "CHEBI:1234", "test exclusion of redundant namespace (standard)"),
             (
                 "mzspec",
-                "PXD002255::ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
-                "mzspec:PXD002255::ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
+                "PXD002255:ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
+                "mzspec:PXD002255:ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
                 "test simple concatenation with false banana",
             ),
             (
                 "mzspec",
-                "mzspec:PXD002255::ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
-                "mzspec:PXD002255::ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
+                "mzspec:PXD002255:ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
+                "mzspec:PXD002255:ES_XP_Ubi_97H_HCD_349:scan:9617:LAEIYVNSSFYK/2",
                 "test simple concatenation (redundant) with false banana",
             ),
         ]:


### PR DESCRIPTION
This script visualizes updates in the Bioregistry given two dates, separating them into two bar graphs—one showing updates in main fields, and one showing updates in fields mapped to other registries.