### PR TITLE
New schema element: secondary reviewers

### DIFF
--- a/src/bioregistry/app/templates/resource.html
+++ b/src/bioregistry/app/templates/resource.html
@@ -381,6 +381,11 @@
                     <dd>
                         {{ utils.render_author(resource.reviewer, link=url_for('metaregistry_ui.contributor', orcid=resource.reviewer.orcid)) }}
                     </dd>
+                    {%- for reviewer in resource.reviewer_extras or [] %}
+                    <dd>
+                        {{ utils.render_author(reviewer, link=url_for('metaregistry_ui.contributor', orcid=reviewer.orcid)) }}
+                    </dd>
+                    {%- endfor %}
                 {% endif %}
             </dl>
         </div>

--- a/src/bioregistry/curation/cleanup_authors.py
+++ b/src/bioregistry/curation/cleanup_authors.py
@@ -46,6 +46,11 @@ def _main():
             resource.contributor = _new(resource.contributor.orcid)
         if resource.reviewer and resource.reviewer.orcid:
             resource.reviewer = _new(resource.reviewer.orcid)
+        if resource.reviewer_extras:
+            resource.reviewer_extras = [
+                _new(reviewer.orcid) if reviewer.orcid else reviewer
+                for reviewer in resource.reviewer_extras
+            ]
         if resource.contact and resource.contact.orcid:
             resource.contact = _new(resource.contact.orcid)
         if resource.contributor_extras:

--- a/src/bioregistry/curation/find_contact_groups.py
+++ b/src/bioregistry/curation/find_contact_groups.py
@@ -1,11 +1,13 @@
 """Find group emails."""
 
+import click
 from tabulate import tabulate
 
 import bioregistry
 from bioregistry.constants import DISALLOWED_EMAIL_PARTS
 
 
+@click.command()
 def main() -> None:
     """Find group mails."""
     rows = []
@@ -21,7 +23,7 @@ def main() -> None:
                 url = ""
 
             rows.append((resource.prefix, resource.get_name(), contact.name, contact.email, url))
-    print(tabulate(rows))
+    click.echo(tabulate(rows))
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/export/rdf_export.py
+++ b/src/bioregistry/export/rdf_export.py
@@ -227,14 +227,21 @@ def _add_resource(  # noqa:C901
 
     contact = resource.get_contact()
     if contact is not None:
-        contact_node = contact.add_triples(graph)
-        graph.add((node, bioregistry_schema["0000019"], contact_node))
+        graph.add((node, bioregistry_schema["0000019"], contact.add_triples(graph)))
+    for contact in resource.contact_extras or []:
+        graph.add((node, bioregistry_schema["0000019"], contact.add_triples(graph)))
+
     if resource.reviewer is not None and resource.reviewer.orcid:
-        reviewer_node = resource.reviewer.add_triples(graph)
-        graph.add((node, bioregistry_schema["0000021"], reviewer_node))
+        graph.add((node, bioregistry_schema["0000021"], resource.reviewer.add_triples(graph)))
+    for reviewer in resource.reviewer_extras or []:
+        if reviewer.orcid:
+            graph.add((node, bioregistry_schema["0000021"], reviewer.add_triples(graph)))
+
     if resource.contributor is not None and resource.contributor.orcid:
-        contributor_node = resource.contributor.add_triples(graph)
-        graph.add((contributor_node, DCTERMS.contributor, node))
+        graph.add((node, DCTERMS.contributor, resource.contributor.add_triples(graph)))
+    for contributor in resource.contributor_extras:
+        if contributor.orcid:
+            graph.add((node, DCTERMS.contributor, contributor.add_triples(graph)))
 
     mappings = resource.get_mappings()
     for metaprefix, metaidentifier in (mappings or {}).items():

--- a/src/bioregistry/export/rdf_export.py
+++ b/src/bioregistry/export/rdf_export.py
@@ -239,7 +239,7 @@ def _add_resource(  # noqa:C901
 
     if resource.contributor is not None and resource.contributor.orcid:
         graph.add((node, DCTERMS.contributor, resource.contributor.add_triples(graph)))
-    for contributor in resource.contributor_extras:
+    for contributor in resource.contributor_extras or []:
         if contributor.orcid:
             graph.add((node, DCTERMS.contributor, contributor.add_triples(graph)))
 

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -1663,6 +1663,9 @@ def _read_contributors(
                 rv[contributor.orcid] = contributor
         if resource.reviewer and resource.reviewer.orcid:
             rv[resource.reviewer.orcid] = resource.reviewer
+        for reviewer in resource.reviewer_extras or []:
+            if reviewer.orcid:
+                rv[reviewer.orcid] = reviewer
         if not direct_only:
             contact = resource.get_contact()
             if contact and contact.orcid:

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -1561,6 +1561,22 @@
           "default": null,
           "description": "The reviewer of the prefix to the Bioregistry, including at a minimum their name and ORCiD and optional their email address and GitHub handle. All entries curated through the Bioregistry GitHub Workflow should contain this field pointing to the person who reviewed it on GitHub."
         },
+        "reviewer_extras": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Author"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional reviewers of the prefix.",
+          "title": "Reviewer Extras"
+        },
         "proprietary": {
           "anyOf": [
             {

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -564,6 +564,10 @@ class Resource(BaseModel):
     """
         ),
     )
+    reviewer_extras: list[Author] | None = Field(
+        default=None,
+        description="Additional reviewers of the prefix.",
+    )
     proprietary: bool | None = Field(
         default=None,
         description=_dedent(

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -348,7 +348,8 @@ class Resource(BaseModel):
     )
     contact_group_email: EmailStr | None = Field(
         default=None,
-        description="A group contact email for the project. It's required to have a primary contact to have this field.",
+        description="A group contact email for the project. It's required to have a primary contact "
+        "to have this field.",
     )
     contact_page: str | None = Field(
         default=None,

--- a/src/bioregistry/schema_utils.py
+++ b/src/bioregistry/schema_utils.py
@@ -191,6 +191,9 @@ def read_prefix_reviews(registry: Mapping[str, Resource]) -> Mapping[str, set[st
     for prefix, resource in registry.items():
         if resource.reviewer and resource.reviewer.orcid:
             rv[resource.reviewer.orcid].add(prefix)
+        for reviewer in resource.reviewer_extras or []:
+            if reviewer.orcid:
+                rv[reviewer.orcid].add(prefix)
     return dict(rv)
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -822,12 +822,16 @@ class TestRegistry(unittest.TestCase):
         for prefix, resource in self.registry.items():
             if not resource.reviewer_extras:
                 continue
-            self.assertIsNotNone(resource.reviewer, msg="If you have secondary reviewers, you must have a primary reviewer")
-            for reviewer in resource.reviewer_extras:
-                self.assertIsNotNone(reviewer.name)
-                self.assertIsNotNone(reviewer.orcid)
-                self.assertIsNotNone(reviewer.github)
-                self.assert_contact_metadata(reviewer)
+            with self.subTest(prefix=prefix):
+                self.assertIsNotNone(
+                    resource.reviewer,
+                    msg="If you have secondary reviewers, you must have a primary reviewer",
+                )
+                for reviewer in resource.reviewer_extras:
+                    self.assertIsNotNone(reviewer.name)
+                    self.assertIsNotNone(reviewer.orcid)
+                    self.assertIsNotNone(reviewer.github)
+                    self.assert_contact_metadata(reviewer)
 
     def test_contacts(self):
         """Check contacts have minimal metadata."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -817,6 +817,18 @@ class TestRegistry(unittest.TestCase):
                 self.assertIsNotNone(resource.reviewer.github)
                 self.assert_contact_metadata(resource.reviewer)
 
+    def test_reviewers_extras(self) -> None:
+        """Test extra reviewers."""
+        for prefix, resource in self.registry.items():
+            if not resource.reviewer_extras:
+                continue
+            self.assertIsNotNone(resource.reviewer, msg="If you have secondary reviewers, you must have a primary reviewer")
+            for reviewer in resource.reviewer_extras:
+                self.assertIsNotNone(reviewer.name)
+                self.assertIsNotNone(reviewer.orcid)
+                self.assertIsNotNone(reviewer.github)
+                self.assert_contact_metadata(reviewer)
+
     def test_contacts(self):
         """Check contacts have minimal metadata."""
         for prefix, resource in self.registry.items():


### PR DESCRIPTION
This PR adds a slot for multiple reviews, for situations like in #1406 where multiple people gave meaningful feedback and decided on accepting a record

This PR also updates the RDF output to add a few things missed with recent PRs #1389/#1388