### PR TITLE
Update paper_ranking workflow

### DIFF
--- a/.github/workflows/paper_ranking.yml
+++ b/.github/workflows/paper_ranking.yml
@@ -30,6 +30,10 @@ jobs:
         start_date=$(date -d "$end_date - 30 days" +'%Y-%m-%d')
         echo "START_DATE=$start_date" >> $GITHUB_ENV
         echo "END_DATE=$end_date" >> $GITHUB_ENV
+    
+    - name: Export Python Path
+      run: |
+        export PYTHONPATH=$PYTHONPATH:$(pwd)/src
 
     - name: Run Paper Ranking Script
       id: run-ranking-script

--- a/.github/workflows/paper_ranking.yml
+++ b/.github/workflows/paper_ranking.yml
@@ -31,13 +31,14 @@ jobs:
         echo "START_DATE=$start_date" >> $GITHUB_ENV
         echo "END_DATE=$end_date" >> $GITHUB_ENV
     
-    - name: Export Python Path
+    - name: Set PYTHONPATH
       run: |
-        export PYTHONPATH=$PYTHONPATH:$(pwd)/src
+        echo "PYTHONPATH=$PWD/src" >> $GITHUB_ENV
 
     - name: Run Paper Ranking Script
       id: run-ranking-script
       run: |
+        echo "PYTHONPATH=$PYTHONPATH"  # Verify PYTHONPATH
         python src/bioregistry/analysis/paper_ranking.py --start-date ${{ env.START_DATE }} --end-date ${{ env.END_DATE }}
 
     - name: Upload Full List as Artifact

--- a/src/bioregistry/analysis/paper_ranking.py
+++ b/src/bioregistry/analysis/paper_ranking.py
@@ -298,7 +298,7 @@ def _first_of_month() -> str:
     "--end-date",
     required=True,
     help="End date of the period",
-    default=lambda x: datetime.date.today().isoformat(),
+    default=datetime.date.today().isoformat(),
 )
 def main(bioregistry_file: Path, start_date: str, end_date: str) -> None:
     """Load data, train classifiers, evaluate models, and predict new data.

--- a/src/bioregistry/analysis/paper_ranking_requirements.txt
+++ b/src/bioregistry/analysis/paper_ranking_requirements.txt
@@ -1,4 +1,5 @@
 click
+curies
 indra
 pandas
 scikit-learn


### PR DESCRIPTION
This pull request addresses the issue where the most recent iteration of the 'paper ranking workflow' failed due to the `bioregistry` module not being found.

Log details: https://github.com/biopragmatics/bioregistry/actions/runs/12101327040/job/33741034641

I made the following changes to address this issue (and a couple other issues):
- Updated `paper_ranking.yml` to ensure that the PYTHONPATH is properly set, pointing to the `src` directory.
- Added `curies` to `paper_ranking_requirements.txt`
- Removed unnecessary lambda function

I confirmed that these changes successfully run the pipeline and update the corresponding issue without error in my forked repository.