### PR TITLE
Add prefix: cncb.gwh

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -244,4 +244,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39876062	1	0009-0008-8406-631X	2025-02-01	new_prefix	1398	
 39877976	0	0009-0008-8406-631X	2025-01-21	irrelevant_other	1431	
 39882309	0	0009-0008-8406-631X	2025-01-18	non_resource_paper	1431	unable to resolve identifiers bc format is tsv
-39977364	1	0009-0008-8406-631X	2025-03-07	new_publication	1452	
+39977364	1	0009-0008-8406-631X	2025-03-07	new_prefix	1452	

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -244,3 +244,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39876062	1	0009-0008-8406-631X	2025-02-01	new_prefix	1398	
 39877976	0	0009-0008-8406-631X	2025-01-21	irrelevant_other	1431	
 39882309	0	0009-0008-8406-631X	2025-01-18	non_resource_paper	1431	unable to resolve identifiers bc format is tsv
+39977364	1	0009-0008-8406-631X	2025-03-07	new_publication		

--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -244,4 +244,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39876062	1	0009-0008-8406-631X	2025-02-01	new_prefix	1398	
 39877976	0	0009-0008-8406-631X	2025-01-21	irrelevant_other	1431	
 39882309	0	0009-0008-8406-631X	2025-01-18	non_resource_paper	1431	unable to resolve identifiers bc format is tsv
-39977364	1	0009-0008-8406-631X	2025-03-07	new_publication		
+39977364	1	0009-0008-8406-631X	2025-03-07	new_publication	1452	


### PR DESCRIPTION
This PR adds a new prefix called `gwh` (The Genome Warehouse). The link to the pubmed article and database are below:

https://pubmed.ncbi.nlm.nih.gov/39977364/
https://ngdc.cncb.ac.cn/gwh/

This repository is separated into three categories: Assembly, Coronaviridae, and Poxviridae. This prefix is for the "Assembly" part of the database. Each of the other categories are providers for existing prefixes. 