### PR TITLE
Avoid returning windows-style line returns

### DIFF
--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -713,9 +713,10 @@ class Resource(BaseModel):
         rv = self.get_prefix_key(key, metaprefixes)
         if rv is None:
             return None
-        if isinstance(rv, str):
-            return rv
-        raise TypeError
+        if not isinstance(rv, str):
+            raise TypeError
+        rv = rv.replace("\r\n", "\n")
+        return rv
 
     def _get_prefix_key_bool(
         self, key: str, metaprefixes: Union[str, Sequence[str]]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -73,6 +73,19 @@ class TestRegistry(unittest.TestCase):
     """,
         )
 
+    def test_line_returns(self) -> None:
+        """Test that there are no Windows-style line returns in curated data."""
+        for prefix, resource in self.registry.items():
+            with self.subTest(prefix=prefix):
+                resource_dict = resource.model_dump()
+                for key, value in resource_dict.items():
+                    if isinstance(value, str):
+                        self.assertNotIn(
+                            "\\r",
+                            value,
+                            msg=f"Windows-style line return detected in {key} field of {prefix}",
+                        )
+
     def test_prefixes(self):
         """Check prefixes aren't malformed."""
         for prefix, resource in self.registry.items():
@@ -159,6 +172,7 @@ class TestRegistry(unittest.TestCase):
             with self.subTest(prefix=prefix, name=bioregistry.get_name(prefix)):
                 desc = bioregistry.get_description(prefix)
                 self.assertIsNotNone(desc)
+                self.assertNotIn("\r", desc)
 
     def test_has_homepage(self):
         """Test that all non-deprecated entries have a homepage."""


### PR DESCRIPTION
There are few examples of data that have windows-style line returns. This isn't a full fix - the best way would be to update all of the sources to work on this, but is an intermediate that makes sure that the getter methods on the Resource class at least process them out.