### PR TITLE
Remove incorrect `mro` mapping

### DIFF
--- a/src/bioregistry/data/mismatch.json
+++ b/src/bioregistry/data/mismatch.json
@@ -139,6 +139,9 @@
     "bartoc": "20333",
     "lov": "mod"
   },
+  "mro": {
+    "bioportal": "MRO"
+  },
   "ncbitaxon": {
     "lov": "taxon",
     "prefixcommons": "uniprot.taxonomy"


### PR DESCRIPTION
I randomly noticed an incorrect mapping to the `mro` prefix from an identically named entry in Bioportal which is actually something unrelated. This PR removes this mapping.