### PR TITLE
Various updates to ICD 11 prefix record

### DIFF
--- a/exports/alignment/biolink.tsv
+++ b/exports/alignment/biolink.tsv
@@ -7,7 +7,6 @@ DOID-PROPERTY	http://purl.obolibrary.org/obo/doid#$1	False	True
 gff3	https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md#$1	False	False
 GOP	http://purl.obolibrary.org/obo/go#$1	False	True
 gtpo	https://rdf.guidetopharmacology.org/ns/gtpo#$1	False	False
-icd11.foundation	http://id.who.int/icd/entity/$1	False	False
 NBO-PROPERTY	http://purl.obolibrary.org/obo/nbo#$1	False	True
 NCIT-OBO	http://purl.obolibrary.org/obo/ncit#$1	False	True
 PHARMGKB.VARIANT	https://www.pharmgkb.org/variant/$1	False	False

--- a/src/bioregistry/data/contexts.json
+++ b/src/bioregistry/data/contexts.json
@@ -31,6 +31,7 @@
     "prefix_remapping": {
       "ensembl": "ENSEMBL",
       "icd10": "ICD10WHO",
+      "icd11": "icd11.foundation",
       "mesh": "MESH",
       "omim.ps": "OMIMPS",
       "orphanet.ordo": "Orphanet",


### PR DESCRIPTION
I want to say that this is a compromise I can just tolerate, but I don't really like it. The choice of having `icd11`, `ICD-11` and `ICD11` be associated with the foundation component strikes me as questionable (but I also don't know _for sure_ if this is wrong, else I would insist). What I really do not like is to have `icd11` being the default prefix for the icd11 foundation, rather than the much less ambiguous `icd11.foundation`.

I would say, lets not do any more damage now, this PR will satisfy our immediate needs, but IMO we should just have the icd11 team itself decide what they want. I know them all quite well, and will reach out now to see what they say.