### PR TITLE
Add pandas as web dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ web = [
     "markdown",
     "curies[fastapi]",
     "a2wsgi",
+    "pandas",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ web = [
     "markdown",
     "curies[fastapi]",
     "a2wsgi",
-    "pandas",
 ]
 
 

--- a/src/bioregistry/lint.py
+++ b/src/bioregistry/lint.py
@@ -1,7 +1,6 @@
 """Linting functions."""
 
 import click
-import pandas as pd
 
 from bioregistry.constants import CURATED_PAPERS_PATH
 from bioregistry.schema import Publication
@@ -36,6 +35,9 @@ def lint():
         read_contexts,
     ):
         read_resource_func.cache_clear()
+    # Import here to avoid dependency in the context of
+    # web app / Docker
+    import pandas as pd
 
     registry = read_registry()
     for resource in registry.values():


### PR DESCRIPTION
Fixes #1234. More generally, since the web app imports from the cli which in turn imports the linting code, dependencies for linting need to be available in the Docker.