### PR TITLE
Add standard references

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -242,7 +242,9 @@ texinfo_documents = [
 # Note: don't add trailing slashes, since sphinx adds "/objects.inv" to the end
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "rdflib": ("https://rdflib.readthedocs.io/en/stable/", None),
+    "rdflib": ("https://rdflib.readthedocs.io/en/stable", None),
+    "curies": ("https://curies.readthedocs.io/en/latest/", None),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
     "pandas": ("https://pandas.pydata.org/docs", None),
 }
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,6 +58,7 @@ To install in development mode, use the following:
    pandas
    deployment
    curation
+   references
 
 Indices and Tables
 ------------------

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -6,4 +6,3 @@ user-facing code from the Bioregistry Python package.
 .. automodapi:: bioregistry
     :no-heading:
     :no-main-docstr:
-    :no-inheritance-diagram:

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,0 +1,31 @@
+Reference Classes
+=================
+
+The :mod:`curies` package provides reusable building blocks for representing pre-parsed compact URIs
+(CURIEs) in more complex data models with :mod:`pydantic`.
+
+The Bioregistry extends these models using Pydantic's model validation framework (see
+:func:`pydantic.model_validator`) in order to automatically standardize prefixes and local unique
+identifiers against the Bioregistry database.
+
+There are two different implementations:
+
+1. Normalized references, which use Bioregistry's :func:`bioregistry.normalize_prefix` to create
+   fully lower-case prefixes - :class:`bioregistry.NormalizedReference` -
+   :class:`bioregistry.NormalizedNamableReference` - :class:`bioregistry.NormalizedNamedReference`
+2. Preferred references, which use :func:`bioregistry.get_preferred_prefix` to adds case stylization
+   in prefixes that often appears in semantic web applications. -
+   :class:`bioregistry.StandardReference` - :class:`bioregistry.StandardNamableReference` -
+   :class:`bioregistry.StandardNamedReference`
+
+In the following example, the prefix is normalized to lowercase.
+
+>>> from bioregistry import NormalizedReference
+>>> NormalizedReference(prefix="oboInOwl", identifier="inSubset")
+NormalizedReference(prefix='oboinowl', identifier='inSubset')
+
+In the following example, the prefix is stylized to the preferred prefix.
+
+>>> from bioregistry import StandardReference
+>>> StandardReference(prefix="oboInOwl", identifier="inSubset")
+StandardReference(prefix='oboInOwl', identifier='inSubset')

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -11,12 +11,18 @@ identifiers against the Bioregistry database.
 There are two different implementations:
 
 1. Normalized references, which use Bioregistry's :func:`bioregistry.normalize_prefix` to create
-   fully lower-case prefixes - :class:`bioregistry.NormalizedReference` -
-   :class:`bioregistry.NormalizedNamableReference` - :class:`bioregistry.NormalizedNamedReference`
+   fully lower-case prefixes
+
+   - :class:`bioregistry.NormalizedReference`
+   - :class:`bioregistry.NormalizedNamableReference`
+   - :class:`bioregistry.NormalizedNamedReference`
+
 2. Preferred references, which use :func:`bioregistry.get_preferred_prefix` to adds case stylization
-   in prefixes that often appears in semantic web applications. -
-   :class:`bioregistry.StandardReference` - :class:`bioregistry.StandardNamableReference` -
-   :class:`bioregistry.StandardNamedReference`
+   in prefixes that often appears in semantic web applications.
+
+   - :class:`bioregistry.StandardReference`
+   - :class:`bioregistry.StandardNamableReference`
+   - :class:`bioregistry.StandardNamedReference`
 
 In the following example, the prefix is normalized to lowercase.
 

--- a/src/bioregistry/__init__.py
+++ b/src/bioregistry/__init__.py
@@ -12,6 +12,14 @@ from .metaresource_api import (
     get_registry_uri,
 )
 from .parse_iri import curie_from_iri, parse_iri
+from .reference import (
+    NormalizedNamableReference,
+    NormalizedNamedReference,
+    NormalizedReference,
+    StandardNamableReference,
+    StandardNamedReference,
+    StandardReference,
+)
 from .resolve import (
     count_mappings,
     get_appears_in,
@@ -137,9 +145,15 @@ __all__ = [
     "Collection",
     "Context",
     "Manager",
+    "NormalizedNamableReference",
+    "NormalizedNamedReference",
+    "NormalizedReference",
     "Provider",
     "Registry",
     "Resource",
+    "StandardNamableReference",
+    "StandardNamedReference",
+    "StandardReference",
     "count_mappings",
     "curie_from_iri",
     "curie_to_str",

--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -57,7 +57,26 @@ def _standardize_values(values: dict[str, str]) -> dict[str, str]:
 
 
 class NormalizedReference(curies.Reference):
-    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+    """Extends :class:`curies.Reference` to normalize the prefix against the Bioregistry.
+
+    >>> NormalizedReference(prefix="go", identifier="0032571")
+    NormalizedReference(prefix='go', identifier='0032571')
+
+    With a name:
+
+    >>> NormalizedReference(prefix="go", identifier="0032571")
+    NormalizedReference(prefix='go', identifier='0032571')
+
+    Standardizes capitalization to lowercase:
+
+    >>> NormalizedReference(prefix="GO", identifier="0032571")
+    NormalizedReference(prefix='go', identifier='0032571')
+
+    Standardizes prefix synonyms to lowercase:
+
+    >>> NormalizedReference(prefix="GOBP", identifier="0032571")
+    NormalizedReference(prefix='go', identifier='0032571')
+    """
 
     @model_validator(mode="before")
     def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
@@ -66,15 +85,62 @@ class NormalizedReference(curies.Reference):
 
 
 class NormalizedNamableReference(NormalizedReference, curies.NamableReference):
-    """An extension to :class:`curies.NamableReference` that automatically validates prefix and identifier."""
+    """Extends :class:`curies.NamableReference` to normalize the prefix against the Bioregistry.
+
+    >>> NormalizedNamedReference(prefix="go", identifier="0032571")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name=None)
+
+    With a name:
+
+    >>> NormalizedNamedReference(prefix="go", identifier="0032571", name="response to vitamin K")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name='response to vitamin K')
+
+    Standardizes capitalization to lowercase:
+
+    >>> NormalizedNamedReference(prefix="GO", identifier="0032571", name="response to vitamin K")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name='response to vitamin K')
+
+    Standardizes prefix synonyms to lowercase:
+
+    >>> NormalizedNamedReference(prefix="GOBP", identifier="0032571", name="response to vitamin K")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name='response to vitamin K')
+    """
 
 
 class NormalizedNamedReference(NormalizedNamableReference, curies.NamedReference):
-    """An extension to :class:`curies.NamedReference` that automatically validates prefix and identifier."""
+    """Extends :class:`curies.NamedReference` to normalize the prefix against the Bioregistry.
+
+    >>> NormalizedNamedReference(prefix="go", identifier="0032571", name="response to vitamin K")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name='response to vitamin K')
+
+    Standardizes capitalization to lowercase:
+
+    >>> NormalizedNamedReference(prefix="GO", identifier="0032571", name="response to vitamin K")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name='response to vitamin K')
+
+    Standardizes prefix synonyms to lowercase:
+
+    >>> NormalizedNamedReference(prefix="GOBP", identifier="0032571", name="response to vitamin K")
+    NormalizedNamedReference(prefix='go', identifier='0032571', name='response to vitamin K')
+    """
 
 
 class StandardReference(curies.Reference):
-    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier.
+
+    >>> StandardReference(prefix="GO", identifier="0032571")
+    StandardReference(prefix='GO', identifier='0032571')
+
+    Standardizes capitalization to preferred prefix:
+
+    >>> StandardReference(prefix="go", identifier="0032571")
+    StandardReference(prefix='GO', identifier='0032571')
+
+    Standardizes prefix synonyms to lowercase:
+
+    >>> StandardReference(prefix="GOBP", identifier="0032571")
+    StandardReference(prefix='GO', identifier='0032571')
+    """
 
     @model_validator(mode="before")
     def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
@@ -83,8 +149,41 @@ class StandardReference(curies.Reference):
 
 
 class StandardNamableReference(StandardReference, curies.NamableReference):
-    """An extension to :class:`curies.NamableReference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.NamableReference` that automatically validates prefix and identifier.
+
+    >>> StandardNamableReference(prefix="GO", identifier="0032571")
+    StandardNamableReference(prefix='GO', identifier='0032571', name=None)
+
+    With a name:
+
+    >>> StandardNamableReference(prefix="GO", identifier="0032571", name="response to vitamin K")
+    StandardNamableReference(prefix='GO', identifier='0032571', name='response to vitamin K')
+
+    Standardizes capitalization to preferred prefix:
+
+    >>> StandardNamableReference(prefix="go", identifier="0032571", name="response to vitamin K")
+    StandardNamableReference(prefix='GO', identifier='0032571', name='response to vitamin K')
+
+    Standardizes prefix synonyms to lowercase:
+
+    >>> StandardNamableReference(prefix="GOBP", identifier="0032571", name="response to vitamin K")
+    StandardNamableReference(prefix='GO', identifier='0032571', name='response to vitamin K')
+    """
 
 
 class StandardNamedReference(StandardNamableReference, curies.NamedReference):
-    """An extension to :class:`curies.NamedReference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.NamedReference` that automatically validates prefix and identifier.
+
+    >>> StandardNamedReference(prefix="GO", identifier="0032571", name="response to vitamin K")
+    StandardNamedReference(prefix='GO', identifier='0032571', name='response to vitamin K')
+
+    Standardizes capitalization to preferred prefix:
+
+    >>> StandardNamedReference(prefix="go", identifier="0032571", name="response to vitamin K")
+    StandardNamedReference(prefix='GO', identifier='0032571', name='response to vitamin K')
+
+    Standardizes prefix synonyms to lowercase:
+
+    >>> StandardNamedReference(prefix="GOBP", identifier="0032571", name="response to vitamin K")
+    StandardNamedReference(prefix='GO', identifier='0032571', name='response to vitamin K')
+    """

--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import bioregistry
+import curies
+from curies.api import ExpansionError, IdentifierStandardizationError
+from pydantic import model_validator
+
+__all__ = [
+    "StandardReference",
+    "StandardNamableReference",
+    "StandardNamedReference"
+]
+
+
+def validate_identifier(values: dict[str, str]) -> dict[str, str]:  # noqa
+    """Validate the identifier."""
+    prefix, identifier = values.get("prefix"), values.get("identifier")
+    if not prefix or not identifier:
+        raise RuntimeError
+    resource = bioregistry.get_resource(prefix)
+    if resource is None:
+        raise ExpansionError(f"Unknown prefix: {prefix}")
+    values["prefix"] = resource.prefix
+    if " " in identifier:
+        raise IdentifierStandardizationError(f"[{prefix}] space in identifier: {identifier}")
+    values["identifier"] = resource.standardize_identifier(identifier)
+    if not resource.is_valid_identifier(values["identifier"]):
+        raise IdentifierStandardizationError(f"non-standard identifier: {resource.prefix}:{values['identifier']}")
+    return values
+
+
+class StandardReference(curies.Reference):
+    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+
+    @model_validator(mode="before")
+    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
+        """Validate the identifier."""
+        return validate_identifier(values)
+
+
+
+class StandardNamableReference(StandardReference, curies.NamableReference):
+    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+
+    @model_validator(mode="before")
+    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
+        """Validate the identifier."""
+        return validate_identifier(values)
+
+class StandardNamedReference(StandardNamableReference, curies.NamedReference):
+    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+
+    @model_validator(mode="before")
+    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
+        """Validate the identifier."""
+        return validate_identifier(values)

--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -9,16 +9,16 @@ from pydantic import model_validator
 import bioregistry
 
 __all__ = [
-    "NormalizedReference",
     "NormalizedNamableReference",
     "NormalizedNamedReference",
-    "StandardReference",
-    "StandardNamedReference",
+    "NormalizedReference",
     "StandardNamableReference",
+    "StandardNamedReference",
+    "StandardReference",
 ]
 
 
-def _normalize_values(values: dict[str, str]) -> dict[str, str]:  # noqa
+def _normalize_values(values: dict[str, str]) -> dict[str, str]:
     """Validate the identifier."""
     prefix, identifier = values.get("prefix"), values.get("identifier")
     if not prefix or not identifier:
@@ -37,7 +37,7 @@ def _normalize_values(values: dict[str, str]) -> dict[str, str]:  # noqa
     return values
 
 
-def _standardize_values(values: dict[str, str]) -> dict[str, str]:  # noqa
+def _standardize_values(values: dict[str, str]) -> dict[str, str]:
     """Validate the identifier."""
     prefix, identifier = values.get("prefix"), values.get("identifier")
     if not prefix or not identifier:

--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -66,11 +66,11 @@ class NormalizedReference(curies.Reference):
 
 
 class NormalizedNamableReference(NormalizedReference, curies.NamableReference):
-    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.NamableReference` that automatically validates prefix and identifier."""
 
 
 class NormalizedNamedReference(NormalizedNamableReference, curies.NamedReference):
-    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.NamedReference` that automatically validates prefix and identifier."""
 
 
 class StandardReference(curies.Reference):
@@ -83,8 +83,8 @@ class StandardReference(curies.Reference):
 
 
 class StandardNamableReference(StandardReference, curies.NamableReference):
-    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.NamableReference` that automatically validates prefix and identifier."""
 
 
 class StandardNamedReference(StandardNamableReference, curies.NamedReference):
-    """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
+    """An extension to :class:`curies.NamedReference` that automatically validates prefix and identifier."""

--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -68,19 +68,9 @@ class NormalizedReference(curies.Reference):
 class NormalizedNamableReference(NormalizedReference, curies.NamableReference):
     """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
 
-    @model_validator(mode="before")
-    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
-        """Validate the identifier."""
-        return _normalize_values(values)
-
 
 class NormalizedNamedReference(NormalizedNamableReference, curies.NamedReference):
     """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
-
-    @model_validator(mode="before")
-    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
-        """Validate the identifier."""
-        return _normalize_values(values)
 
 
 class StandardReference(curies.Reference):
@@ -95,16 +85,6 @@ class StandardReference(curies.Reference):
 class StandardNamableReference(StandardReference, curies.NamableReference):
     """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
 
-    @model_validator(mode="before")
-    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
-        """Validate the identifier."""
-        return _standardize_values(values)
-
 
 class StandardNamedReference(StandardNamableReference, curies.NamedReference):
     """An extension to :class:`curies.Reference` that automatically validates prefix and identifier."""
-
-    @model_validator(mode="before")
-    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
-        """Validate the identifier."""
-        return _standardize_values(values)

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -122,19 +122,23 @@ def get_preferred_prefix(prefix: str) -> str | None:
     :returns: The preferred prefix, if annotated in the Bioregistry or OBO Foundry.
 
     No preferred prefix annotation, defaults to normalized prefix
+
     >>> get_preferred_prefix("rhea")
     None
 
     Preferred prefix defined in the Bioregistry
+
     >>> get_preferred_prefix("wb")
     'WormBase'
 
     Preferred prefix defined in the OBO Foundry
+
     >>> get_preferred_prefix("fbbt")
     'FBbt'
 
     Preferred prefix from the OBO Foundry overridden by the Bioregistry
     (see also https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1559)
+
     >>> get_preferred_prefix("dpo")
     'DPO'
     """

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,0 +1,107 @@
+"""Test references.
+
+Run with
+
+"""
+
+import unittest
+
+import curies
+from pydantic import ValidationError
+
+from bioregistry.reference import StandardReference, StandardNamedReference, StandardNamableReference
+
+TEST_LUID = "0032571"
+TEST_NAME = "response to vitamin K"
+TEST_CURIES = ["go:0032571", "GO:0032571", "GO:GO:0032571"]
+BAD_CURIES = [
+    "nope:nope",  # fails because of missing prefix
+    "go:0032571  asga",  # fails because of space
+    "go:32571",  # failes because doesn't pass regex
+]
+
+
+class TestReference(unittest.TestCase):
+    """Test references."""
+
+    def test_failed_validation(self) -> None:
+        """Test throwing a runtime error when missing prefix/identifier."""
+        with self.assertRaises(RuntimeError):
+            StandardReference.model_validate({})
+        with self.assertRaises(RuntimeError):
+            StandardReference.model_validate({"prefix": "nope"})
+        with self.assertRaises(RuntimeError):
+            StandardReference.model_validate({"identifier": "nope"})
+        with self.assertRaises(RuntimeError):
+            StandardReference.model_validate({"curie": "nope"})
+
+    def test_invalid(self) -> None:
+        """Test invalid CURIEs."""
+        for curie in BAD_CURIES:
+            for cls in [StandardReference, StandardNamableReference]:
+                with self.subTest(curie=curie, cls=cls.__name__), self.assertRaises(ValidationError):
+                    cls.from_curie(curie)
+
+            with self.assertRaises(ValidationError):
+                StandardNamedReference.from_curie(curie, name="something")
+
+    def test_standard_reference(self) -> None:
+        """Test parsing a regular reference."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                r1 = StandardReference.from_curie(curie)
+                self.assertIsInstance(r1, StandardReference)
+                self.assertEqual("go", r1.prefix)
+                self.assertEqual(TEST_LUID, r1.identifier)
+                self.assertFalse(hasattr(r1, "name"))
+
+    def test_nameable_reference_no_name(self) -> None:
+        """Test parsing namable reference without a name."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                r2 = StandardNamableReference.from_curie(curie)
+                self.assertIsInstance(r2, curies.Reference)
+                self.assertIsInstance(r2, curies.NamableReference)
+                self.assertIsInstance(r2, StandardReference)
+                self.assertIsInstance(r2, StandardNamableReference)
+                self.assertEqual("go", r2.prefix)
+                self.assertEqual(TEST_LUID, r2.identifier)
+                self.assertTrue(hasattr(r2, "name"))
+                self.assertIsNone(r2.name)
+
+    def test_nameable_reference_with_name(self) -> None:
+        """Test parsing namable reference with a name."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                r3 = StandardNamableReference.from_curie(curie, TEST_NAME)
+                self.assertIsInstance(r3, curies.Reference)
+                self.assertIsInstance(r3, curies.NamableReference)
+                self.assertIsInstance(r3, StandardReference)
+                self.assertIsInstance(r3, StandardNamableReference)
+                self.assertEqual("go", r3.prefix)
+                self.assertEqual(TEST_LUID, r3.identifier)
+                self.assertTrue(hasattr(r3, "name"))
+                self.assertIsNotNone(r3.name)
+                self.assertEqual(TEST_NAME, r3.name)
+
+    def test_named_reference(self) -> None:
+        """Test parsing named references."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                r4 = StandardNamedReference.from_curie(curie, TEST_NAME)
+                self.assertIsInstance(r4, curies.Reference)
+                self.assertIsInstance(r4, curies.NamableReference)
+                self.assertIsInstance(r4, curies.NamedReference)
+                self.assertIsInstance(r4, StandardReference)
+                self.assertIsInstance(r4, StandardNamableReference)
+                self.assertIsInstance(r4, StandardNamedReference)
+                self.assertEqual("go", r4.prefix)
+                self.assertEqual(TEST_LUID, r4.identifier)
+                self.assertTrue(hasattr(r4, "name"))
+                self.assertEqual(TEST_NAME, r4.name)
+
+    def test_equal(self) -> None:
+        """Test equality between references."""
+        r1 = curies.Reference(prefix="go", identifier=TEST_LUID)
+        r2 = StandardNamedReference.from_curie(f"go:{TEST_LUID}", name=TEST_NAME)
+        self.assertEqual(r1, r2)

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,6 +1,5 @@
 """Test references."""
 
-import itertools as itt
 import unittest
 
 import curies

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,49 +1,147 @@
-"""Test references.
+"""Test references."""
 
-Run with
-
-"""
-
+import itertools as itt
 import unittest
 
 import curies
 from pydantic import ValidationError
 
-from bioregistry.reference import StandardReference, StandardNamedReference, StandardNamableReference
+from bioregistry.reference import (
+    NormalizedNamableReference,
+    NormalizedNamedReference,
+    NormalizedReference,
+    StandardNamableReference,
+    StandardNamedReference,
+    StandardReference,
+)
 
+TEST_NORM_PREFIX = "go"
+TEST_STANDARD_PREFIX = "GO"
 TEST_LUID = "0032571"
 TEST_NAME = "response to vitamin K"
 TEST_CURIES = ["go:0032571", "GO:0032571", "GO:GO:0032571"]
 BAD_CURIES = [
     "nope:nope",  # fails because of missing prefix
     "go:0032571  asga",  # fails because of space
-    "go:32571",  # failes because doesn't pass regex
+    "go:32571",  # fails because doesn't pass regex
 ]
 
 
-class TestReference(unittest.TestCase):
-    """Test references."""
+class TestNormalizedReference(unittest.TestCase):
+    """Test normalized references, which use Bioregistry lowercasing."""
 
     def test_failed_validation(self) -> None:
         """Test throwing a runtime error when missing prefix/identifier."""
-        with self.assertRaises(RuntimeError):
-            StandardReference.model_validate({})
-        with self.assertRaises(RuntimeError):
-            StandardReference.model_validate({"prefix": "nope"})
-        with self.assertRaises(RuntimeError):
-            StandardReference.model_validate({"identifier": "nope"})
-        with self.assertRaises(RuntimeError):
-            StandardReference.model_validate({"curie": "nope"})
+        for cls in [
+            NormalizedReference,
+            NormalizedNamableReference,
+            StandardReference,
+            StandardNamableReference,
+            StandardNamedReference,
+            NormalizedNamedReference,
+        ]:
+            with self.subTest(cls=cls.__name__):
+                with self.assertRaises(RuntimeError):
+                    cls.model_validate({})
+                with self.assertRaises(RuntimeError):
+                    cls.model_validate({"prefix": "nope"})
+                with self.assertRaises(RuntimeError):
+                    cls.model_validate({"identifier": "nope"})
+                with self.assertRaises(RuntimeError):
+                    cls.model_validate({"curie": "nope"})
 
     def test_invalid(self) -> None:
         """Test invalid CURIEs."""
         for curie in BAD_CURIES:
-            for cls in [StandardReference, StandardNamableReference]:
-                with self.subTest(curie=curie, cls=cls.__name__), self.assertRaises(ValidationError):
+            for cls in [
+                NormalizedReference,
+                NormalizedNamableReference,
+                StandardReference,
+                StandardNamableReference,
+            ]:
+                with (
+                    self.subTest(curie=curie, cls=cls.__name__),
+                    self.assertRaises(ValidationError),
+                ):
                     cls.from_curie(curie)
 
             with self.assertRaises(ValidationError):
+                NormalizedNamedReference.from_curie(curie, name="something")
+
+            with self.assertRaises(ValidationError):
                 StandardNamedReference.from_curie(curie, name="something")
+
+    def test_normalized_reference(self) -> None:
+        """Test parsing a regular reference."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                reference = NormalizedReference.from_curie(curie)
+                self.assertIsInstance(reference, NormalizedReference)
+                self.assertEqual(TEST_NORM_PREFIX, reference.prefix)
+                self.assertEqual(TEST_LUID, reference.identifier)
+                self.assertFalse(hasattr(reference, "name"))
+
+    def test_normalized_nameable_reference_no_name(self) -> None:
+        """Test parsing namable reference without a name."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                reference = NormalizedNamableReference.from_curie(curie)
+                self.assertIsInstance(reference, curies.Reference)
+                self.assertIsInstance(reference, curies.NamableReference)
+                self.assertIsInstance(reference, NormalizedReference)
+                self.assertIsInstance(reference, NormalizedNamableReference)
+                self.assertEqual(TEST_NORM_PREFIX, reference.prefix)
+                self.assertEqual(TEST_LUID, reference.identifier)
+                self.assertTrue(hasattr(reference, "name"))
+                self.assertIsNone(reference.name)
+
+    def test_normalized_nameable_reference_with_name(self) -> None:
+        """Test parsing namable reference with a name."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                reference = NormalizedNamableReference.from_curie(curie, TEST_NAME)
+                self.assertIsInstance(reference, curies.Reference)
+                self.assertIsInstance(reference, curies.NamableReference)
+                self.assertIsInstance(reference, NormalizedReference)
+                self.assertIsInstance(reference, NormalizedNamableReference)
+                self.assertEqual(TEST_NORM_PREFIX, reference.prefix)
+                self.assertEqual(TEST_LUID, reference.identifier)
+                self.assertTrue(hasattr(reference, "name"))
+                self.assertEqual(TEST_NAME, reference.name)
+
+    def test_normalized_named_reference(self) -> None:
+        """Test parsing named references."""
+        for curie in TEST_CURIES:
+            with self.subTest(curie=curie):
+                reference = NormalizedNamedReference.from_curie(curie, TEST_NAME)
+                self.assertIsInstance(reference, curies.Reference)
+                self.assertIsInstance(reference, curies.NamableReference)
+                self.assertIsInstance(reference, curies.NamedReference)
+                self.assertIsInstance(reference, NormalizedReference)
+                self.assertIsInstance(reference, NormalizedNamableReference)
+                self.assertIsInstance(reference, NormalizedNamedReference)
+                self.assertEqual(TEST_NORM_PREFIX, reference.prefix)
+                self.assertEqual(TEST_LUID, reference.identifier)
+                self.assertTrue(hasattr(reference, "name"))
+                self.assertEqual(TEST_NAME, reference.name)
+
+    def test_normalized_equal(self) -> None:
+        """Test equality between references."""
+        r1 = curies.Reference(prefix=TEST_NORM_PREFIX, identifier=TEST_LUID)
+        r2 = NormalizedNamedReference.from_curie(f"go:{TEST_LUID}", name=TEST_NAME)
+        r3 = curies.Reference(prefix=TEST_STANDARD_PREFIX, identifier=TEST_LUID)
+        r4 = StandardNamedReference.from_curie(f"go:{TEST_LUID}", name=TEST_NAME)
+
+        self.assertEqual(r1, r2)
+        self.assertEqual(r3, r4)
+        self.assertNotEqual(r1, r3)
+        self.assertNotEqual(r1, r4)
+        self.assertNotEqual(r2, r3)
+        self.assertNotEqual(r2, r4)
+
+
+class TestStandardizeReference(unittest.TestCase):
+    """Test standardized references, which use preferred prefixes."""
 
     def test_standard_reference(self) -> None:
         """Test parsing a regular reference."""
@@ -51,11 +149,11 @@ class TestReference(unittest.TestCase):
             with self.subTest(curie=curie):
                 r1 = StandardReference.from_curie(curie)
                 self.assertIsInstance(r1, StandardReference)
-                self.assertEqual("go", r1.prefix)
+                self.assertEqual(TEST_STANDARD_PREFIX, r1.prefix)
                 self.assertEqual(TEST_LUID, r1.identifier)
                 self.assertFalse(hasattr(r1, "name"))
 
-    def test_nameable_reference_no_name(self) -> None:
+    def test_standard_nameable_reference_no_name(self) -> None:
         """Test parsing namable reference without a name."""
         for curie in TEST_CURIES:
             with self.subTest(curie=curie):
@@ -64,12 +162,14 @@ class TestReference(unittest.TestCase):
                 self.assertIsInstance(r2, curies.NamableReference)
                 self.assertIsInstance(r2, StandardReference)
                 self.assertIsInstance(r2, StandardNamableReference)
-                self.assertEqual("go", r2.prefix)
+                self.assertNotIsInstance(r2, NormalizedReference)
+                self.assertNotIsInstance(r2, NormalizedNamableReference)
+                self.assertEqual(TEST_STANDARD_PREFIX, r2.prefix)
                 self.assertEqual(TEST_LUID, r2.identifier)
                 self.assertTrue(hasattr(r2, "name"))
                 self.assertIsNone(r2.name)
 
-    def test_nameable_reference_with_name(self) -> None:
+    def test_standard_nameable_reference_with_name(self) -> None:
         """Test parsing namable reference with a name."""
         for curie in TEST_CURIES:
             with self.subTest(curie=curie):
@@ -78,13 +178,15 @@ class TestReference(unittest.TestCase):
                 self.assertIsInstance(r3, curies.NamableReference)
                 self.assertIsInstance(r3, StandardReference)
                 self.assertIsInstance(r3, StandardNamableReference)
-                self.assertEqual("go", r3.prefix)
+                self.assertNotIsInstance(r3, NormalizedReference)
+                self.assertNotIsInstance(r3, NormalizedNamableReference)
+                self.assertEqual(TEST_STANDARD_PREFIX, r3.prefix)
                 self.assertEqual(TEST_LUID, r3.identifier)
                 self.assertTrue(hasattr(r3, "name"))
                 self.assertIsNotNone(r3.name)
                 self.assertEqual(TEST_NAME, r3.name)
 
-    def test_named_reference(self) -> None:
+    def test_standard_named_reference(self) -> None:
         """Test parsing named references."""
         for curie in TEST_CURIES:
             with self.subTest(curie=curie):
@@ -95,13 +197,10 @@ class TestReference(unittest.TestCase):
                 self.assertIsInstance(r4, StandardReference)
                 self.assertIsInstance(r4, StandardNamableReference)
                 self.assertIsInstance(r4, StandardNamedReference)
-                self.assertEqual("go", r4.prefix)
+                self.assertNotIsInstance(r4, NormalizedReference)
+                self.assertNotIsInstance(r4, NormalizedNamableReference)
+                self.assertNotIsInstance(r4, NormalizedNamedReference)
+                self.assertEqual(TEST_STANDARD_PREFIX, r4.prefix)
                 self.assertEqual(TEST_LUID, r4.identifier)
                 self.assertTrue(hasattr(r4, "name"))
                 self.assertEqual(TEST_NAME, r4.name)
-
-    def test_equal(self) -> None:
-        """Test equality between references."""
-        r1 = curies.Reference(prefix="go", identifier=TEST_LUID)
-        r2 = StandardNamedReference.from_curie(f"go:{TEST_LUID}", name=TEST_NAME)
-        self.assertEqual(r1, r2)


### PR DESCRIPTION
This upstreams and improves the Reference class from PyOBO so any library relying on Bioregistry can make sure that its references are either standardized to the Bioregistry's normalized prefixes, or to preferred prefixes.

- [x] add implementation
- [x] add tests
- [x] add tutorial / improve docs