### PR TITLE
Function for adding a resource to a manager

### DIFF
--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -208,6 +208,13 @@ class Manager:
 
         self._converter = None
 
+    def add_resource(self, resource: Resource) -> None:
+        """Add a custom resource to the manager."""
+        self.synonyms[resource.prefix] = resource.prefix
+        self.registry[resource.prefix] = resource
+        if self._converter is not None and (uri_prefix := resource.get_uri_prefix()):
+            self._converter.add_prefix(resource.prefix, uri_prefix)
+
     @property
     def converter(self) -> curies.Converter:
         """Get the default converter."""

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -259,3 +259,7 @@ class TestResourceManager(unittest.TestCase):
         self.assertIn("loggerhead", res.source_only)
         # This is a non-ontology so it won't get in OBO Foundry
         self.assertIn("DCTERMS", res.target_only)
+
+    def test_add_resource(self) -> None:
+        """Test adding a resource to a manager."""
+        raise NotImplementedError


### PR DESCRIPTION
This PR adds a function for adding a custom resource to a manager. This is useful for custom instances of the Bioregstry, especially when being accessed via the Python API

- [x] impl
- [ ] docs
- [ ] tutorial