### PR TITLE
Add prefixes: synbip.*

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -54,3 +54,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39341994	0	0009-0009-5240-7463	2024-10-15	not_identifiers_resource	1223	
 39345624	1	0009-0009-5240-7463	2024-10-19	new_publication	1223	Publication for sgd and sgd.pathways
 39401100	1	0009-0009-5240-7463	2024-11-20	new_publication	1264	Publication for intact and intact.molecule
+39413165	1	0009-0009-5240-7463	2024-11-20	new_prefix	1268	Identifiers for synthetic binding proteins


### PR DESCRIPTION
This pull request introduces four new prefixes for the Synthetic Binding Protein Database (SYNBIP):
PubMed paper: https://pubmed.ncbi.nlm.nih.gov/39413165/
Database: https://idrblab.org/synbip/

- `synbip.sbp`: IDs for the synthetic binding proteins (SBPs)
-  `synbip.bts`: IDs for the binding targets of SBPs
- `synbip.pss`: IDs for the proteins scaffolds of SBPs
- `synbip.epitope`: IDs for the SBP-target complex interactions