### PR TITLE
Update omim.ps preferred prefix to OMIMPS in obo context

### DIFF
--- a/src/bioregistry/data/contexts.json
+++ b/src/bioregistry/data/contexts.json
@@ -32,10 +32,10 @@
       "ensembl": "ENSEMBL",
       "icd10": "ICD10WHO",
       "mesh": "MESH",
+      "omim.ps": "OMIMPS",
       "orphanet.ordo": "Orphanet",
       "pubmed": "PMID",
       "snomedct": "SCTID",
-      "omim.ps": "OMIMPS",
       "umls": "UMLS"
     },
     "uri_prefix_priority": [

--- a/src/bioregistry/data/contexts.json
+++ b/src/bioregistry/data/contexts.json
@@ -35,6 +35,7 @@
       "orphanet.ordo": "Orphanet",
       "pubmed": "PMID",
       "snomedct": "SCTID",
+      "omim.ps": "OMIMPS",
       "umls": "UMLS"
     },
     "uri_prefix_priority": [


### PR DESCRIPTION
Most people in the community have moved to using MIM identifiers for OMIM, which we all should. However, some of (like Mondo) have not managed to do that move yet. This change is safe for anyone using the mim strategy.

- [x] needs @anitacaron review