### PR TITLE
Add new publication for intact and intact.molecule

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -53,3 +53,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39341795	1	0009-0009-5240-7463	2024-10-19	new_prefix	1223	Identifiers for non-coding RNA biomarkers for cancers
 39341994	0	0009-0009-5240-7463	2024-10-15	not_identifiers_resource	1223	
 39345624	1	0009-0009-5240-7463	2024-10-19	new_publication	1223	Publication for sgd and sgd.pathways
+39401100	1	0009-0009-5240-7463	2024-11-20	new_publication	1264	Publication for intact and intact.molecule


### PR DESCRIPTION
This pull request curates a new publication for 2 existing prefixes in the bioregistry: `intact` and `intact.molecule`. 

This is based on the following PubMed paper:
https://pubmed.ncbi.nlm.nih.gov/39401100/