### PR TITLE
Update corum

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -79,6 +79,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39526195	0	0009-0009-5240-7463	2024-12-05	irrelevant_other	1296	
 39526373	1	0009-0009-5240-7463	2024-12-04	new_publication	1296	This is a publication for ncbi generally, does not fit well into any existing prefix
 39526381	1	0009-0009-5240-7463	2024-12-01	new_publication	1290	Publication for refseq
+39526397	1	0009-0009-5240-7463	2024-12-16	new_publication	1334	Publication for corum
 39535874	1	0009-0009-5240-7463	2024-12-05	not_notable	1296	This database website is very low quality and fails to resolve many of its own IDs
 39540856	0	0009-0009-5240-7463	2024-12-05	no_website	1296	
 39546404	0	0009-0009-5240-7463	2024-12-05	not_identifiers_resource	1296	


### PR DESCRIPTION
PubMed: https://pubmed.ncbi.nlm.nih.gov/39526397/

This pull request curates a new publication for the `corum` prefix. It also updates the homepage and uri_format keys since the the current homepage and resolver links are being borrowed from the `miriam` mapping which is outdated. The old homepage link leads to a 404 error and the old uri_format takes you to the current homepage. 

old homepage: https://mips.helmholtz-muenchen.de/genre/proj/corum
new homepage: https://mips.helmholtz-muenchen.de/corum

old uri_format with example identifier: https://mips.helmholtz-muenchen.de/corum/?id=100
new uri_format with example identifier: https://mips.helmholtz-muenchen.de/corum/?complex_id=100