### PR TITLE
New prefix: molbic

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -57,6 +57,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39341795	1	0009-0009-5240-7463	2024-10-19	new_prefix	1223	Identifiers for non-coding RNA biomarkers for cancers
 39341994	0	0009-0009-5240-7463	2024-10-15	not_identifiers_resource	1223	
 39345624	1	0009-0009-5240-7463	2024-10-19	new_publication	1223	Publication for sgd and sgd.pathways
+39373530	1	0009-0009-5240-7463	2025-02-15	new_prefix	1418	
 39379619	1	0009-0009-5240-7463	2024-11-26	new_provider	1285	Provider for UniProt
 39399372	0	0009-0009-5240-7463	2024-11-19	irrelevant_other	1288	
 39401100	1	0009-0009-5240-7463	2024-11-20	new_publication	1264	Publication for intact and intact.molecule


### PR DESCRIPTION
PubMed: https://pubmed.ncbi.nlm.nih.gov/39373530/
Database: https://idrblab.org/MolBiC/

This PR curates 3 new prefixes for MolBiC which provides identifiers for cell-based molecular bioactivities. There are 3 distinct sematic spaces listed below:

compounds -> `molbic.compound` 
proteins -> `molbic.protein`
cell lines -> `molbic.cell`