### PR TITLE
Adjust the dates for paper_ranking pipeline to be from the first to the last of the previous month

### DIFF
--- a/.github/workflows/paper_ranking.yml
+++ b/.github/workflows/paper_ranking.yml
@@ -2,7 +2,7 @@ name: Run Paper Ranking Script and Update Issue
 
 on:
   schedule:
-    - cron: '0 0 1 * *' # runs on the first day of every month
+    - cron: '0 5 1 * *' # runs on the first day of every month
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/paper_ranking.yml
+++ b/.github/workflows/paper_ranking.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Set Date Variables
       id: set-date-variables
       run: |
-        end_date=$(date +'%Y-%m-%d')
-        start_date=$(date -d "$end_date - 30 days" +'%Y-%m-%d')
+        start_date=$(date -d "$(date +'%Y-%m-01') -1 month" +'%Y-%m-01')
+        end_date=$(date -d "$start_date +1 month -1 day" +'%Y-%m-%d')
         echo "START_DATE=$start_date" >> $GITHUB_ENV
         echo "END_DATE=$end_date" >> $GITHUB_ENV
     


### PR DESCRIPTION
This pull request modifies the `start_date` and `end_date` variables of the `paper_ranking` pipeline to be set to the first and last date of the month respectively. 

The old variables were simply subtracting 30 days from the start date which was causing it to miss out on ranking papers from the 1st of the month in some cases. 

I also modified the `cron` job to run at midnight EST instead of midnight UTC which is what it was set to previously.

@cthoyt 