### PR TITLE
Add rule to drop erroneous cellosaurus based redirects

### DIFF
--- a/src/bioregistry/external/alignment_utils.py
+++ b/src/bioregistry/external/alignment_utils.py
@@ -187,7 +187,7 @@ class Aligner:
     def cli(cls):
         """Construct a CLI for the aligner."""
 
-        @click.command()
+        @click.command(help=f"Align {cls.key}")
         @click.option("--dry", is_flag=True, help="if set, don't write changes to the registry")
         @click.option("--show", is_flag=True, help="if set, print a curation table")
         @click.option(

--- a/src/bioregistry/external/cellosaurus/__init__.py
+++ b/src/bioregistry/external/cellosaurus/__init__.py
@@ -6,7 +6,7 @@ import itertools as itt
 import json
 import logging
 from pathlib import Path
-from typing import Mapping
+from typing import Dict, Mapping
 
 from pystow.utils import download
 
@@ -52,7 +52,7 @@ def get_cellosaurus(force_download: bool = False, keep_missing_uri: bool = True)
     for cond, slines in itt.groupby(lines, lambda line: line == "//"):
         if cond:
             continue
-        d = {}
+        d: Dict[str, str] = {}
         for line in slines:
             if line[6] != ":":  # strip notes out
                 continue
@@ -75,7 +75,7 @@ def get_cellosaurus(force_download: bool = False, keep_missing_uri: bool = True)
     return rv
 
 
-def _process_db_url(key: str, value: str) -> str | None:
+def _process_db_url(key, value):
     if value in {"https://%s", "None"}:
         return
     if value.endswith("http://purl.obolibrary.org/obo/%s"):
@@ -84,7 +84,7 @@ def _process_db_url(key: str, value: str) -> str | None:
             "See discussion at https://github.com/biopragmatics/bioregistry/issues/1259.",
             key,
         )
-        return None
+        return
     return value.rstrip("/").replace("%s", "$1")
 
 

--- a/src/bioregistry/external/cellosaurus/__init__.py
+++ b/src/bioregistry/external/cellosaurus/__init__.py
@@ -79,7 +79,7 @@ def _process_db_url(key: str, value: str) -> str | None:
     if value in {"https://%s", "None"}:
         return
     if value.endswith("http://purl.obolibrary.org/obo/%s"):
-        logger.warning(
+        logger.debug(
             "Cellosaurus curated an OBO PURL for `%s` that is is missing namespace. "
             "See discussion at https://github.com/biopragmatics/bioregistry/issues/1259.",
             key,

--- a/src/bioregistry/external/cellosaurus/__init__.py
+++ b/src/bioregistry/external/cellosaurus/__init__.py
@@ -75,6 +75,8 @@ def get_cellosaurus(force_download: bool = False, keep_missing_uri: bool = True)
 def _process_db_url(value):
     if value in {"https://%s", "None"}:
         return
+    if re.match(r"^https://www\.ebi\.ac\.uk/ols4/ontologies/[a-z]+/classes\?iri=http://purl\.obolibrary\.org/obo/$", value):
+        return
     return value.rstrip("/").replace("%s", "$1")
 
 

--- a/src/bioregistry/external/cellosaurus/processed.json
+++ b/src/bioregistry/external/cellosaurus/processed.json
@@ -50,8 +50,7 @@
   "BCGO": {
     "category": "Anatomy/cell type resources",
     "homepage": "https://github.com/obi-bcgo/bcgo",
-    "name": "Beta Cell Genomics Ontology",
-    "uri_format": "http://www.ontobee.org/ontology/BCGO?iri=http://purl.obolibrary.org/obo/$1"
+    "name": "Beta Cell Genomics Ontology"
   },
   "BCRC": {
     "category": "Cell line collections (Providers)",
@@ -131,8 +130,7 @@
   "CL": {
     "category": "Anatomy/cell type resources",
     "homepage": "https://obophenotype.github.io/cell-ontology/",
-    "name": "Cell Ontology",
-    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/cl/classes?iri=http://purl.obolibrary.org/obo/$1"
+    "name": "Cell Ontology"
   },
   "CLDB": {
     "category": "Cell line databases/resources",
@@ -143,8 +141,7 @@
   "CLO": {
     "category": "Cell line databases/resources",
     "homepage": "http://www.clo-ontology.org",
-    "name": "Cell Line Ontology",
-    "uri_format": "https://www.ebi.ac.uk/ols4/ontologies/clo/classes?iri=http://purl.obolibrary.org/obo/$1"
+    "name": "Cell Line Ontology"
   },
   "CLS": {
     "category": "Cell line collections (Providers)",


### PR DESCRIPTION
Closes #1259

Cellsaurus contains a number of wrong redirects that could be fixed this way..

Test with:

```console
$ python -m bioregistry.external.cellosaurus.__init__
Cellosaurus curated an OBO PURL for `BCGO` that is is missing namespace. See discussion at https://github.com/biopragmatics/bioregistry/issues/1259.                                                                                        
Cellosaurus curated an OBO PURL for `CL` that is is missing namespace. See discussion at https://github.com/biopragmatics/bioregistry/issues/1259.
Cellosaurus curated an OBO PURL for `CLO` that is is missing namespace. See discussion at https://github.com/biopragmatics/bioregistry/issues/1259.

$ bioregistry export
```