### PR TITLE
Add prefix: rdbsb

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -57,6 +57,7 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39341795	1	0009-0009-5240-7463	2024-10-19	new_prefix	1223	Identifiers for non-coding RNA biomarkers for cancers
 39341994	0	0009-0009-5240-7463	2024-10-15	not_identifiers_resource	1223	
 39345624	1	0009-0009-5240-7463	2024-10-19	new_publication	1223	Publication for sgd and sgd.pathways
+39360609	1	0009-0009-5240-7463	2024-03-21	new_prefix	1473	
 39373530	1	0009-0009-5240-7463	2025-02-15	new_prefix	1418	
 39379619	1	0009-0009-5240-7463	2024-11-26	new_provider	1285	Provider for UniProt
 39399372	0	0009-0009-5240-7463	2024-11-19	irrelevant_other	1288	


### PR DESCRIPTION
This PR curates a new prefix: `rdbsb`.

PubMed: https://pubmed.ncbi.nlm.nih.gov/39360609/
Database: https://www.biosino.org/rdbsb/

It is a database of catalytic bioparts which provides basic details, function information, and sequence information.