### PR TITLE
Add publication for `sgd` and `sgd.pathways`

### DIFF
--- a/docs/guides/publications.md
+++ b/docs/guides/publications.md
@@ -63,6 +63,15 @@ What else is good to keep track of in the references list:
 3. Links to discussions on Slack or other platforms (keeping in mind links might not last forever)
 4. Any other context that's useful for a Bioregistry reader
 
+## Publications for Databases
+
+A single database can correspond to several Bioregistry prefixes, such as in the case of KEGG,
+ChEMBL, and even smaller resources like HGNC, which has both a gene vocabulary ([`hgnc`](https://bioregistry.io/hgnc])
+and gene group vocabulary ([`hgnc.genegroup`](https://bioregistry.io/hgnc.genegroup)).
+
+Publications are often made on the database level, so, therefore, if you want to curate a publication for the database,
+it usually makes sense to duplicate the publication into each prefix.
+
 ## Why Should I Curate Publications and References?
 
 1. They give additional context for Bioregistry readers who want to know more about the paper

--- a/docs/guides/publications.md
+++ b/docs/guides/publications.md
@@ -72,6 +72,10 @@ and gene group vocabulary ([`hgnc.genegroup`](https://bioregistry.io/hgnc.genegr
 Publications are often made on the database level, so, therefore, if you want to curate a publication for the database,
 it usually makes sense to duplicate the publication into each prefix.
 
+However, it's also possible that a long-standing database might have more generic publications describing the whole
+database, and specific publications describing a certain aspect. If one of the specific publications only corresponds
+to a single prefix, then use your best judgement to not duplicate it unnecessarily.
+
 ## Why Should I Curate Publications and References?
 
 1. They give additional context for Bioregistry readers who want to know more about the paper


### PR DESCRIPTION
This PR adds publication [pubmed:39345624](https://bioregistry.io/pubmed:39345624) to `sgd`.

Unsure whether this should also be included under the publications for `sgd.pathways`.