### PR TITLE
Updated logo URLs in Metaregistry

### DIFF
--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -395,7 +395,7 @@
       },
       "homepage": "https://web.expasy.org/cellosaurus/",
       "license": "CC BY 4.0",
-      "logo_url": "https://www.cellosaurus.org/cellosaurus.png",
+      "logo_url": "https://www.cellosaurus.org/images/cellosaurus/cellosaurus.png",
       "name": "Cellosaurus Registry",
       "prefix": "cellosaurus",
       "qualities": {


### PR DESCRIPTION
This PR updates malfunctioning logo URLs in the Metaregistry to working ones.