### PR TITLE
Fix integbio provider URL

### DIFF
--- a/src/bioregistry/data/metaregistry.json
+++ b/src/bioregistry/data/metaregistry.json
@@ -798,7 +798,7 @@
       "logo_url": "https://integbio.jp/templates/integbio/images/logo/logo.png",
       "name": "Integbio",
       "prefix": "integbio",
-      "provider_uri_format": "https://integbio.jp/dbcatalog/en/record/$1",
+      "provider_uri_format": "https://catalog.integbio.jp/dbcatalog/en/record/$1",
       "qualities": {
         "automatable_download": true,
         "bulk_data": true,


### PR DESCRIPTION
The URL to access records in the Integbio Database Catalog has changed, this PR updates it to one that works well currently.