### PR TITLE
Update pyproject.toml with defusedxml in web

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ web = [
     "markdown",
     "curies[fastapi]",
     "a2wsgi",
+    "defusedxml",
 ]
 
 


### PR DESCRIPTION
This PR adds defusedxml as a dependency in `web` to avoid `ModuleNotFoundError` on startup.

Closes #1336.