### PR TITLE
Update schema

### DIFF
--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -1690,6 +1690,7 @@
         "miriam": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1702,6 +1703,7 @@
         "n2t": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1714,6 +1716,7 @@
         "prefixcommons": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1726,6 +1729,7 @@
         "wikidata": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1738,6 +1742,7 @@
         "go": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1750,6 +1755,7 @@
         "obofoundry": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1762,6 +1768,7 @@
         "bioportal": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1774,6 +1781,7 @@
         "ecoportal": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1786,6 +1794,7 @@
         "agroportal": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1798,6 +1807,7 @@
         "cropoct": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1810,6 +1820,7 @@
         "ols": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1822,6 +1833,7 @@
         "aberowl": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1834,6 +1846,7 @@
         "ncbi": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1846,6 +1859,7 @@
         "uniprot": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1858,6 +1872,7 @@
         "biolink": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1870,6 +1885,7 @@
         "cellosaurus": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1882,6 +1898,7 @@
         "ontobee": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1894,6 +1911,7 @@
         "cheminf": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1906,6 +1924,7 @@
         "fairsharing": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1918,6 +1937,7 @@
         "biocontext": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1930,6 +1950,7 @@
         "edam": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1942,6 +1963,7 @@
         "re3data": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1954,6 +1976,7 @@
         "hl7": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1966,6 +1989,7 @@
         "bartoc": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1978,6 +2002,7 @@
         "rrid": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1990,6 +2015,7 @@
         "lov": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -2002,6 +2028,7 @@
         "zazuko": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -2014,6 +2041,7 @@
         "togoid": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -2026,6 +2054,7 @@
         "integbio": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -2038,6 +2067,7 @@
         "pathguide": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -241,43 +241,6 @@ class Author(Attributable):
     )
 
 
-class Provider(BaseModel):
-    """A provider."""
-
-    code: str = Field(..., description="A locally unique code within the prefix for the provider")
-    name: str = Field(..., description="Name of the provider")
-    description: str = Field(..., description="Description of the provider")
-    homepage: str = Field(..., description="Homepage of the provider")
-    uri_format: str = Field(
-        ...,
-        title="URI Format",
-        description=f"The URI format string, which must have at least one ``$1`` in it. {URI_IRI_INFO}",
-    )
-    first_party: bool | None = Field(
-        None, description="Annotates whether a provider is from the first-party organization"
-    )
-    publications: list[Publication] | None = Field(
-        default=None,
-        description="A list of publications about the provider. See the `indra` provider for `hgnc` for an example.",
-    )
-    example: str | None = Field(
-        default=None,
-        description="An example local identifier, specific to the provider. Providing this value is "
-        "only necessary if the example associated with the prefix for which this is a provider "
-        "is not resolvable by the provider. The example identifier should exclude any redundant "
-        "usage of the prefix. For example, a GO identifier should only "
-        "look like ``1234567`` and not like ``GO:1234567``",
-    )
-
-    def resolve(self, identifier: str) -> str:
-        """Resolve the identifier into a URI.
-
-        :param identifier: The identifier in the semantic space
-        :return: The URI for the identifier
-        """
-        return self.uri_format.replace("$1", identifier)
-
-
 class Publication(BaseModel):
     """Metadata about a publication."""
 
@@ -317,6 +280,43 @@ class Publication(BaseModel):
             or (self.doi is not None and self.doi == other.doi)
             or (self.pmc is not None and self.pmc == other.pmc)
         )
+
+
+class Provider(BaseModel):
+    """A provider."""
+
+    code: str = Field(..., description="A locally unique code within the prefix for the provider")
+    name: str = Field(..., description="Name of the provider")
+    description: str = Field(..., description="Description of the provider")
+    homepage: str = Field(..., description="Homepage of the provider")
+    uri_format: str = Field(
+        ...,
+        title="URI Format",
+        description=f"The URI format string, which must have at least one ``$1`` in it. {URI_IRI_INFO}",
+    )
+    first_party: bool | None = Field(
+        None, description="Annotates whether a provider is from the first-party organization"
+    )
+    publications: list[Publication] | None = Field(
+        default=None,
+        description="A list of publications about the provider. See the `indra` provider for `hgnc` for an example.",
+    )
+    example: str | None = Field(
+        default=None,
+        description="An example local identifier, specific to the provider. Providing this value is "
+        "only necessary if the example associated with the prefix for which this is a provider "
+        "is not resolvable by the provider. The example identifier should exclude any redundant "
+        "usage of the prefix. For example, a GO identifier should only "
+        "look like ``1234567`` and not like ``GO:1234567``",
+    )
+
+    def resolve(self, identifier: str) -> str:
+        """Resolve the identifier into a URI.
+
+        :param identifier: The identifier in the semantic space
+        :return: The URI for the identifier
+        """
+        return self.uri_format.replace("$1", identifier)
 
 
 class Resource(BaseModel):

--- a/tox.ini
+++ b/tox.ini
@@ -226,10 +226,11 @@ commands =
     erdantic bioregistry.Registry bioregistry.Resource -o docs/img/datamodel_umls.svg
     erdantic bioregistry.Registry bioregistry.Resource -o docs/img/datamodel_umls.png
 
-[testenv:schema]
+[testenv:schema-refresh]
+# you can't use "schema" as an environment name
 usedevelop = true
 deps =
-    pydantic<2.0
+    pydantic>=2.11
 commands =
     python -m bioregistry.schema.struct
 


### PR DESCRIPTION
- Closes #1487
- Moves Publication class above Provider class, which uses it. Another alternative is to use the `Provider.model_rebuild()` class method, but these aren't so circular that this was necessary