### PR TITLE
Update prefix in test to one not currently in MIRIAM

### DIFF
--- a/tests/test_identifiers_org.py
+++ b/tests/test_identifiers_org.py
@@ -41,7 +41,8 @@ class TestIdentifiersOrg(unittest.TestCase):
             with self.subTest(prefix=prefix):
                 self.assertEqual(miriam_prefix, bioregistry.get_identifiers_org_prefix(prefix))
 
-        for prefix in ["MONDO"]:
+        # Test prefixes that don't exist in MIRIAM
+        for prefix in ["IDOMAL"]:
             self.assertIsNone(bioregistry.get_identifiers_org_prefix(prefix))
 
     def test_standardize_identifier(self):


### PR DESCRIPTION
The test condition
```python
        for prefix in ["MONDO"]:
            self.assertIsNone(bioregistry.get_identifiers_org_prefix(prefix))
```
assumes that MONDO is not in MIRIAM/identifiers.org but it was actually recently added there (https://registry.identifiers.org/registry/mondo) so this test case needs to be updated to a different prefix that doesn't exist there.

This PR updates it to another example that is in a similar group to what MONDO used to be in in that it is in OBOFoundry but not in MIRIAM.

This is necessary to get the new build working as an additional step for #1433.