### PR TITLE
Add new provider for uniprot: oglcnac

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -53,4 +53,5 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39341795	1	0009-0009-5240-7463	2024-10-19	new_prefix	1223	Identifiers for non-coding RNA biomarkers for cancers
 39341994	0	0009-0009-5240-7463	2024-10-15	not_identifiers_resource	1223	
 39345624	1	0009-0009-5240-7463	2024-10-19	new_publication	1223	Publication for sgd and sgd.pathways
+39379619	1	0009-0009-5240-7463	2024-11-26	new_provider	1285	Provider for UniProt
 39401100	1	0009-0009-5240-7463	2024-11-20	new_publication	1264	Publication for intact and intact.molecule


### PR DESCRIPTION
This pull request curates a new provider for UniProt: `oglcnac`.

PubMed: https://pubmed.ncbi.nlm.nih.gov/39379619/
Database: https://www.oglcnac.mcw.edu/