### PR TITLE
Remove version prefix for stato in OLS conf

### DIFF
--- a/src/bioregistry/external/ols/processing_ols.json
+++ b/src/bioregistry/external/ols/processing_ols.json
@@ -1261,8 +1261,7 @@
     },
     {
       "prefix": "stato",
-      "version_type": "semver",
-      "version_prefix": "RC"
+      "version_type": "semver"
     },
     {
       "prefix": "swo",


### PR DESCRIPTION
This PR fixes a configuration that is erroring when running update jobs which perform alignment.