### PR TITLE
Add .well-known route for FLOSS/fund

### DIFF
--- a/src/bioregistry/app/static/funding-manifest-urls.txt
+++ b/src/bioregistry/app/static/funding-manifest-urls.txt
@@ -1,0 +1,1 @@
+https://cthoyt.com/funding.json

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -597,6 +597,12 @@ def usage():
     return render_template("meta/access.html", resource=resource)
 
 
+@ui_blueprint.route("/.well-known/funding-manifest-urls")
+def funding_manifest_urls():
+    """Render the FLOSS Fund page, described by https://floss.fund/funding-manifest/."""
+    return current_app.send_static_file("funding-manifest-urls.txt")
+
+
 @ui_blueprint.route("/schema/")
 def schema():
     """Render the Bioregistry RDF schema."""


### PR DESCRIPTION
This adds the ability for external `funding.json` files to point to the Bioregistry, as described in https://floss.fund/funding-manifest/