### PR TITLE
Data updates for obo-db-ingest

### DIFF
--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -130,6 +130,8 @@ MIRIAM_BLACKLIST = {
     "pid.pathway",
     # this uses namespace-in-namespace
     "neurolex",
+    # Miriam needs to be extended
+    "ccds",
 }
 IDENTIFIERS_ORG_URL_PREFIX = "https://identifiers.org/"
 


### PR DESCRIPTION
This PR makes several minor updates to support making a new output of https://github.com/biopragmatics/obo-db-ingest

1. Extend CDDS pattern to allow for unversioned records (i.e., not ending with `\.\d+`
2. Extend COSMIC pattern to allow for dashes
3. Add ability to encode 3.4.24.B15 in EC (see https://www.brenda-enzymes.org/enzyme.php?ecno=3.4.24.B15)
4. Add second letter in MEROPS entry so XM02.001 can be encoded (the M was the issue). This appears in HGNC gene cross-references.