### PR TITLE
Improve parsing return types

### DIFF
--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -1,11 +1,13 @@
 """Constants and utilities for registries."""
 
+import enum
 import os
 import pathlib
 import re
 from typing import Union
 
 import pystow
+from curies import ReferenceTuple
 
 __all__ = [
     "BIOREGISTRY_MODULE",
@@ -16,6 +18,8 @@ __all__ = [
     "METAREGISTRY_PATH",
     "MISMATCH_PATH",
     "RAW_DIRECTORY",
+    "FailureReturnType",
+    "get_failure_return_type",
 ]
 
 PATTERN_KEY = "pattern"
@@ -154,7 +158,7 @@ EXTRAS = f"%20Community%20Health%20Score&link={CH_BASE}"
 EMAIL_RE_STR = r"^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,7}$"
 EMAIL_RE = re.compile(EMAIL_RE_STR)
 
-MaybeCURIE = Union[tuple[str, str], tuple[None, None]]
+MaybeCURIE = Union[ReferenceTuple, tuple[None, None], None]
 
 DISALLOWED_EMAIL_PARTS = {
     "contact@",
@@ -163,3 +167,21 @@ DISALLOWED_EMAIL_PARTS = {
     "discuss@",
     "support@",
 }
+
+
+class FailureReturnType(enum.Enum):
+    """A flag for what to return when handling reference tuples."""
+
+    #: return a single None
+    single = enum.auto()
+    #: return a pair of None's
+    pair = enum.auto()
+
+
+def get_failure_return_type(frt: FailureReturnType) -> None | tuple[None, None]:
+    """Get the right failure return type."""
+    if frt == FailureReturnType.single:
+        return None
+    elif frt == FailureReturnType.pair:
+        return None, None
+    raise TypeError

--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -1,5 +1,7 @@
 """Constants and utilities for registries."""
 
+from __future__ import annotations
+
 import enum
 import os
 import pathlib

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -1,8 +1,10 @@
 """Functionality for parsing IRIs."""
 
-from typing import Optional
+from typing import Literal, Optional, overload
 
-from .constants import MaybeCURIE
+from curies import ReferenceTuple
+
+from .constants import FailureReturnType
 from .resource_manager import manager
 
 __all__ = [
@@ -51,17 +53,49 @@ def curie_from_iri(
     return manager.compress(iri, use_preferred=use_preferred)
 
 
+# docstr-coverage:excused `overload`
+@overload
+def parse_iri(
+    iri: str,
+    *,
+    use_preferred: bool = ...,
+    on_failure_return_type: Literal[FailureReturnType.pair] = FailureReturnType.pair,
+) -> ReferenceTuple | tuple[None, None]: ...
+
+
+# docstr-coverage:excused `overload`
+@overload
+def parse_iri(
+    iri: str,
+    *,
+    use_preferred: bool = ...,
+    on_failure_return_type: Literal[FailureReturnType.single],
+) -> ReferenceTuple | None: ...
+
+
 def parse_iri(
     iri: str,
     *,
     use_preferred: bool = False,
-) -> MaybeCURIE:
+    on_failure_return_type: FailureReturnType = FailureReturnType.pair,
+) -> ReferenceTuple | tuple[None, None] | None:
     """Parse a compact identifier from an IRI that wraps :meth:`Manager.parse_uri`.
 
     :param iri: A valid IRI
     :param use_preferred:
         If set to true, uses the "preferred prefix", if available, instead
         of the canonicalized Bioregistry prefix.
+    :param on_failure_return_type: whether to return a single None or a pair of None's
     :return: A pair of prefix/identifier, if can be parsed
+    :raises TypeError: if an invalid on_failure_return_type is given
     """
-    return manager.parse_uri(iri, use_preferred=use_preferred)
+    if on_failure_return_type == FailureReturnType.single:
+        return manager.parse_uri(
+            iri, use_preferred=use_preferred, on_failure_return_type=on_failure_return_type
+        )
+    elif on_failure_return_type == FailureReturnType.pair:
+        return manager.parse_uri(
+            iri, use_preferred=use_preferred, on_failure_return_type=on_failure_return_type
+        )
+    else:
+        raise TypeError

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -1,5 +1,7 @@
 """Functionality for parsing IRIs."""
 
+from __future__ import annotations
+
 from typing import Literal, Optional, overload
 
 from curies import ReferenceTuple

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -58,7 +58,7 @@ def sparql_service_available(endpoint: str) -> bool:
     """Test if a SPARQL service is running."""
     try:
         records = get(endpoint, PING_SPARQL, "application/json")
-    except requests.exceptions.ConnectionError:
+    except (requests.exceptions.ConnectionError, requests.exceptions.JSONDecodeError):
         return False
     return list(records) == [("hello", "there")]
 

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -135,7 +135,7 @@ class TestWeb(unittest.TestCase):
                     g.query("SELECT ?s WHERE { ?s a <https://bioregistry.io/schema/#0000001> }")
                 )
                 self.assertEqual(1, len(results))
-                self.assertEqual(f"https://bioregistry.io/registry/_3dmet", str(results[0][0]))
+                self.assertEqual("https://bioregistry.io/registry/_3dmet", str(results[0][0]))
 
     def test_api_metaregistry(self):
         """Test the metaregistry endpoint."""

--- a/tox.ini
+++ b/tox.ini
@@ -144,6 +144,7 @@ deps =
     types-beautifulsoup4
     types-Markdown
     pystow
+    curies
 extras =
     web
     charts


### PR DESCRIPTION
This PR adds a `on_failure_return_type` option to several parsing-related functions so you can opt into returning `None` instead of `tuple[None, None]`.

This PR also switches from regular 2-tuples to `curies.ReferenceTuple` named tuples for functions that handle/return prefix-identifier pairs.