### PR TITLE
Add descriptions for external TogoID entries

### DIFF
--- a/src/bioregistry/external/togoid/processed.json
+++ b/src/bioregistry/external/togoid/processed.json
@@ -85,6 +85,7 @@
   },
   "Bioproject": {
     "catalog": "nbdc00476",
+    "description": "BioProject is a database which collects the results of research projects under the umbrella of the project or initiative. The database consists of tables of projects, which users can search or browse to find all data outputs related to that project. Users can submit projects or download data via FTP.",
     "examples": [
       "PRJDB575",
       "PRJDB1880",
@@ -107,6 +108,7 @@
   },
   "BioprojectUmbrella": {
     "catalog": "nbdc00476",
+    "description": "BioProject is a database which collects the results of research projects under the umbrella of the project or initiative. The database consists of tables of projects, which users can search or browse to find all data outputs related to that project. Users can submit projects or download data via FTP.",
     "examples": [
       "PRJDB10770",
       "PRJDB14691",
@@ -151,6 +153,7 @@
   },
   "Ccds": {
     "catalog": "nbdc00023",
+    "description": "This database seeks to identify a core set of human and mouse protein coding regions of high quality that are consistently annotated.",
     "examples": [
       "CCDS1471",
       "CCDS10913",
@@ -195,6 +198,7 @@
   },
   "Chebi": {
     "catalog": "nbdc00027",
+    "description": "ChEBI is a collection of data on entities of biological interest.\r\nThis database concentrates on assembling data on smaller chemical compounds, such as atoms, molecules, ions, radicals etc. These should be produced in nature or be synthetic molecules affecting biological processes in living organisms.\r\nChEBI does not generally include molecules directly encoded by the genome.\r\nThe database contains 31,651 entries with annotations.\r\nA keyword search option is available.\r\nIn addition to this an advanced search option, which includes a structure drawing tool, is provided.\r\nThe ChEBI database can be searched individually or in combination with other databases.",
     "examples": [
       "84824",
       "40167",
@@ -217,6 +221,7 @@
   },
   "ChemblCompound": {
     "catalog": "nbdc02555",
+    "description": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided.",
     "examples": [
       "CHEMBL121649",
       "CHEMBL190334",
@@ -239,6 +244,7 @@
   },
   "ChemblTarget": {
     "catalog": "nbdc02555",
+    "description": "ChEMBL is a database for bioactive molecules. It collects information of small molecules, such as calculated properties (e.g. logP, Molecular Weight, Lipinski Parameters, etc.) and abstracted bioactivities (e.g. binding constants, pharmacology and ADMET data), and the target information. Metadata of assays for small molecule activities or assays for binding activities between small molecules and its targets are also provided.",
     "examples": [
       "CHEMBL2788",
       "CHEMBL3091264",
@@ -261,6 +267,7 @@
   },
   "Clinvar": {
     "catalog": "nbdc01514",
+    "description": "ClinVar is a freely available archive describing relationships between medically important variants and phenotypes. Submissions report human variation, interpretations of the relationship of that variation to human health, and the evidence supporting each interpretation. ClinVar is tightly coupled with dbSNP and dbVar, which maintain information about locations of variations on human assemblies, and also based on the phenotypic descriptions maintained in MedGen (http://www.ncbi.nlm.nih.gov/medgen). Each record contains the submitter, the variation and the phenotype. Furthermore, to facilitate evaluation of the medical importance of each variant, ClinVar aggregates submissions with the same variation/phenotype combination, adds value from other NCBI databases, and reports if there are conflicting clinical interpretations. Data in ClinVar are available in multiple formats, including html, download as XML, VCF or tab-delimited subsets.",
     "examples": [
       "658761",
       "619209",
@@ -283,6 +290,7 @@
   },
   "Cog": {
     "catalog": "nbdc00397",
+    "description": "This database defines all orthologs of protein sequences coded by known genomes. The species name, protein name, and phylogenetic tree of orthologous clusters can be viewed through this site. Each cluster is comprised of individual proteins and its paralogs, matched to evolutionarily conserved molecular domains.",
     "examples": [
       "COG0130",
       "COG0663",
@@ -305,6 +313,7 @@
   },
   "Dbsnp": {
     "catalog": "nbdc00206",
+    "description": "dbSNP collects information on polymorphisms based on single and small-scale multi-base substitutions, including insertions and deletions, microsatelites, and non-polymorphic variants. Differences in the frequency of polymorphisms in a population can be visually compared for each SNP.",
     "examples": [
       "rs746303788",
       "rs1407020249",
@@ -327,6 +336,7 @@
   },
   "Doid": {
     "catalog": "nbdc00261",
+    "description": "This site provides a Disease Ontology, which is a standardized ontology organized by human disease terms and related medical concepts. The DO terms are associated with MeSH, ICD, NCI's thesaurus, SNOMED and OMIM to integrate disease and medical vocabularies.",
     "examples": [
       "DO:9036",
       "DO:3159",
@@ -349,6 +359,7 @@
   },
   "Drugbank": {
     "catalog": "nbdc01071",
+    "description": "DrugBank is a database of detailed informatics resources on approved and experimental drugs. The database contains informaiton on drug targets as well as the results of experiments resulting in extensive bioinformatics and chemoinformatics data. Users can browse or search by drug or target. Data is available for download.",
     "examples": [
       "DB15589",
       "DB13471",
@@ -393,6 +404,7 @@
   },
   "EnsemblGene": {
     "catalog": "nbdc00054",
+    "description": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps.",
     "examples": [
       "ENSG00000186283",
       "ENSAMEG00000018238",
@@ -415,6 +427,7 @@
   },
   "EnsemblProtein": {
     "catalog": "nbdc00054",
+    "description": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps.",
     "examples": [
       "ENSP00000365411",
       "ENSP00000420674",
@@ -437,6 +450,7 @@
   },
   "EnsemblTranscript": {
     "catalog": "nbdc00054",
+    "description": "ENSEMBL is a collection of automatically annotated genome databases for vertebrates and a number of eukaryotes, integrated with all other relevant biological data available.\r\nThe repository covers data on gene annotation, microarray probeset mapping and comparative genomics among many other topics.\r\nInformation may be downloaded by a variety of means: \r\nFor small amounts of data, an export option is suggested.\r\nFor larger amounts of data, an FTP site is provided from where a complete database may be downloaded in one of various formats, from flat files to MySQL dumps.",
     "examples": [
       "ENST00000638000",
       "ENST00000307864",
@@ -459,6 +473,7 @@
   },
   "FlybaseGene": {
     "catalog": "nbdc00064",
+    "description": "This database contains genetic information on Drosophila. It allows users to search using BLAST, GenomeBrowser or QuickSearch tool with taxonomical information and image-based data on the life-cycle stages of Drosophila. The information of Drosophila material resources are also provided.",
     "examples": [
       "FBgn0040373",
       "FBgn0040372",
@@ -502,6 +517,7 @@
   },
   "GeoSample": {
     "catalog": "nbdc00080",
+    "description": "This is a public data repository of functional genomics data obtained through microarrays and sequencing. Records are carefully examined by experts and standardized to comply with Minimum Information About a Microarray Experiment (MIAME) standards. The data can be searched by sample name, analysis platform, organism, assay details, and keywords. Raw data can also be downloaded from the database.",
     "examples": [
       "GSM3683883",
       "GSM6900216",
@@ -524,6 +540,7 @@
   },
   "GeoSeries": {
     "catalog": "nbdc00080",
+    "description": "This is a public data repository of functional genomics data obtained through microarrays and sequencing. Records are carefully examined by experts and standardized to comply with Minimum Information About a Microarray Experiment (MIAME) standards. The data can be searched by sample name, analysis platform, organism, assay details, and keywords. Raw data can also be downloaded from the database.",
     "examples": [
       "GSE1",
       "GSE43529",
@@ -545,8 +562,30 @@
     "prefix": "GeoSeries",
     "uri_format": "http://identifiers.org/geo/$1"
   },
+  "Glycomotif": {
+    "examples": [
+      "G64227KZ",
+      "G14091MR",
+      "G00552RX",
+      "G18625KA",
+      "G54733XO",
+      "G72557NR",
+      "G90598GO",
+      "G93805MV",
+      "G99524KA",
+      "G00029MO"
+    ],
+    "keywords": [
+      "Glycan"
+    ],
+    "name": "GlycoMotif",
+    "pattern": "^(?:GM\\.)?(?G[0-9]{5}[A-Z]{2})$",
+    "prefix": "Glycomotif",
+    "uri_format": "http://glycomotif.glyomics.org/glycomotif/GM.$1"
+  },
   "Glytoucan": {
     "catalog": "nbdc01535",
+    "description": "GlyTouCan is an international repository of glycan structures. This database contains uncurated glycan structures ranging in resolution from monosaccharide composition to fully defined structures, as long as there are no inconsistencies in the structure. The database allows users to search by text, graphic input or motif, and browse using motif-list or glycan-list.",
     "examples": [
       "G88006IV",
       "G53085MI",
@@ -569,6 +608,7 @@
   },
   "Go": {
     "catalog": "nbdc00074",
+    "description": "GO is a database which provides a controlled vocabulary of terms for describing gene product characteristics and gene product annotation data. It contains data of terms, definitions and ontology structure. The most recent version of the ontology and the annotation files contributed by members of the GO Consortium are available for download. The GO provides the AmiGO browser and search engine which are web browser-based access to the GO database.",
     "examples": [
       "GO:0005643",
       "GO:0097110",
@@ -635,6 +675,7 @@
   },
   "Hmdb": {
     "catalog": "nbdc00909",
+    "description": "HUMDB is a database of human metabolites. The database contains information on thousands of metabolites produced by and found in the human body as a result of metabolic processes. genes and proteins related to the metabolites are also affiliated with records, where appropriate. Data on metabolites and the associated genes and proteins are available for download.",
     "examples": [
       "HMDB0029433",
       "HMDB0015609",
@@ -657,6 +698,7 @@
   },
   "Homologene": {
     "catalog": "nbdc00101",
+    "description": "In Homologenes, users can find automatically constructed homologous gene sets from the full-length genome sequences of a wide range of eukaryotic species, as well as mRNA and protein sequences.",
     "examples": [
       "117",
       "17",
@@ -679,6 +721,7 @@
   },
   "HpInheritance": {
     "catalog": "nbdc02559",
+    "description": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotype specialized in human disease. The medical literatures, Orphanet, DECIPHER, and OMIM are used for developing the HPO.",
     "examples": [
       "HP:0032382",
       "HP:0001475",
@@ -701,6 +744,7 @@
   },
   "HpPhenotype": {
     "catalog": "nbdc02559",
+    "description": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotype specialized in human disease. The medical literatures, Orphanet, DECIPHER, and OMIM are used for developing the HPO.",
     "examples": [
       "HP:0001947",
       "HP:0031592",
@@ -744,6 +788,7 @@
   },
   "Insdc": {
     "catalog": "nbdc02567",
+    "description": "It is a portal site for the INSDC(International Nucleotide Sequence Database Collaboration), which is an initiative operated between DDBJ, EMBL-EBI and NCBI.  Each organization operates DNA databases in close coordination and cooperation with each other to achieve common accession numbers, and standardize data format (INSD-XML). The databases are called the International Nucleotide Sequence Databases (INSD).",
     "examples": [
       "U10991",
       "AF116914",
@@ -766,6 +811,7 @@
   },
   "InsdcMaster": {
     "catalog": "nbdc02567",
+    "description": "It is a portal site for the INSDC(International Nucleotide Sequence Database Collaboration), which is an initiative operated between DDBJ, EMBL-EBI and NCBI.  Each organization operates DNA databases in close coordination and cooperation with each other to achieve common accession numbers, and standardize data format (INSD-XML). The databases are called the International Nucleotide Sequence Databases (INSD).",
     "examples": [
       "ABGA00000000",
       "AADE00000000",
@@ -788,6 +834,7 @@
   },
   "Intact": {
     "catalog": "nbdc00507",
+    "description": "IntAct is a database of molecular interactions. The database contains information on more than 400,000 interactions gathered from primary literature. Users can search by gene, protein, or publication, among others, and the database includes manually annotated data from several other interaction databases. Software and bulk data, updoated weekly, are also available for download.",
     "examples": [
       "EBI-7947422",
       "EBI-15714708",
@@ -810,6 +857,7 @@
   },
   "Interpro": {
     "catalog": "nbdc00108",
+    "description": "InterPro is a database that analyses proteins functionally and classifies them into families as well as predicts their domain and sites in the genome.\r\nThis repository harvests its content from a large number of related databases and consolidates its findings into a single searchable resource avoiding the occurrence of redundant entries.\r\nInterPro aims to update their content every 8 weeks.\r\nA keyword search is available and an option is provided where a protein sequence can be entered for analysis.",
     "examples": [
       "IPR038152",
       "IPR040448",
@@ -918,6 +966,7 @@
   },
   "Lrg": {
     "catalog": "nbdc02566",
+    "description": "LRG is a database of stable genomic, transcript and protein reference sequences for reporting clinically relevant sequence variants. NCBI (RefSeq) and EMBL-EBI (Ensembl/GENCODE) are working together to rationalise differences in their gene sets. Records contain information about genomic, transcript and protein sequences, annotations, maps about the genome assembly, etc. This database allows users to search using LRG identifier, HGNC gene name, NCBI and Ensembl accession numbers (gene or transcript), gene synonym or LRG status (public or pending). Genome browsers on Ensembl, NCBI and UCSC are available.",
     "examples": [
       "LRG_41",
       "LRG_356",
@@ -940,6 +989,7 @@
   },
   "MbgdGene": {
     "catalog": "nbdc00130",
+    "description": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison.",
     "examples": [
       "ash:AL1_RS04670",
       "ash:AL1_RS08245",
@@ -962,6 +1012,7 @@
   },
   "MbgdOrganism": {
     "catalog": "nbdc00130",
+    "description": "MBGD is a database with a workbench system for comparative analysis of completely sequenced microbial genomes, mainly for creating orthologous or homologous gene cluster tables. MBGD classifies genomes by the hierarchical clustering method known as UPGMA, using precomputed similarity relationships identified by all-against-all BLAST search. Users can change the set of organisms or cutoff parameters to create their own orthologous groupings. Thus comparative genomics is facilitated from various points of view such as ortholog identification, paralog clustering, motif analysis and gene order comparison.",
     "examples": [
       "lac",
       "pfl",
@@ -984,6 +1035,7 @@
   },
   "Meddra": {
     "catalog": "nbdc02564",
+    "description": "MedDRA is a standardized medical terminology for regulatory information of medical products. It is available for use in the registration, documentation and safety monitoring of medical products. It is provided in many languages, which are Chinese, Czech, Dutch, French, German, Hungarian, Italian, Japanese, Korean, Portuguese, Portuguese - Brazilian, Russian, and Spanish in addition to English Master.",
     "examples": [
       "10008033",
       "10027710",
@@ -1006,6 +1058,7 @@
   },
   "Medgen": {
     "catalog": "nbdc02560",
+    "description": "MedGen is a portal database about conditions and phenotypes related to Medical Genetics. It aggregates terms from the NIH Genetic Testing Registry (GTR), UMLS, HPO, Orphanet, ClinVar and other sources into concepts, and assigns a unique identifier and a preferred name and symbol. Each entry includes names, identifiers used by other databases, mode of inheritance, clinical features, and map location of the loci affecting the disorder. This database provides links to such resources as:\r\nGenetic tests registered in the NIH Genetic Testing Registry (GTR), GeneReviews, ClinVar, OMIM, Related genes, Disorders with similar clinical features, Medical and research literature, Practice guidelines, Consumer resources, Ontologies such as HPO and ORDO.",
     "examples": [
       "C0264897",
       "C0028860",
@@ -1028,6 +1081,7 @@
   },
   "Mesh": {
     "catalog": "nbdc00132",
+    "description": "This is a database of keywords representing the content of articles and biological information. The keywords are structured in layers to allow users to find more detailed information or perform abstract searches.",
     "examples": [
       "D002065",
       "C562829",
@@ -1050,6 +1104,7 @@
   },
   "MgiAllele": {
     "catalog": "nbdc00135",
+    "description": "This is a comprehensive site for mouse research. The site contains detailed information on mouse genes, gene expression data, polymorphisms and mutations, pathways, data on model rats for hereditary cancers, and phenotypes of each mouse model system. They have developed and provided The Human - Mouse: Disease Connection (HMDC) and Mammalian Phenotype Ontology.",
     "examples": [
       "MGI:1857242",
       "MGI:1857411",
@@ -1072,6 +1127,7 @@
   },
   "MgiGene": {
     "catalog": "nbdc00135",
+    "description": "This is a comprehensive site for mouse research. The site contains detailed information on mouse genes, gene expression data, polymorphisms and mutations, pathways, data on model rats for hereditary cancers, and phenotypes of each mouse model system. They have developed and provided The Human - Mouse: Disease Connection (HMDC) and Mammalian Phenotype Ontology.",
     "examples": [
       "MGI:2387184",
       "MGI:1920977",
@@ -1094,6 +1150,7 @@
   },
   "MgiGenotype": {
     "catalog": "nbdc00135",
+    "description": "This is a comprehensive site for mouse research. The site contains detailed information on mouse genes, gene expression data, polymorphisms and mutations, pathways, data on model rats for hereditary cancers, and phenotypes of each mouse model system. They have developed and provided The Human - Mouse: Disease Connection (HMDC) and Mammalian Phenotype Ontology.",
     "examples": [
       "MGI:2166359",
       "MGI:2166381",
@@ -1116,6 +1173,7 @@
   },
   "Mirbase": {
     "catalog": "nbdc00136",
+    "description": "miRBase is a database for published microRNA sequences and annotations, which include mature miRNA sequences (indicated by miR), and hairpin structures predicted by sequences that are precursors for miRNA (indicated by mir). A variety of search methods can be used, including by keyword, genomic position, cluster, expression data, and user-provided sequences. Furthermore, these sequences and annotations can be downloaded.",
     "examples": [
       "MI0003587",
       "MI0000252",
@@ -1138,6 +1196,7 @@
   },
   "Mondo": {
     "catalog": "nbdc02563",
+    "description": "Mondo is an ontology for integrating disease definitions. It collects disease definitions and data models from numerous sources, which include HPO, OMIM, SNOMED CT, ICD, PhenoDB, MedDRA, MedGen, ORDO, DO, GARD, etc. It provides a hierarchical structure which can be used for classification or \"rolling up\" diseases to higher level groupings.",
     "examples": [
       "MONDO:0000115",
       "MONDO:0002345",
@@ -1181,6 +1240,7 @@
   },
   "Nando": {
     "catalog": "nbdc02557",
+    "description": "NanbyoData provides informative data related to intractable diseases using Nanbyo Disease Ontology (NANDO). Designated intractable diseases and chronic specific pediatric diseases in Japan are the subject diseases. NANDO, and genes and phenotypes related intractable diseases are downloadable.",
     "examples": [
       "NANDO:1200461",
       "NANDO:1200466",
@@ -1203,6 +1263,7 @@
   },
   "NbdcHumanDb": {
     "catalog": "nbdc01348",
+    "description": "This site is a platform for sharing data from studies in humans, providing rules and frameworks for promoting the utilization and sharing of the enormous amount of human data while considering protection of personal information. The site was established by the JST NBDC and cooperates with the DNA Data Bank of Japan (DDBJ) to publish data. This site can provide data related to humans as well as guidelines for the use of such information.",
     "examples": [
       "hum0004",
       "hum0006",
@@ -1225,6 +1286,7 @@
   },
   "Ncbigene": {
     "catalog": "nbdc00073",
+    "description": "The gene database provides information on gene sequence, structure, location, and function for annotated genes from the NCBI database. Users can search by accession ID or keyword, compare and identify sequences using BLAST, or submit references into function (RIFs) based on experimental results. Bulk download and an update mailing list are available.",
     "examples": [
       "63962027",
       "1046",
@@ -1333,6 +1395,7 @@
   },
   "OmimGene": {
     "catalog": "nbdc00154",
+    "description": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype.",
     "examples": [
       "604810",
       "115460",
@@ -1355,6 +1418,7 @@
   },
   "OmimPhenotype": {
     "catalog": "nbdc00154",
+    "description": "OMIM is a database of human disease and genetic information and the online representation of Mendelian Inheritance in Man, a project initiated in the 1960s. The database summarizes heritable traits and provides information on both the trait and experimentally determined genetic causes. The database is manually curated by experts and can be searched by OMIM ID, gene, disease, or phenotype.",
     "examples": [
       "207780",
       "236100",
@@ -1377,6 +1441,7 @@
   },
   "OrphanetGene": {
     "catalog": "nbdc01422",
+    "description": "Orphanet is a portal site for rare diseases and orphan drugs. It provides inventory of rare diseases and classification, inventory of orphan drugs, clinical trials, etc.",
     "examples": [
       "ORPHA:217124",
       "ORPHA:218033",
@@ -1399,6 +1464,7 @@
   },
   "OrphanetPhenotype": {
     "catalog": "nbdc01422",
+    "description": "Orphanet is a portal site for rare diseases and orphan drugs. It provides inventory of rare diseases and classification, inventory of orphan drugs, clinical trials, etc.",
     "examples": [
       "ORPHA:101078",
       "ORPHA:596",
@@ -1442,6 +1508,7 @@
   },
   "Pdb": {
     "catalog": "nbdc00156",
+    "description": "This is an international public repository for three-dimensional structures and structure coordinates (conformations) of proteins and nucleic acids, and the central database for biological structural data. Data obtained through X-ray crystallography and NMR experiments are stored in PDB. In addition to three-dimensional information of proteins, users can find amino acid sequences, protein-related information on GO, and other compounds bound to the protein.",
     "examples": [
       "3PFQ",
       "2OUY",
@@ -1486,6 +1553,7 @@
   },
   "Pfam": {
     "catalog": "nbdc00163",
+    "description": "Pfam Version 26.0 is a comprehensive database of protein families containing multiple sequence alignments and HMMs.\r\nThis repository provides data on 13,672 protein families.\r\nThe site can be searched with a known protein sequence for matching families. \r\nOptions to search for a Pfam family, clan, sequence or structure are available.\r\nA keyword search option is also provided.",
     "examples": [
       "PF03719",
       "PF03726",
@@ -1506,8 +1574,31 @@
     "prefix": "Pfam",
     "uri_format": "http://identifiers.org/pfam/$1"
   },
+  "Pmc": {
+    "catalog": "nbdc01836",
+    "examples": [
+      "PMC7857752",
+      "PMC10139720",
+      "PMC3815299",
+      "PMC4990340",
+      "PMC6885017",
+      "PMC5286597",
+      "PMC8035296",
+      "PMC46450",
+      "PMC11138896",
+      "PMC9528096"
+    ],
+    "keywords": [
+      "Literature"
+    ],
+    "name": "PMC",
+    "pattern": "^(?:PMC)?(?\\d+)$",
+    "prefix": "Pmc",
+    "uri_format": "http://identifiers.org/pmc/PMC$1"
+  },
   "Prosite": {
     "catalog": "nbdc00241",
+    "description": "ExPASy PROSITE is a database of protein domains, protein families and their functional sites.\r\nThis repository also provides profiles and associated patterns, which can be used to identify the above.\r\nThis version (20.91) was made available on 4 March 2013.\r\nIt contains 1,661 documentation entries, 1,053 profiles and 1,308 patterns.\r\nThe database can be searched by entering a document number, a ProRule description, a taxonomic series or by calling up a page, whereupon the proteins are listed according to the number of positive UniProtKB hits, from most to least.\r\nThe option is also provided to have a sequence scanned against PROSITE patterns and profiles.\r\nIn the Advanced search option that is available, additional criteria may be added when a scan request is entered to specify the results more accurately.",
     "examples": [
       "PS01177",
       "PS00516",
@@ -1530,6 +1621,7 @@
   },
   "PrositeProrule": {
     "catalog": "nbdc00241",
+    "description": "ExPASy PROSITE is a database of protein domains, protein families and their functional sites.\r\nThis repository also provides profiles and associated patterns, which can be used to identify the above.\r\nThis version (20.91) was made available on 4 March 2013.\r\nIt contains 1,661 documentation entries, 1,053 profiles and 1,308 patterns.\r\nThe database can be searched by entering a document number, a ProRule description, a taxonomic series or by calling up a page, whereupon the proteins are listed according to the number of positive UniProtKB hits, from most to least.\r\nThe option is also provided to have a sequence scanned against PROSITE patterns and profiles.\r\nIn the Advanced search option that is available, additional criteria may be added when a scan request is entered to specify the results more accurately.",
     "examples": [
       "PRU00498",
       "PRU00672",
@@ -1552,6 +1644,7 @@
   },
   "PubchemCompound": {
     "catalog": "nbdc00641",
+    "description": "PubChem Compound is a database of chemical structrues of validated small molecules. The dataase contains entries for PubChem entities which are grouped by structural identity and similarity. Users can submit compounds and download via FTP.",
     "examples": [
       "9548669",
       "160419",
@@ -1596,6 +1689,7 @@
   },
   "PubchemSubstance": {
     "catalog": "nbdc00642",
+    "description": "PubChem Substance is a database of samples of chemical entities which links to the biological activity of those samples in PubChem BioAssay. The database contains structural information on substances with links to further information in cases where the substance has been more fully characterized. It consists of records of chemical entities deposited by various contributors, so a chemical entity may be described different records with different data in this database.",
     "examples": [
       "15229855",
       "15277848",
@@ -1618,6 +1712,7 @@
   },
   "Pubmed": {
     "catalog": "nbdc00179",
+    "description": "This database contains bibliographic information from journal articles in the field of life science as well as MEDLINE (title, authors, journal name, abstracts). Links are provided for articles with free access to the full article.",
     "examples": [
       "19281226",
       "19879151",
@@ -1640,6 +1735,7 @@
   },
   "ReactomePathway": {
     "catalog": "nbdc00185",
+    "description": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human.",
     "examples": [
       "R-HSA-165159",
       "R-DRE-1630316",
@@ -1662,6 +1758,7 @@
   },
   "ReactomeReaction": {
     "catalog": "nbdc00185",
+    "description": "REACTOME is a database of human pathways for basic research, genome analysis, pathway modeling, systems biology and education. It contains manually curated and peer-reviewed pathway data which are annotated by expert biologists, in collaboration with Reactome editorial staff and cross-referenced to many bioinformatics databases. This database provides an intuitive website to navigate pathway knowledge and a suite of data analysis tools to support the pathway-based analysis of complex experimental and computational data sets. The curated  human pathway data are available to infer orthologous events in 20 non-human species including mouse, rat, chicken, worm, fly, yeast, plant and bacteria. Using species comparison tool, users are able to compare predicted pathways with those of human to find reactions and pathways common to a selected species and human.",
     "examples": [
       "R-DRE-1482961",
       "R-DRE-6814409",
@@ -1684,6 +1781,7 @@
   },
   "RefseqGenomic": {
     "catalog": "nbdc00187",
+    "description": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download.",
     "examples": [
       "NG_004671",
       "NG_011844",
@@ -1707,6 +1805,7 @@
   },
   "RefseqProtein": {
     "catalog": "nbdc00187",
+    "description": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download.",
     "examples": [
       "NP_001171968",
       "NP_001365494",
@@ -1729,6 +1828,7 @@
   },
   "RefseqRna": {
     "catalog": "nbdc00187",
+    "description": "RefSeq is a database of standard reference genomic, transcript, and protein sequences. The database contains consensus sequence data for over 20,000 organisms and over 27 million proteins and is designed to provide a common basis for experimental studies that can be searched using accession ID, keyword, or BLAST. Bulk data is available for FTP download.",
     "examples": [
       "XR_001747779",
       "XM_017013006",
@@ -1751,6 +1851,7 @@
   },
   "Rgd": {
     "catalog": "nbdc00188",
+    "description": "This is a comprehensive site for rat genome researches. In addition to information on rat genes, the site contains information on rat strains, data on rat models for disease, and publications.",
     "examples": [
       "1308312",
       "1311120",
@@ -1795,6 +1896,7 @@
   },
   "Sgd": {
     "catalog": "nbdc00202",
+    "description": "This is an integrated database for budding yeast Saccharomyces cerevisiae. It contains search and analysis tools based on genes, sequences, and functions, as well as information related to citations, and the community. The information is updated and maintained by curators. It enables users to find functional relationships to sequences and gene products of fungi and higher organisms can also be verified. The SGD also maintains all gene names for budding yeast through the gene Name Registry.",
     "examples": [
       "S000003096",
       "S000003789",
@@ -1817,6 +1919,7 @@
   },
   "Smart": {
     "catalog": "nbdc00682",
+    "description": "SMART is a database of protein domains found in several different protein classes. The database contains classification information for domains and the proteins they can be found in. Users can search by sequence or domain information. The database can also be requested for local installation.",
     "examples": [
       "SM00130",
       "SM00239",
@@ -1839,6 +1942,7 @@
   },
   "SraAccession": {
     "catalog": "nbdc00687",
+    "description": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP.",
     "examples": [
       "DRA000741",
       "DRA000768",
@@ -1861,6 +1965,7 @@
   },
   "SraAnalysis": {
     "catalog": "nbdc00687",
+    "description": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP.",
     "examples": [
       "DRZ000249",
       "DRZ000087",
@@ -1883,6 +1988,7 @@
   },
   "SraExperiment": {
     "catalog": "nbdc00687",
+    "description": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP.",
     "examples": [
       "DRX000585",
       "DRX000114",
@@ -1905,6 +2011,7 @@
   },
   "SraProject": {
     "catalog": "nbdc00687",
+    "description": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP.",
     "examples": [
       "DRP000994",
       "DRP000877",
@@ -1927,6 +2034,7 @@
   },
   "SraRun": {
     "catalog": "nbdc00687",
+    "description": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP.",
     "examples": [
       "DRR000834",
       "DRR000683",
@@ -1949,6 +2057,7 @@
   },
   "SraSample": {
     "catalog": "nbdc00687",
+    "description": "SRA is a database of raw sequence reads from next-generation sequencing systems. The database contains millions of unannotated raw reads generated from a variety of projects. Data can be submitted to the archive or downloaded via FTP.",
     "examples": [
       "DRS001431",
       "DRS001371",
@@ -1993,6 +2102,7 @@
   },
   "Tair": {
     "catalog": "nbdc00697",
+    "description": "TAIR is a database of Arabidopsis thaliana information. The database contains genetic and molecular information for the plant, including several browseable data formats including seed stocks, gene names, and mutant collections. Users can download data from several categories, from images to gene expression microarrays.",
     "examples": [
       "AT3G60400",
       "AT1G26300",
@@ -2015,6 +2125,7 @@
   },
   "Taxonomy": {
     "catalog": "nbdc00700",
+    "description": "Taxonomy is a database of systematic classifications of organisms repesented in public sequencing databases. The database contains phylogenetic relatonships and nomenclature for an estimated 10% of all living species. Tools include a browser, genetic codes, and a common evolutionary tree. Taxonomic classificatinos can be downloaded via FTP.",
     "examples": [
       "1171376",
       "484906",
@@ -2037,6 +2148,7 @@
   },
   "Togovar": {
     "catalog": "nbdc02359",
+    "description": "TogoVar (NBDC's integrated database of Japanese genomic variation) is a database that has collected and organized genome sequence differences between individuals (variants) in the Japanese population and disease information associated with them. TogoVar provides variant frequencies in the Japanese population that have been aggregated across research projects. Two available datasets, JGA-NGS and JGA-SNP, are obtained by aggregating individual genomic data that have been registered in the NBDC Human Database / Japanese Genotype-phenotype Archive (JGA). In addition, TogoVar integrates information related to genotypes or phenotypes that has been compiled independently in a variety of different databases and provides information for interpreting variants in a one-stop, easy-to-understand manner.\r\nUsers can learn how to use it by a movie: https://togotv.dbcls.jp/en/20181012.html",
     "examples": [
       "tgv100005930",
       "tgv100000890",
@@ -2080,6 +2192,7 @@
   },
   "Uniprot": {
     "catalog": "nbdc00221",
+    "description": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes.",
     "examples": [
       "A0A174V9D2",
       "A0A1V4U2Y9",
@@ -2102,6 +2215,7 @@
   },
   "UniprotMnemonic": {
     "catalog": "nbdc00221",
+    "description": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes.",
     "examples": [
       "2ABA_ORYSJ",
       "33K_ADES1",
@@ -2122,12 +2236,12 @@
     "prefix": "UniprotMnemonic",
     "uri_format": "http://purl.uniprot.org/uniprot/$1"
   },
-  "UniprotReferenceProteome": {
+  "UniprotProteome": {
     "catalog": "nbdc00221",
+    "description": "This database contains information on amino acid sequences and their functions. It is composed of four core databases, UniProtKB, UniRef, UniParc, and Proteomes. UniProtKB contains two types of data, which are manually curated high quality SwissProt annotations based on literature information, and automatically annotated TrEMBL. \r\nUniRef provides results of sequence similarity searches. \r\nUniParc integrates information such as ID for other databases per sequence ID.\r\nProteomes provides proteome data of each organism with completely sequenced genomes.",
     "examples": [
       "UP000005640",
       "UP000002311",
-      "UP000005640",
       "UP000000589",
       "UP000000803",
       "UP000000437",
@@ -2139,9 +2253,9 @@
     "keywords": [
       "Proteome"
     ],
-    "name": "UniProt reference proteome",
+    "name": "UniProt proteome",
     "pattern": "^(?UP\\d{0,9})$",
-    "prefix": "UniprotReferenceProteome",
+    "prefix": "UniprotProteome",
     "uri_format": "http://purl.uniprot.org/proteomes/$1"
   },
   "Vgnc": {
@@ -2190,6 +2304,7 @@
   },
   "WormbaseGene": {
     "catalog": "nbdc00740",
+    "description": "WormBase is a database of information on nematodes and other worms. The database contains extensive information on a number of species including genome sequences, genes, gene expression, proteins, and phenotypes. Users can search by keyword, BLAST, or BLAT, and create user accounts to save searches and other useful information.",
     "examples": [
       "WBGene00016754",
       "WBGene00015101",
@@ -2234,6 +2349,7 @@
   },
   "ZfinGene": {
     "catalog": "nbdc00746",
+    "description": "ZFIN is a central repository and web-based resource for zebrafish genetics and development. This database contains manually curated data for zebrafish genes, phenotypes, genotypes, gene expression, antibodies, anatomical structures and publications from three primary sources: curation of zebrafish publications, individual research laboratories and collaborations with bioinformatics organizations. The database also contains a wide-ranging collection of web-based search forms and tools facilitates access to integrated views of these data promoting analysis and scientific discovery. ZFIN works closely with ZIRC to connect their genetic data with available probes and fish lines.",
     "examples": [
       "ZDB-GENE-030131-9947",
       "ZDB-GENE-030131-2670",


### PR DESCRIPTION
This PR implements retrieving descriptions for external TodoID entries and adding them to the pre-processed data artifact. This is beneficial for workflows such as #1439 to which additional description serves as important context in understanding what exact resource a prefix represents.