### PR TITLE
Update CurationRelevance vocabulary

### DIFF
--- a/docs/guides/literature_curation.md
+++ b/docs/guides/literature_curation.md
@@ -44,17 +44,17 @@ a paper, curators should update the TSV file with the following information:
 This table of `relevancy_type` tags is continuously evolving as new papers are
 evaluated and is subject to change in the future.
 
-| Key                      | Definition                                                                                 |
-| ------------------------ | ------------------------------------------------------------------------------------------ |
-| new_prefix               | A resource for new primary identifiers                                                     |
-| new_provider             | A resolver for existing identifiers                                                        |
-| new_publication          | A new publication for an existing prefix                                                   |
-| not_identifiers_resource | A database, but not for identifier information                                             |
-| no_website               | Paper suggestive of a new database, but no link to website provided                        |
-| existing                 | An existing entry in the bioregistry                                                       |
-| unclear                  | Not clear how to curate in the bioregistry, follow up discussion required                  |
-| irrelevant_other         | Completely unrelated information                                                           |
-| not_notable              | Relevant for training purposes, but not curated in Bioregistry due to poor/unknown quality |
+| Key                      | Definition                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| new_prefix               | A resource for new primary identifiers                                                                       |
+| new_provider             | A resolver for existing identifiers                                                                          |
+| new_publication          | A new publication for an existing prefix                                                                     |
+| not_identifiers_resource | Papers linking to external non-identifier resources such as software repositories, visualization tools, etc. |
+| non_resource_paper       | Self-contained papers that do not link to any external resources                                             |
+| existing                 | An existing entry in the bioregistry                                                                         |
+| unclear                  | Not clear how to curate in the bioregistry, follow up discussion required                                    |
+| irrelevant_other         | Completely unrelated information                                                                             |
+| not_notable              | Relevant for training purposes, but not curated in Bioregistry due to poor/unknown quality                   |
 
 ## Common Mistakes
 

--- a/src/bioregistry/curation/literature.py
+++ b/src/bioregistry/curation/literature.py
@@ -27,10 +27,10 @@ class CurationRelevance(str, enum.Enum):
     new_provider = enum.auto()
     #: A new publication for an existing prefix
     new_publication = enum.auto()
-    #: A database, but not for identifier information
+    #: Papers linking to external non-identifier resources such as software repositories, visualization tools, etc.
     not_identifiers_resource = enum.auto()
-    #: Paper suggestive of a new database, but no link to website provided
-    no_website = enum.auto()
+    #: Self-contained papers that do not link to any external resources
+    non_resource_paper = enum.auto()
     #: An existing entry in the bioregistry
     existing = enum.auto()
     #: Not clear how to curate in the bioregistry, follow up discussion required

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -3,7 +3,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 38991851	1	0009-0009-5240-7463	2024-09-28	unclear	1193	identifiers for sharing, retrieving, and validating sample metadata. Unclear if this should be curated as a prefix, provider or a separate registry
 39005357	0	0009-0009-5240-7463	2024-10-05	irrelevant_other	1193	
 39010878	0	0009-0009-5240-7463	2024-10-05	irrelevant_other	1193	
-39014503	0	0009-0009-5240-7463	2024-09-25	no_website	1193	
+39014503	0	0009-0009-5240-7463	2024-09-25	non_resource_paper	1193	
 39024225	0	0009-0009-5240-7463	2024-10-15	irrelevant_other	1223	
 39028894	0	0009-0009-5240-7463	2024-10-04	not_identifiers_resource	1193	
 39038934	0	0009-0009-5240-7463	2024-11-30	not_identifiers_resource	1296	
@@ -34,7 +34,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39163546	1	0009-0009-5240-7463	2024-10-08	new_prefix	1223	Identifiers for genetically engineered mouse models
 39171834	0	0009-0009-5240-7463	2024-10-14	irrelevant_other	1223	
 39174566	0	0009-0009-5240-7463	2024-10-14	irrelevant_other	1223	
-39176907	0	0009-0009-5240-7463	2024-10-16	no_website	1223	Paper talks about creation of new identifiers but no website available
+39176907	0	0009-0009-5240-7463	2024-10-16	non_resource_paper	1223	Paper talks about creation of new identifiers but no website available
 39184336	0	0009-0009-5240-7463	2024-10-14	irrelevant_other	1223	
 39192607	1	0009-0009-5240-7463	2024-10-14	new_provider	1223	Provider for Uniprot IDs
 39201310	0	0009-0009-5240-7463	2024-10-14	irrelevant_other	1223	
@@ -92,7 +92,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39540428	1	0009-0009-5240-7463	2024-12-14	new_publication	1329	Publication for pfam
 39540430	1	0009-0009-5240-7463	2024-12-10	new_prefix	1301	Identifiers for secondary metabolite biosynthetic gene clusters and sources
 39540736	0	0009-0009-5240-7463	2024-12-11	irrelevant_other	1305	
-39540856	0	0009-0009-5240-7463	2024-12-05	no_website	1296	
+39540856	0	0009-0009-5240-7463	2024-12-05	non_resource_paper	1296	
 39546404	0	0009-0009-5240-7463	2024-12-05	not_identifiers_resource	1296	
 39552041	1	0009-0009-5240-7463	2024-12-01	new_publication	1292	Publication for UniProt
 39553733	0	0009-0009-5240-7463	2024-12-11	irrelevant_other	1305	
@@ -118,7 +118,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39592010	1	0009-0009-5240-7463	2024-12-13	new_prefix	1328	Identifiers for cis-regulatory elements (CREs)
 39592652	0	0009-0009-5240-7463	2024-12-10	not_identifiers_resource	1305	
 39607847	0	0009-0009-5240-7463	2024-12-03	irrelevant_other	1296	
-39611775	0	0009-0009-5240-7463	2024-12-11	no_website	1305	
+39611775	0	0009-0009-5240-7463	2024-12-11	non_resource_paper	1305	
 39616207	0	0009-0009-5240-7463	2024-12-09	irrelevant_other	1305	
 39626458	0	0009-0009-5240-7463	2024-12-10	irrelevant_other	1305	
 39629064	0	0009-0009-5240-7463	2024-12-09	irrelevant_other	1305	


### PR DESCRIPTION
This pull request updates the Curation Relevance vocabulary to 
- Expand the definition of `not_identifier_resource` 
- Replace the `no_website` tag with `non_resource_paper`

See https://github.com/biopragmatics/bioregistry/pull/1351#issuecomment-2585363039 for a full explanation of what these tags mean and why they were implemented.