### PR TITLE
Require bioregistry prefixes conform to W3C NCNAME convention

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,8 +62,11 @@ that's required to go with a given prefix.
    or more characters for legibility.
 6. New prefixes must be lowercase. However, lexical variants can be stored as
    synonyms for reference (e.g., FBbt).
-7. New prefixes must validate against the following regular expression:
-   `^[a-z][a-z0-9]+(\.[a-z][a-z0-9]+?)$`
+7. New prefixes must validate against the regular expression for the W3C
+   definition of an
+   [`NCNAME`](https://www.w3.org/TR/1999/REC-xml-names-19990114/#NT-NCName):
+   `^[A-Za-z_][A-Za-z0-9\\.\\-_]*$`. As an additional requirement, new prefixes
+   must not start with an underscore.
 8. New prefixes must pass all metadata checks, which are canonically defined by
    the quality assurance workflow.
 
@@ -72,6 +75,11 @@ be trivially applied to automatically imported prefixes. In some cases,
 historical prefixes can be modified to follow these requirements. For example,
 Identifiers.org's `ec-code` was renamed to `ec` while maintaining `ec-code` as a
 synonym.
+
+Some external registries' prefixes are not W3C conformant because they start
+with a number, such as `3dmet` in MIRIAM. If it's not clear what a better prefix
+might be, add an underscore to the start of the prefix and maintain the other
+prefix as a synonym.
 
 Original discussion about minimum prefix requirements can be found at
 https://github.com/biopragmatics/bioregistry/issues/158.

--- a/src/bioregistry/external/alignment_utils.py
+++ b/src/bioregistry/external/alignment_utils.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Callable, ClassVar, Optional
 
 import click
+from curies.w3c import NCNAME_RE
 from tabulate import tabulate
 
 from ..constants import METADATA_CURATION_DIRECTORY
@@ -128,6 +129,16 @@ class Aligner:
             # add the identifier from an external resource if it's been marked as high quality
             elif self.include_new:
                 bioregistry_id = norm(external_id)
+                if not NCNAME_RE.match(bioregistry_id):
+                    if NCNAME_RE.match("_" + bioregistry_id):
+                        # The prefix is non-conformant to W3C, but if we prepend
+                        # an underscore, it is. This happens for prefixes that start
+                        # with numbers.
+                        bioregistry_id = "_" + bioregistry_id
+                    else:
+                        # The prefix is non-conformant to W3C, therefore we can't
+                        # add it safely without manual intervention
+                        continue
                 if is_mismatch(bioregistry_id, self.key, external_id):
                     continue
                 self.internal_registry[bioregistry_id] = Resource(prefix=bioregistry_id)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 import curies
 import rdflib
+from curies.w3c import NCNAME_RE
 
 import bioregistry
 from bioregistry import Resource, manager
@@ -27,7 +28,6 @@ from bioregistry.schema.struct import (
 )
 from bioregistry.schema_utils import is_mismatch
 from bioregistry.utils import _norm
-from curies.w3c import NCNAME_RE
 
 logger = logging.getLogger(__name__)
 
@@ -86,16 +86,20 @@ class TestRegistry(unittest.TestCase):
                             msg=f"Windows-style line return detected in {key} field of {prefix}",
                         )
 
-    def test_prefixes(self):
+    def test_prefixes(self) -> None:
         """Check prefixes aren't malformed."""
         for prefix, resource in self.registry.items():
             with self.subTest(prefix=prefix):
                 self.assertEqual(prefix, resource.prefix)
                 self.assertEqual(prefix.lower(), prefix, msg="prefix is not lowercased")
-                self.assertFalse(prefix.startswith("_"))
                 self.assertFalse(prefix.endswith("_"))
                 self.assertNotIn(":", prefix)
                 self.assertRegex(prefix, NCNAME_RE)
+                if prefix.startswith("_"):
+                    self.assertTrue(
+                        prefix[1].isnumeric(),
+                        msg="Only start a prefix with an underscore if the first _actual_ character is a number",
+                    )
 
     def test_keys(self):
         """Check the required metadata is there."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -27,6 +27,7 @@ from bioregistry.schema.struct import (
 )
 from bioregistry.schema_utils import is_mismatch
 from bioregistry.utils import _norm
+from curies.w3c import NCNAME_RE
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,7 @@ class TestRegistry(unittest.TestCase):
                 self.assertFalse(prefix.startswith("_"))
                 self.assertFalse(prefix.endswith("_"))
                 self.assertNotIn(":", prefix)
+                self.assertRegex(prefix, NCNAME_RE)
 
     def test_keys(self):
         """Check the required metadata is there."""

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools as itt
 import json
 import unittest
 from typing import ClassVar
@@ -109,13 +110,14 @@ class TestWeb(unittest.TestCase):
 
     def test_ui_resource_rdf(self):
         """Test the UI resource with content negotiation."""
-        prefix = "3dmet"
-        for accept, fmt in [
+        prefixes = ["3dmet", "_3dmet"]
+        fmts = [
             ("text/turtle", "turtle"),
             ("text/n3", "n3"),
             ("application/ld+json", "jsonld"),
-        ]:
-            with self.subTest(format=fmt):
+        ]
+        for prefix, (accept, fmt) in itt.product(prefixes, fmts):
+            with self.subTest(prefix=prefix, format=fmt):
                 res = self.client.get(f"/registry/{prefix}", headers={"Accept": accept})
                 self.assertEqual(
                     200, res.status_code, msg=f"Failed on {prefix} to accept {accept} ({fmt})"
@@ -133,7 +135,7 @@ class TestWeb(unittest.TestCase):
                     g.query("SELECT ?s WHERE { ?s a <https://bioregistry.io/schema/#0000001> }")
                 )
                 self.assertEqual(1, len(results))
-                self.assertEqual(f"https://bioregistry.io/registry/{prefix}", str(results[0][0]))
+                self.assertEqual(f"https://bioregistry.io/registry/_3dmet", str(results[0][0]))
 
     def test_api_metaregistry(self):
         """Test the metaregistry endpoint."""


### PR DESCRIPTION
The W3C defines a technical standard for [`NCNAME`](https://www.w3.org/TR/1999/REC-xml-names-19990114/#NT-NCName), which for most intents and purposes is the same as CURIE prefixes. It follows this form:

```
prefix := NCName
NCName := (Letter | '_') (NCNameChar)*
NCNameChar	::=	Letter | Digit | '.' | '-' | '_'
```

This PR does the following:

1. Adds a data integrity test to make sure all Bioregistry prefixes conform to the W3C NCNAME standard
2. Adds a pattern to the Bioregistry record for itself matching the NCNAME definition
3. Renames the three Bioregistry preixes that aren't conforming, while maintaining the previous prefixes as synonyms:
   - `3dmet` (dead resource)
   - `4dn.replicate`
   - `4dn.biosource`
4. Adds documentation to the contribution guidelines on how to "normalize" prefixes coming from external registries that aren't NCNAME-conformant.
5. Updates the automated ingestion workflow to apply the underscore rule described in 4)


This PR is a first step towards addressing https://github.com/biopragmatics/bioregistry/issues/1338