### PR TITLE
Implement object model for provider publications

### DIFF
--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -246,7 +246,7 @@ class Provider(BaseModel):
     )
     publications: Optional[List["Publication"]] = Field(
         default=None,
-        description="A list of publications about the provider",
+        description="A list of publications about the provider. See the `indra` provider for `hgnc` for an example.",
     )
 
     def resolve(self, identifier: str) -> str:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1307,10 +1307,8 @@ class Resource(BaseModel):
         if self.uniprot:
             for publication in self.uniprot.get("publications", []):
                 publications.append(Publication.parse_obj(publication))
-        if self.providers:
-            for provider in self.providers:
-                if provider.publications:
-                    publications += provider.publications
+        for provider in self.providers or []:
+            publications.extend(provider.publications or [])
         return deduplicate_publications(publications)
 
     def get_mastodon(self) -> Optional[str]:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -291,6 +291,13 @@ class Publication(BaseModel):
                 return f"https://bioregistry.io/{prefix}:{identifier}"
         raise ValueError("no fields were full")
 
+    def _matches_any_field(self, other: "Publication") -> bool:
+        return (
+            (self.pubmed is not None and self.pubmed == other.pubmed)
+            or (self.doi is not None and self.doi == other.doi)
+            or (self.pmc is not None and self.pmc == other.pmc)
+        )
+
 
 class Resource(BaseModel):
     """Metadata about an ontology, database, or other resource."""

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -244,6 +244,10 @@ class Provider(BaseModel):
     first_party: Optional[bool] = Field(
         None, description="Annotates whether a provider is from the first-party organization"
     )
+    publications: Optional[List["Publication"]] = Field(
+        default=None,
+        description="A list of publications about the provider",
+    )
 
     def resolve(self, identifier: str) -> str:
         """Resolve the identifier into a URI.
@@ -1296,6 +1300,10 @@ class Resource(BaseModel):
         if self.uniprot:
             for publication in self.uniprot.get("publications", []):
                 publications.append(Publication.parse_obj(publication))
+        if self.providers:
+            for provider in self.providers:
+                if provider.publications:
+                    publications += provider.publications
         return deduplicate_publications(publications)
 
     def get_mastodon(self) -> Optional[str]:


### PR DESCRIPTION
This PR allows publications to be added to providers of a prefix. This is useful since provider-specific publications don't have a natural alternative place to be curated. Fixes #1207.