### PR TITLE
Add new publication for refseq

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -58,3 +58,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39413165	1	0009-0009-5240-7463	2024-11-20	new_prefix	1268	Identifiers for synthetic binding proteins
 39470701	1	0009-0009-5240-7463	2024-11-26	new_publication	1286	Publication for mobidb
 39498478	1	0009-0009-5240-7463	2024-11-25	new_publication	1283	Publication for gold
+39526381	1	0009-0009-5240-7463	2024-12-01	new_publication	1290	Publication for refseq


### PR DESCRIPTION
This pull request curates a new publication for the `refseq` prefix.

PubMed: https://pubmed.ncbi.nlm.nih.gov/39526381/