### PR TITLE
Handle empty string predicate modifier and comment when reading mappings

### DIFF
--- a/src/bioregistry/schema_utils.py
+++ b/src/bioregistry/schema_utils.py
@@ -112,7 +112,14 @@ def _read_semantic_mappings(path: str | Path) -> list[SemanticMapping]:
     """Read curated mappings as a nested dict data structure."""
     with Path(path).expanduser().resolve().open() as file:
         return [
-            SemanticMapping.model_validate(record)
+            SemanticMapping.model_validate(
+                {
+                    **record,
+                    # We need to convert the predicate_modifier and comment to None if they are empty strings
+                    "predicate_modifier": record["predicate_modifier"] or None,
+                    "comment": record["comment"] or None,
+                }
+            )
             for record in csv.DictReader(file, delimiter="\t")
         ]
 

--- a/tests/test_curated_mappings.py
+++ b/tests/test_curated_mappings.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 from bioregistry import is_valid_curie
 from bioregistry.constants import CURATED_MAPPINGS_PATH
-from bioregistry.schema_utils import read_metaregistry
+from bioregistry.schema_utils import read_mappings, read_metaregistry, SemanticMapping
 
 
 class TestTSV(unittest.TestCase):
@@ -86,3 +86,18 @@ class TestTSV(unittest.TestCase):
     $ tox -e bioregistry-lint
             """,
             )
+
+
+class TestSemanticMappings(unittest.TestCase):
+    """Tests to make sure semantic mappings are read correctly from TSV."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.mappings = read_mappings()
+
+    def test_semantic_mappings(self):
+        """Test semantic mapping validity."""
+        for mapping in self.mappings:
+            self.assertIsInstance(mapping, SemanticMapping)
+            self.assertNotEqual(mapping.comment, "")
+            self.assertIn(mapping.predicate_modifier, {None, "Not"})


### PR DESCRIPTION
This PR fixes an issue in the Pydantic implementation of #1458 where some empty strings need to be converted into None-s when reading the table into an object model.