### PR TITLE
Curate new publications in Bioregistry

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -60,3 +60,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39498478	1	0009-0009-5240-7463	2024-11-25	new_publication	1283	Publication for gold
 39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1291	Publication for UniProt
 39574417	1	0009-0009-5240-7463	2024-12-05	new_publication	1291	Publication for BindingDB
+39565202	1	0009-0009-5240-7463	2024-12-05	new_publication	1291	Publication for InterPro

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -69,8 +69,8 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39493756	0	0009-0009-5240-7463	2024-11-25	not_identifiers_resource	1288	
 39494269	0	0009-0009-5240-7463	2024-11-25	irrelevant_other	1288	
 39498478	1	0009-0009-5240-7463	2024-11-25	new_publication	1283	Publication for gold
+39498484	1	0009-0009-5240-7463	2024-11-27	unclear	1288	Provider for ensembl IDs, issue with curation due to multiple URI formats. Similar case: (PMID: 39104285)
+39526381	1	0009-0009-5240-7463	2024-12-01	new_publication	1290	Publication for refseq
 39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1292	Publication for UniProt
 39565202	1	0009-0009-5240-7463	2024-12-05	new_publication	1292	Publication for InterPro
 39574417	1	0009-0009-5240-7463	2024-12-05	new_publication	1292	Publication for BindingDB
-39498484	1	0009-0009-5240-7463	2024-11-27	unclear	1288	Provider for ensembl IDs, issue with curation due to multiple URI formats. Similar case: (PMID: 39104285)
-39526381	1	0009-0009-5240-7463	2024-12-01	new_publication	1290	Publication for refseq

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -58,3 +58,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39413165	1	0009-0009-5240-7463	2024-11-20	new_prefix	1268	Identifiers for synthetic binding proteins
 39470701	1	0009-0009-5240-7463	2024-11-26	new_publication	1286	Publication for mobidb
 39498478	1	0009-0009-5240-7463	2024-11-25	new_publication	1283	Publication for gold
+39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1291	Publication for UniProt

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -59,3 +59,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39470701	1	0009-0009-5240-7463	2024-11-26	new_publication	1286	Publication for mobidb
 39498478	1	0009-0009-5240-7463	2024-11-25	new_publication	1283	Publication for gold
 39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1291	Publication for UniProt
+39574417	1	0009-0009-5240-7463	2024-12-05	new_publication	1291	Publication for BindingDB

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -58,6 +58,6 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39413165	1	0009-0009-5240-7463	2024-11-20	new_prefix	1268	Identifiers for synthetic binding proteins
 39470701	1	0009-0009-5240-7463	2024-11-26	new_publication	1286	Publication for mobidb
 39498478	1	0009-0009-5240-7463	2024-11-25	new_publication	1283	Publication for gold
-39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1291	Publication for UniProt
-39574417	1	0009-0009-5240-7463	2024-12-05	new_publication	1291	Publication for BindingDB
-39565202	1	0009-0009-5240-7463	2024-12-05	new_publication	1291	Publication for InterPro
+39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1292	Publication for UniProt
+39565202	1	0009-0009-5240-7463	2024-12-05	new_publication	1292	Publication for InterPro
+39574417	1	0009-0009-5240-7463	2024-12-05	new_publication	1292	Publication for BindingDB


### PR DESCRIPTION
This pull request curates 3 new publications for different prefixes.

prefix: `bindingdb`
PubMed: https://pubmed.ncbi.nlm.nih.gov/39574417/

prefix: `interpro`
PubMed: https://pubmed.ncbi.nlm.nih.gov/39565202/

prefix: `uniprot`
PubMed: https://pubmed.ncbi.nlm.nih.gov/39552041/