### PR TITLE
Remove incorrect HP mappings

### DIFF
--- a/src/bioregistry/data/mismatch.json
+++ b/src/bioregistry/data/mismatch.json
@@ -118,6 +118,11 @@
     "miriam": "gro",
     "obofoundry": "gro"
   },
+  "hp": {
+    "aberowl": "HP_O",
+    "bioportal": "HP_O",
+    "lov": "hpo"
+  },
   "hpath": {
     "fairsharing": "FAIRsharing.kj336a"
   },


### PR DESCRIPTION
This PR removes three incorrect mappings for the `hp` prefix since these mappings refer to resources other than the Human Phenotype Ontology in external registries. This came up while looking into #1433 though this is not the root cause of that error.