### PR TITLE
Rename eccode to ec

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ assert 'ncbitaxon' == normalize_prefix('taxonomy')
 assert 'pubchem.compound' == normalize_prefix('pubchem')
 
 # This works for prefixes that are often written many ways, like:
-assert 'eccode' == normalize_prefix('ec-code')
-assert 'eccode' == normalize_prefix('EC_CODE')
+assert 'ec' == normalize_prefix('ec-code')
+assert 'ec' == normalize_prefix('EC_CODE')
 
 # If a prefix is not registered, it gives back `None`
 assert normalize_prefix('not a real key') is None

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,7 +70,7 @@ that's required to go with a given prefix.
 Unfortunately, these requirements can not be applied retroactively and can not
 be trivially applied to automatically imported prefixes. In some cases,
 historical prefixes can be modified to follow these requirements. For example,
-Identifiers.org's `ec-code` was renamed to `eccode` while maintaining `ec-code`
+Identifiers.org's `ec-code` was renamed to `ec` while maintaining `ec-code`
 as a synonym.
 
 Original discussion about minimum prefix requirements can be found at

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,8 +70,8 @@ that's required to go with a given prefix.
 Unfortunately, these requirements can not be applied retroactively and can not
 be trivially applied to automatically imported prefixes. In some cases,
 historical prefixes can be modified to follow these requirements. For example,
-Identifiers.org's `ec-code` was renamed to `ec` while maintaining `ec-code`
-as a synonym.
+Identifiers.org's `ec-code` was renamed to `ec` while maintaining `ec-code` as a
+synonym.
 
 Original discussion about minimum prefix requirements can be found at
 https://github.com/biopragmatics/bioregistry/issues/158.

--- a/docs/_data/warnings.yml
+++ b/docs/_data/warnings.yml
@@ -121,7 +121,7 @@ wrong_patterns:
   homepage: https://www.enzyme-database.org/
   miriam: ^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$
   name: Enzyme Commission Code
-  prefix: eccode
+  prefix: ec
 - correct: ^\d{7}$
   homepage: https://www.evidenceontology.org
   miriam: ECO:\d{7}$

--- a/docs/_data/warnings.yml
+++ b/docs/_data/warnings.yml
@@ -121,7 +121,7 @@ wrong_patterns:
   homepage: https://www.enzyme-database.org/
   miriam: ^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$
   name: Enzyme Commission Code
-  prefix: ec
+  prefix: eccode
 - correct: ^\d{7}$
   homepage: https://www.evidenceontology.org
   miriam: ECO:\d{7}$

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,7 +30,7 @@ number (e.g., Gene Ontology), and some are expansive (e.g.,
 [NCI Thesaurus (NCIT)](https://bioregistry.io/efo)).
 
 Some resources are complete by definition (e.g.,
-[Enzyme Classification](https://bioregistry.io/eccode)), some resources are
+[Enzyme Classification](https://bioregistry.io/ec)), some resources are
 complete but subject to change (e.g., HGNC), and some are always incomplete
 (e.g., PDB).
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,9 +30,8 @@ number (e.g., Gene Ontology), and some are expansive (e.g.,
 [NCI Thesaurus (NCIT)](https://bioregistry.io/efo)).
 
 Some resources are complete by definition (e.g.,
-[Enzyme Classification](https://bioregistry.io/ec)), some resources are
-complete but subject to change (e.g., HGNC), and some are always incomplete
-(e.g., PDB).
+[Enzyme Classification](https://bioregistry.io/ec)), some resources are complete
+but subject to change (e.g., HGNC), and some are always incomplete (e.g., PDB).
 
 Resources do not always correspond one-to-one with projects, such as how the
 ChEMBL database contains both the

--- a/src/bioregistry/app/templates/meta/access.html
+++ b/src/bioregistry/app/templates/meta/access.html
@@ -76,8 +76,8 @@ assert 'ncbitaxon' == bioregistry.normalize_prefix('taxonomy')
 assert 'pubchem.compound' == bioregistry.normalize_prefix('pubchem')
 
 # This works for prefixes that are often written many ways, like:
-assert 'eccode' == bioregistry.normalize_prefix('ec-code')
-assert 'eccode' == bioregistry.normalize_prefix('EC_CODE')
+assert 'ec' == bioregistry.normalize_prefix('ec-code')
+assert 'ec' == bioregistry.normalize_prefix('EC_CODE')
 
 # If a prefix is not registered, it gives back `None`
 assert bioregistry.normalize_prefix('not a real key') is None</code></pre>

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -948,8 +948,8 @@ def normalize_prefix(prefix: str, *, use_preferred: bool = False) -> str | None:
 
     This works for prefixes that are often written many ways, like:
 
-    >>> assert "eccode" == normalize_prefix("ec-code")
-    >>> assert "eccode" == normalize_prefix("EC_CODE")
+    >>> assert "ec" == normalize_prefix("ec-code")
+    >>> assert "ec" == normalize_prefix("EC_CODE")
 
     Get a "preferred" prefix:
 

--- a/tests/test_identifiers_org.py
+++ b/tests/test_identifiers_org.py
@@ -36,7 +36,7 @@ class TestIdentifiersOrg(unittest.TestCase):
         """Test getting identifiers.org prefixes."""
         for prefix, miriam_prefix in [
             ("ncbitaxon", "taxonomy"),
-            ("eccode", "ec-code"),
+            ("ec", "ec-code"),
         ]:
             with self.subTest(prefix=prefix):
                 self.assertEqual(miriam_prefix, bioregistry.get_identifiers_org_prefix(prefix))

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -20,8 +20,8 @@ class TestResolve(unittest.TestCase):
             ("ncbitaxon", "taxonomy"),
             ("scomp", "SCOMP"),
             ("sfam", "SFAM"),
-            ("eccode", "ec-code"),
-            ("eccode", "EC_CODE"),
+            ("ec", "ec-code"),
+            ("ec", "EC_CODE"),
             ("chembl.compound", "chembl.compound"),
             ("chembl.compound", "chemblcompound"),
             ("chembl", "chembl"),
@@ -41,12 +41,12 @@ class TestResolve(unittest.TestCase):
     def test_validate_true(self):
         """Test that validation returns true."""
         tests = [
-            ("eccode", "1"),
-            ("eccode", "1.1"),
-            ("eccode", "1.1.1"),
-            ("eccode", "1.1.1.1"),
-            ("eccode", "1.1.123.1"),
-            ("eccode", "1.1.1.123"),
+            ("ec", "1"),
+            ("ec", "1.1"),
+            ("ec", "1.1.1"),
+            ("ec", "1.1.1.1"),
+            ("ec", "1.1.123.1"),
+            ("ec", "1.1.1.123"),
             # Namespace in LUI: Standard rule for upper-casing
             ("chebi", "24867"),
             ("chebi", "CHEBI:1234"),


### PR DESCRIPTION
This pull request addresses the following issue: https://github.com/biopragmatics/bioregistry/issues/1404

The following changes are implemented:
- Rename `eccode` prefix to `ec`
- `preferred_prefix` is set to `EC`
- Maintain `eccode` as a synonym
- Update any instances of `provides: eccode` to  `provides: ec`

A few additional files that referenced `eccode` are updated to reflect this change as well.
