### PR TITLE
Add `not_notable` to CurationRelevance vocabulary for semi-automated curation workflow

### DIFF
--- a/src/bioregistry/curation/literature.py
+++ b/src/bioregistry/curation/literature.py
@@ -37,3 +37,5 @@ class CurationRelevance(str, enum.Enum):
     unclear = enum.auto()
     #: Completely unrelated information
     irrelevant_other = enum.auto()
+    #: Relevant for training purposes, but not curated in Bioregistry due to poor/unknown quality
+    not_notable = enum.auto()


### PR DESCRIPTION
This pull request adds the `not_notable` tag to the CurationRelevance vocabulary as a way to mark papers that are relevant for machine learning training but do not meet the threshold for inclusion in the Bioregistry.

While curating papers, there have been a few instances of entries that provide new identifier information but aren't notable enough, or well-maintained enough for inclusion in the bioregistry (https://github.com/biopragmatics/bioregistry/pull/1225). Rather than curating these as subpar prefixes, tagging them as `not_notable` allows us to retain them as positive training samples without cluttering the bioregistry with less impactful entries.