### PR TITLE
Add date issue and (optional) tracker item to mapping SSSOM

### DIFF
--- a/src/bioregistry/data/curated_mappings.sssom.tsv
+++ b/src/bioregistry/data/curated_mappings.sssom.tsv
@@ -1,115 +1,115 @@
-subject_id	predicate_modifier	predicate_id	object_id	creator_id	mapping_justification	comment
-bioregistry:aao	Not	skos:exactMatch	agroportal:AAO	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:abcd	Not	skos:exactMatch	fairsharing:FAIRsharing.kr3215	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:abs	Not	skos:exactMatch	aberowl:ABS	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ac	Not	skos:exactMatch	bioportal:AC	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ac	Not	skos:exactMatch	fairsharing:FAIRsharing.md3e78	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ac	Not	skos:exactMatch	lov:ac	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:aeo	Not	skos:exactMatch	agroportal:AEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:afo	Not	skos:exactMatch	agroportal:AFO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:afo	Not	skos:exactMatch	fairsharing:FAIRsharing.595710	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:agricola	Not	skos:exactMatch	lov:agr	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:agricola	Not	skos:exactMatch	uniprot:DB-0266	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:ark	Not	skos:exactMatch	bartoc:20297	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:arxiv	Not	skos:exactMatch	bartoc:20434	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:atc	Not	skos:exactMatch	agroportal:ATC	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:atc	Not	skos:exactMatch	hl7:2.16.840.1.113883.6.77	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:bcgo	Not	skos:exactMatch	bioportal:BCGO	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:bcgo	Not	skos:exactMatch	fairsharing:FAIRsharing.2hzttx	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:bto	Not	skos:exactMatch	lov:bto	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cco	Not	skos:exactMatch	lov:cco	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:citexplore	Not	skos:exactMatch	aberowl:CTX	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:citexplore	Not	skos:exactMatch	bioportal:CTX	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:citexplore	Not	skos:exactMatch	fairsharing:FAIRsharing.619eqr	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:cl	Not	skos:exactMatch	lov:cl	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cmo	Not	skos:exactMatch	lov:cmo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cp	Not	skos:exactMatch	fairsharing:FAIRsharing.wP3t2L	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cro	Not	skos:exactMatch	lov:cro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:csp	Not	skos:exactMatch	lov:csp	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cst	Not	skos:exactMatch	aberowl:CST	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cst	Not	skos:exactMatch	bioportal:CST	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cst	Not	skos:exactMatch	hl7:2.16.840.1.113883.6.62	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:cto	Not	skos:exactMatch	lov:cto	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:dicom	Not	skos:exactMatch	lov:dicom	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:dpo	Not	skos:exactMatch	lov:dpo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:dpv	Not	skos:exactMatch	zazuko:dpv	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:dso	Not	skos:exactMatch	lov:dso	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:eo	Not	skos:exactMatch	bioportal:EO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:eol	Not	skos:exactMatch	fairsharing:FAIRsharing.3J6NYn	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:epio	Not	skos:exactMatch	fairsharing:FAIRsharing.p6412v	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:epo	Not	skos:exactMatch	aberowl:EPO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:epo	Not	skos:exactMatch	bioportal:EPO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:epso	Not	skos:exactMatch	fairsharing:FAIRsharing.p6412v	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:genbase	Not	skos:exactMatch	fairsharing:FAIRsharing.3da56b	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	aberowl:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	biocontext:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	bioportal:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	fairsharing:FAIRsharing.27rndz	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	lov:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	obofoundry:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	ols:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	ontobee:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geo	Not	skos:exactMatch	zazuko:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:geonames	Not	skos:exactMatch	fairsharing:FAIRsharing.56a0Uj	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:gnd	Not	skos:exactMatch	prefixcommons:gnd	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:gold	Not	skos:exactMatch	lov:gold	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:gro	Not	skos:exactMatch	biocontext:GRO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:gro	Not	skos:exactMatch	miriam:gro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:gro	Not	skos:exactMatch	obofoundry:gro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:hp	Not	skos:exactMatch	aberowl:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration	
-bioregistry:hp	Not	skos:exactMatch	bioportal:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration	
-bioregistry:hp	Not	skos:exactMatch	lov:hpo	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration	
-bioregistry:hpath	Not	skos:exactMatch	fairsharing:FAIRsharing.kj336a	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:icdo	Not	skos:exactMatch	aberowl:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:icdo	Not	skos:exactMatch	bioportal:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:icdo	Not	skos:exactMatch	ontobee:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:kegg.reaction	Not	skos:exactMatch	wikidata:P665	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:ma	Not	skos:exactMatch	zazuko:ma	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:mdm	Not	skos:exactMatch	aberowl:MDM	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:mo	Not	skos:exactMatch	lov:mo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:mod	Not	skos:exactMatch	bartoc:20333	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:mod	Not	skos:exactMatch	lov:mod	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:mop	Not	skos:exactMatch	bartoc:20466	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:mro	Not	skos:exactMatch	bioportal:MRO	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration	
-bioregistry:ncbi.gc	Not	skos:exactMatch	lov:gc	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ncbitaxon	Not	skos:exactMatch	lov:taxon	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ncbitaxon	Not	skos:exactMatch	prefixcommons:uniprot.taxonomy	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:nemo	Not	skos:exactMatch	aberowl:NEMO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:nemo	Not	skos:exactMatch	bioportal:NEMO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:nemo	Not	skos:exactMatch	fairsharing:FAIRsharing.n66krd	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ngl	Not	skos:exactMatch	bartoc:20302	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:oae	Not	skos:exactMatch	lov:oae	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:om	Not	skos:exactMatch	lov:om	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:omim	Not	skos:exactMatch	bioportal:MIM	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:omim	Not	skos:exactMatch	fairsharing:FAIRsharing.azq2t6	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:omim.ps	Not	skos:exactMatch	miriam:ps	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:opm	Not	skos:exactMatch	fairsharing:FAIRsharing.7c683b	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:opm	Not	skos:exactMatch	lov:opm	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:otl	Not	skos:exactMatch	lov:otl	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:peco	Not	skos:exactMatch	lov:peco	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:plo	Not	skos:exactMatch	lov:plo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:po	Not	skos:exactMatch	lov:po	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ppo	Not	skos:exactMatch	lov:ppo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:pr	Not	skos:exactMatch	lov:pro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:pride	Not	skos:exactMatch	integbio:nbdc00630	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:pso	Not	skos:exactMatch	fairsharing:FAIRsharing.dyj433	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:pso	Not	skos:exactMatch	lov:pso	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:pubchem.compound	Not	skos:exactMatch	pathguide:361	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:rdo	Not	skos:exactMatch	aberowl:RDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:rdo	Not	skos:exactMatch	bioportal:RDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:reactome	Not	skos:exactMatch	lov:react	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ro	Not	skos:exactMatch	bioportal:OBOREL	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ro	Not	skos:exactMatch	fairsharing:FAIRsharing.cp0ybc	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:ro	Not	skos:exactMatch	lov:ro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:sao	Not	skos:exactMatch	bartoc:1756	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:sao	Not	skos:exactMatch	lov:sao	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:seed.subsystem	Not	skos:exactMatch	fairsharing:FAIRsharing.68b03f	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:string	Not	skos:exactMatch	zazuko:string	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:sty	Not	skos:exactMatch	biolink:UMLSSG	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:tao	Not	skos:exactMatch	lov:tao	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:te	Not	skos:exactMatch	lov:te	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:trans	Not	skos:exactMatch	bioportal:TRANS	orcid:0000-0001-9439-5346	semapv:MappingReview	
-bioregistry:uniprot.ptm	Not	skos:exactMatch	prefixcommons:ptmswitchboard	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:vso	Not	skos:exactMatch	lov:vso	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:wikipathways	Not	skos:exactMatch	aberowl:wikipathways	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
-bioregistry:wikipathways	Not	skos:exactMatch	bioportal:wikipathways	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration	
+subject_id	predicate_modifier	predicate_id	object_id	creator_id	mapping_justification	comment	issue_tracker_item	date
+bioregistry:aao	Not	skos:exactMatch	agroportal:AAO	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:abcd	Not	skos:exactMatch	fairsharing:FAIRsharing.kr3215	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:abs	Not	skos:exactMatch	aberowl:ABS	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ac	Not	skos:exactMatch	bioportal:AC	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ac	Not	skos:exactMatch	fairsharing:FAIRsharing.md3e78	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ac	Not	skos:exactMatch	lov:ac	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:aeo	Not	skos:exactMatch	agroportal:AEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:afo	Not	skos:exactMatch	agroportal:AFO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:afo	Not	skos:exactMatch	fairsharing:FAIRsharing.595710	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:agricola	Not	skos:exactMatch	lov:agr	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:agricola	Not	skos:exactMatch	uniprot:DB-0266	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:ark	Not	skos:exactMatch	bartoc:20297	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:arxiv	Not	skos:exactMatch	bartoc:20434	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:atc	Not	skos:exactMatch	agroportal:ATC	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:atc	Not	skos:exactMatch	hl7:2.16.840.1.113883.6.77	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:bcgo	Not	skos:exactMatch	bioportal:BCGO	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:bcgo	Not	skos:exactMatch	fairsharing:FAIRsharing.2hzttx	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:bto	Not	skos:exactMatch	lov:bto	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cco	Not	skos:exactMatch	lov:cco	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:citexplore	Not	skos:exactMatch	aberowl:CTX	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:citexplore	Not	skos:exactMatch	bioportal:CTX	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:citexplore	Not	skos:exactMatch	fairsharing:FAIRsharing.619eqr	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:cl	Not	skos:exactMatch	lov:cl	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cmo	Not	skos:exactMatch	lov:cmo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cp	Not	skos:exactMatch	fairsharing:FAIRsharing.wP3t2L	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cro	Not	skos:exactMatch	lov:cro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:csp	Not	skos:exactMatch	lov:csp	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cst	Not	skos:exactMatch	aberowl:CST	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cst	Not	skos:exactMatch	bioportal:CST	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cst	Not	skos:exactMatch	hl7:2.16.840.1.113883.6.62	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:cto	Not	skos:exactMatch	lov:cto	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:dicom	Not	skos:exactMatch	lov:dicom	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:dpo	Not	skos:exactMatch	lov:dpo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:dpv	Not	skos:exactMatch	zazuko:dpv	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:dso	Not	skos:exactMatch	lov:dso	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:eo	Not	skos:exactMatch	bioportal:EO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:eol	Not	skos:exactMatch	fairsharing:FAIRsharing.3J6NYn	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:epio	Not	skos:exactMatch	fairsharing:FAIRsharing.p6412v	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:epo	Not	skos:exactMatch	aberowl:EPO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:epo	Not	skos:exactMatch	bioportal:EPO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:epso	Not	skos:exactMatch	fairsharing:FAIRsharing.p6412v	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:genbase	Not	skos:exactMatch	fairsharing:FAIRsharing.3da56b	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	aberowl:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	biocontext:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	bioportal:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	fairsharing:FAIRsharing.27rndz	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	lov:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	obofoundry:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	ols:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	ontobee:GEO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geo	Not	skos:exactMatch	zazuko:geo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:geonames	Not	skos:exactMatch	fairsharing:FAIRsharing.56a0Uj	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:gnd	Not	skos:exactMatch	prefixcommons:gnd	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:gold	Not	skos:exactMatch	lov:gold	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:gro	Not	skos:exactMatch	biocontext:GRO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:gro	Not	skos:exactMatch	miriam:gro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:gro	Not	skos:exactMatch	obofoundry:gro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:hp	Not	skos:exactMatch	aberowl:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
+bioregistry:hp	Not	skos:exactMatch	bioportal:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
+bioregistry:hp	Not	skos:exactMatch	lov:hpo	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
+bioregistry:hpath	Not	skos:exactMatch	fairsharing:FAIRsharing.kj336a	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:icdo	Not	skos:exactMatch	aberowl:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:icdo	Not	skos:exactMatch	bioportal:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:icdo	Not	skos:exactMatch	ontobee:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:kegg.reaction	Not	skos:exactMatch	wikidata:P665	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:ma	Not	skos:exactMatch	zazuko:ma	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:mdm	Not	skos:exactMatch	aberowl:MDM	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:mo	Not	skos:exactMatch	lov:mo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:mod	Not	skos:exactMatch	bartoc:20333	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:mod	Not	skos:exactMatch	lov:mod	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:mop	Not	skos:exactMatch	bartoc:20466	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:mro	Not	skos:exactMatch	bioportal:MRO	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
+bioregistry:ncbi.gc	Not	skos:exactMatch	lov:gc	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ncbitaxon	Not	skos:exactMatch	lov:taxon	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ncbitaxon	Not	skos:exactMatch	prefixcommons:uniprot.taxonomy	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:nemo	Not	skos:exactMatch	aberowl:NEMO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:nemo	Not	skos:exactMatch	bioportal:NEMO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:nemo	Not	skos:exactMatch	fairsharing:FAIRsharing.n66krd	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ngl	Not	skos:exactMatch	bartoc:20302	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:oae	Not	skos:exactMatch	lov:oae	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:om	Not	skos:exactMatch	lov:om	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:omim	Not	skos:exactMatch	bioportal:MIM	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:omim	Not	skos:exactMatch	fairsharing:FAIRsharing.azq2t6	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:omim.ps	Not	skos:exactMatch	miriam:ps	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:opm	Not	skos:exactMatch	fairsharing:FAIRsharing.7c683b	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:opm	Not	skos:exactMatch	lov:opm	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:otl	Not	skos:exactMatch	lov:otl	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:peco	Not	skos:exactMatch	lov:peco	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:plo	Not	skos:exactMatch	lov:plo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:po	Not	skos:exactMatch	lov:po	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ppo	Not	skos:exactMatch	lov:ppo	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:pr	Not	skos:exactMatch	lov:pro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:pride	Not	skos:exactMatch	integbio:nbdc00630	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:pso	Not	skos:exactMatch	fairsharing:FAIRsharing.dyj433	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:pso	Not	skos:exactMatch	lov:pso	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:pubchem.compound	Not	skos:exactMatch	pathguide:361	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:rdo	Not	skos:exactMatch	aberowl:RDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:rdo	Not	skos:exactMatch	bioportal:RDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:reactome	Not	skos:exactMatch	lov:react	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ro	Not	skos:exactMatch	bioportal:OBOREL	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ro	Not	skos:exactMatch	fairsharing:FAIRsharing.cp0ybc	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:ro	Not	skos:exactMatch	lov:ro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:sao	Not	skos:exactMatch	bartoc:1756	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:sao	Not	skos:exactMatch	lov:sao	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:seed.subsystem	Not	skos:exactMatch	fairsharing:FAIRsharing.68b03f	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:string	Not	skos:exactMatch	zazuko:string	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:sty	Not	skos:exactMatch	biolink:UMLSSG	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:tao	Not	skos:exactMatch	lov:tao	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:te	Not	skos:exactMatch	lov:te	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:trans	Not	skos:exactMatch	bioportal:TRANS	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
+bioregistry:uniprot.ptm	Not	skos:exactMatch	prefixcommons:ptmswitchboard	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:vso	Not	skos:exactMatch	lov:vso	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:wikipathways	Not	skos:exactMatch	aberowl:wikipathways	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
+bioregistry:wikipathways	Not	skos:exactMatch	bioportal:wikipathways	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30

--- a/src/bioregistry/data/curated_mappings.sssom.tsv
+++ b/src/bioregistry/data/curated_mappings.sssom.tsv
@@ -56,9 +56,9 @@ bioregistry:gold	Not	skos:exactMatch	lov:gold	orcid:0000-0003-4423-4370	semapv:M
 bioregistry:gro	Not	skos:exactMatch	biocontext:GRO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:gro	Not	skos:exactMatch	miriam:gro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:gro	Not	skos:exactMatch	obofoundry:gro	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
-bioregistry:hp	Not	skos:exactMatch	aberowl:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
-bioregistry:hp	Not	skos:exactMatch	bioportal:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
-bioregistry:hp	Not	skos:exactMatch	lov:hpo	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
+bioregistry:hp	Not	skos:exactMatch	aberowl:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1434	2025-03-02
+bioregistry:hp	Not	skos:exactMatch	bioportal:HP_O	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1434	2025-03-02
+bioregistry:hp	Not	skos:exactMatch	lov:hpo	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1434	2025-03-02
 bioregistry:hpath	Not	skos:exactMatch	fairsharing:FAIRsharing.kj336a	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:icdo	Not	skos:exactMatch	aberowl:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:icdo	Not	skos:exactMatch	bioportal:ICDO	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
@@ -70,7 +70,7 @@ bioregistry:mo	Not	skos:exactMatch	lov:mo	orcid:0000-0003-4423-4370	semapv:Manua
 bioregistry:mod	Not	skos:exactMatch	bartoc:20333	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:mod	Not	skos:exactMatch	lov:mod	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:mop	Not	skos:exactMatch	bartoc:20466	orcid:0000-0001-9439-5346	semapv:MappingReview		1457	2025-03-31
-bioregistry:mro	Not	skos:exactMatch	bioportal:MRO	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1457	2025-03-31
+bioregistry:mro	Not	skos:exactMatch	bioportal:MRO	orcid:0000-0001-9439-5346	semapv:ManualMappingCuration		1262	2024-11-17
 bioregistry:ncbi.gc	Not	skos:exactMatch	lov:gc	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:ncbitaxon	Not	skos:exactMatch	lov:taxon	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30
 bioregistry:ncbitaxon	Not	skos:exactMatch	prefixcommons:uniprot.taxonomy	orcid:0000-0003-4423-4370	semapv:ManualMappingCuration			2025-03-30

--- a/src/bioregistry/schema_utils.py
+++ b/src/bioregistry/schema_utils.py
@@ -95,7 +95,7 @@ class SemanticMapping(BaseModel):
         None, description="The PR or issue associated with the change"
     )
     date: str = Field(
-        None,
+        ...,
         pattern="^\\d{4}-\\d{2}-\\d{2}$",
         description="The ISO-8601 date of curation in YYYY-MM-DD",
     )

--- a/src/bioregistry/schema_utils.py
+++ b/src/bioregistry/schema_utils.py
@@ -161,6 +161,8 @@ def write_mappings(mappings: list[SemanticMapping]) -> None:
                 mapping.creator.curie,
                 mapping.mapping_justification.curie,
                 mapping.comment,
+                mapping.issue_tracker_item,
+                mapping.date,
             )
             for mapping in mappings
         )

--- a/tests/test_curated_mappings.py
+++ b/tests/test_curated_mappings.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 from bioregistry import is_valid_curie
 from bioregistry.constants import CURATED_MAPPINGS_PATH
-from bioregistry.schema_utils import read_mappings, read_metaregistry, SemanticMapping
+from bioregistry.schema_utils import SemanticMapping, read_mappings, read_metaregistry
 
 
 class TestTSV(unittest.TestCase):
@@ -33,6 +33,17 @@ class TestTSV(unittest.TestCase):
         if row["comment"] is not None:
             self.assertFalse(row["comment"].startswith('"'))
             self.assertFalse(row["comment"].endswith('"'))
+
+        self.assertIn("date", row)
+        if row["date"] > "2025-03-30":
+            # all curations after a certain date require an issue tracker item.
+            # curations from before this date are exempt since they were all done
+            # by charlie in an ad-hoc way before switching over to using SSSOM to
+            # track detailed metadata
+            self.assertIn("issue_tracker_item", row)
+            self.assertIsNotNone(row["issue_tracker_item"])
+            self.assertNotEqual("", row["issue_tracker_item"])
+            self.assertTrue(row["issue_tracker_item"].isnumeric())
 
     def test_tsv_file(self):
         """Tests all rows in TSV file are valid."""

--- a/tests/test_curated_mappings.py
+++ b/tests/test_curated_mappings.py
@@ -34,17 +34,6 @@ class TestTSV(unittest.TestCase):
             self.assertFalse(row["comment"].startswith('"'))
             self.assertFalse(row["comment"].endswith('"'))
 
-        self.assertIn("date", row)
-        if row["date"] > "2025-03-30":
-            # all curations after a certain date require an issue tracker item.
-            # curations from before this date are exempt since they were all done
-            # by charlie in an ad-hoc way before switching over to using SSSOM to
-            # track detailed metadata
-            self.assertIn("issue_tracker_item", row)
-            self.assertIsNotNone(row["issue_tracker_item"])
-            self.assertNotEqual("", row["issue_tracker_item"])
-            self.assertTrue(row["issue_tracker_item"].isnumeric())
-
     def test_tsv_file(self):
         """Tests all rows in TSV file are valid."""
         with CURATED_MAPPINGS_PATH.open() as tsv_file:


### PR DESCRIPTION
This PR adds two fields to the end of the mapping SSSOM file:

1. (optional) Issue tracker / pull request number
2. (required) date of curation

This will make tracking/reporting easier.

Further, this adds stub dates for all of the original curations, and the ones added in the most recent PR
