### PR TITLE
Add prefix: phagedive

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -58,6 +58,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39341994	0	0009-0009-5240-7463	2024-10-15	not_identifiers_resource	1223	
 39345624	1	0009-0009-5240-7463	2024-10-19	new_publication	1223	Publication for sgd and sgd.pathways
 39373530	1	0009-0009-5240-7463	2025-02-15	new_prefix	1418	
+39373542	1	0009-0009-5240-7463	2025-03-09	new_prefix	1454	
 39379619	1	0009-0009-5240-7463	2024-11-26	new_provider	1285	Provider for UniProt
 39399372	0	0009-0009-5240-7463	2024-11-19	irrelevant_other	1288	
 39401100	1	0009-0009-5240-7463	2024-11-20	new_publication	1264	Publication for intact and intact.molecule


### PR DESCRIPTION
This PR curates a new prefix: `phagedive`.

PubMed: https://pubmed.ncbi.nlm.nih.gov/39373542/
Database: https://phagedive.dsmz.de/

It is a database of bacteriophages and archaeal viruses and provides details regarding their taxonomy, host strain, phage morphology, life cycle, origin and genomic data.