### PR TITLE
Exclude preprints from ranking and improve metadata access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ paper-ranking = [
     "pandas",
     "scikit-learn",
     "tabulate",
-    "more_itertools",
 ]
 
 

--- a/src/bioregistry/analysis/paper_ranking.py
+++ b/src/bioregistry/analysis/paper_ranking.py
@@ -141,12 +141,7 @@ def _get_metadata_for_ids(pubmed_ids: Iterable[int | str]) -> dict[str, dict[str
     """Get metadata for articles in PubMed, wrapping the INDRA client."""
     from indra.literature import pubmed_client
 
-    fetched_metadata = {}
-    for chunk in chunked(
-        tqdm(pubmed_ids, unit="article", unit_scale=True, desc="Getting metadata"), 200
-    ):
-        fetched_metadata.update(pubmed_client.get_metadata_for_ids(chunk, get_abstracts=True))
-    return fetched_metadata
+    return pubmed_client.get_metadata_for_all_ids(pubmed_ids, get_abstracts=True)
 
 
 def _get_ids(term: str, use_text_word: bool, start_date: str, end_date: str) -> set[str]:

--- a/src/bioregistry/analysis/paper_ranking.py
+++ b/src/bioregistry/analysis/paper_ranking.py
@@ -76,6 +76,11 @@ DEFAULT_SEARCH_TERMS = [
     "nomenclature",
 ]
 
+EXCLUDE_JOURNALS = {
+    "bioRxiv",
+    "medRxiv",
+}
+
 
 def get_publications_from_bioregistry(path: Path | None = None) -> pd.DataFrame:
     """Load bioregistry data from a JSON file, extracting publication details and fetching abstracts if missing.
@@ -189,6 +194,11 @@ def fetch_pubmed_papers(
 
     records = []
     for pubmed_id, paper in papers.items():
+        # Filter out papers that are from journals (typically
+        # preprint servers that have PMIDs) to be excluded
+        if paper.get('journal_abbrev') in EXCLUDE_JOURNALS:
+            continue
+
         title = paper.get("title")
         abstract = paper.get("abstract", "")
 

--- a/src/bioregistry/analysis/paper_ranking.py
+++ b/src/bioregistry/analysis/paper_ranking.py
@@ -191,7 +191,7 @@ def fetch_pubmed_papers(
     for pubmed_id, paper in papers.items():
         # Filter out papers that are from journals (typically
         # preprint servers that have PMIDs) to be excluded
-        if paper.get('journal_abbrev') in EXCLUDE_JOURNALS:
+        if paper.get("journal_abbrev") in EXCLUDE_JOURNALS:
             continue
 
         title = paper.get("title")

--- a/src/bioregistry/analysis/paper_ranking.py
+++ b/src/bioregistry/analysis/paper_ranking.py
@@ -31,7 +31,6 @@ from typing import Any, NamedTuple, Union
 import click
 import numpy as np
 import pandas as pd
-from more_itertools import chunked
 from numpy.typing import NDArray
 from sklearn.base import ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier

--- a/src/bioregistry/analysis/paper_ranking.py
+++ b/src/bioregistry/analysis/paper_ranking.py
@@ -26,7 +26,7 @@ import textwrap
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, NamedTuple, Union
+from typing import cast, Any, NamedTuple, Union
 
 import click
 import numpy as np
@@ -140,7 +140,10 @@ def _get_metadata_for_ids(pubmed_ids: Iterable[int | str]) -> dict[str, dict[str
     """Get metadata for articles in PubMed, wrapping the INDRA client."""
     from indra.literature import pubmed_client
 
-    return pubmed_client.get_metadata_for_all_ids(pubmed_ids, get_abstracts=True)
+    return cast(
+        dict[str, dict[str, Any]],
+        pubmed_client.get_metadata_for_all_ids(pubmed_ids, get_abstracts=True),
+    )
 
 
 def _get_ids(term: str, use_text_word: bool, start_date: str, end_date: str) -> set[str]:


### PR DESCRIPTION
This PR implements an exclusion list for journals to be used in the automated paper ranking. I added bioRxiv and medRxiv to this list but in principle others can be added if necessary. The PR also simplifies the way we get metadata using a function that upstreams the issue of handling a large number of PMIDs using a function that has been around in INDRA for a while but for some reason not used in this script.

Background: Recently, PubMed is assigning PMIDs to preprints on bioRxiv and medRxiv and these have been showing up in the paper ranking. It is generally not a good idea to curate these as publications associated with Bioregistry entries since any such curation would have to be updated when the paper is published with its stable metadata (title, DOI, PMID, etc. can all change upon publication) which is difficult to coordinate since time of actual publication is hard to monitor. See e.g., #1425 and #1426.
