### PR TITLE
Add `strict` flag to CURIE parsing functions

### DIFF
--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -819,7 +819,20 @@ def parse_curie(
     *,
     sep: str = ...,
     use_preferred: bool = ...,
+    on_failure_return_type: FailureReturnType = ...,
+    strict: Literal[True] = True,
+) -> ReferenceTuple: ...
+
+
+# docstr-coverage:excused `overload`
+@overload
+def parse_curie(
+    curie: str,
+    *,
+    sep: str = ...,
+    use_preferred: bool = ...,
     on_failure_return_type: Literal[FailureReturnType.single],
+    strict: Literal[False] = False,
 ) -> ReferenceTuple | None: ...
 
 
@@ -831,6 +844,7 @@ def parse_curie(
     sep: str = ...,
     use_preferred: bool = ...,
     on_failure_return_type: Literal[FailureReturnType.pair] = FailureReturnType.pair,
+    strict: Literal[False] = False,
 ) -> ReferenceTuple | tuple[None, None]: ...
 
 
@@ -840,6 +854,7 @@ def parse_curie(
     sep: str = ":",
     use_preferred: bool = False,
     on_failure_return_type: FailureReturnType = FailureReturnType.pair,
+    strict: bool = False,
 ) -> MaybeCURIE:
     """Parse a CURIE, normalizing the prefix and identifier if necessary.
 
@@ -899,12 +914,20 @@ def parse_curie(
     >>> parse_curie("pdb:1234", use_preferred=True)
     ReferenceTuple('pdb', '1234')
     """
-    if on_failure_return_type == FailureReturnType.single:
+    if strict:
+        return manager.parse_curie(
+            curie,
+            sep=sep,
+            use_preferred=use_preferred,
+            strict=strict,
+        )
+    elif on_failure_return_type == FailureReturnType.single:
         return manager.parse_curie(
             curie,
             sep=sep,
             use_preferred=use_preferred,
             on_failure_return_type=on_failure_return_type,
+            strict=strict,
         )
     elif on_failure_return_type == FailureReturnType.pair:
         return manager.parse_curie(
@@ -912,6 +935,7 @@ def parse_curie(
             sep=sep,
             use_preferred=use_preferred,
             on_failure_return_type=on_failure_return_type,
+            strict=strict,
         )
     else:
         raise TypeError
@@ -922,6 +946,7 @@ def normalize_parsed_curie(
     identifier: str,
     *,
     use_preferred: bool = False,
+    strict: bool = False,
 ) -> MaybeCURIE:
     """Normalize a prefix/identifier pair.
 
@@ -930,18 +955,33 @@ def normalize_parsed_curie(
     :param use_preferred:
         If set to true, uses the "preferred prefix", if available, instead
         of the canonicalized Bioregistry prefix.
+    :param strict: If true, raises an error if the prefix can't be standardized
     :return: A normalized prefix/identifier pair, conforming to Bioregistry standards. This means no redundant
         prefixes or bananas, all lowercase.
     """
+    if strict:
+        return manager.normalize_parsed_curie(
+            prefix,
+            identifier,
+            use_preferred=use_preferred,
+            strict=strict,
+        )
     return manager.normalize_parsed_curie(
         prefix,
         identifier,
         use_preferred=use_preferred,
         on_failure_return_type=FailureReturnType.pair,
+        strict=strict,
     )
 
 
-def normalize_curie(curie: str, *, sep: str = ":", use_preferred: bool = False) -> str | None:
+def normalize_curie(
+    curie: str,
+    *,
+    sep: str = ":",
+    use_preferred: bool = False,
+    strict: bool = False,
+) -> str | None:
     """Normalize a CURIE.
 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
@@ -950,6 +990,7 @@ def normalize_curie(curie: str, *, sep: str = ":", use_preferred: bool = False) 
     :param use_preferred:
         If set to true, uses the "preferred prefix", if available, instead
         of the canonicalized Bioregistry prefix.
+    :param strict: If true, raises an error if the prefix can't be standardized
     :return: A normalized CURIE, if possible using the colon as a separator
 
     >>> normalize_curie("pdb:1234")
@@ -991,7 +1032,7 @@ def normalize_curie(curie: str, *, sep: str = ":", use_preferred: bool = False) 
     >>> normalize_curie("GO_1234", sep="_", use_preferred=True)
     'GO:1234'
     """
-    return manager.normalize_curie(curie, sep=sep, use_preferred=use_preferred)
+    return manager.normalize_curie(curie, sep=sep, use_preferred=use_preferred, strict=strict)
 
 
 # docstr-coverage:excused `overload`

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -647,6 +647,7 @@ class Manager:
             If set to true, uses the "preferred prefix", if available, instead
             of the canonicalized Bioregistry prefix.
         :param on_failure_return_type: whether to return a single None or a pair of None's
+        :param strict: If true, raises an error if the prefix can't be standardized
         :return: A normalized prefix/identifier pair, conforming to Bioregistry standards. This means no redundant
             prefixes or bananas, all lowercase.
 

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -22,6 +22,7 @@ from typing import (
 
 import curies
 from curies import ReferenceTuple
+from curies.api import NoCURIEDelimiterError, PrefixStandardizationError
 from pydantic import BaseModel
 
 from .constants import (
@@ -289,12 +290,12 @@ class Manager:
             will usually take precedence: MIRIAM, OBO Foundry / OLS, Custom except
             in a few cases, such as NCBITaxon.
 
-        :raises ValueError: If strict is set to true and the prefix could not be standardized
+        :raises PrefixStandardizationError: If strict is set to true and the prefix could not be standardized
         """
         norm_prefix = self.synonyms.get(prefix)
         if norm_prefix is None:
             if strict:
-                raise ValueError(f"could not standardize {prefix}")
+                raise PrefixStandardizationError(prefix)
             return None
         if use_preferred:
             norm_prefix = self.registry[norm_prefix].get_preferred_prefix() or norm_prefix
@@ -482,9 +483,22 @@ class Manager:
         self,
         curie: str,
         *,
-        sep: str = ":",
+        sep: str = ...,
+        use_preferred: bool = ...,
+        on_failure_return_type: FailureReturnType = ...,
+        strict: Literal[True] = True,
+    ) -> ReferenceTuple: ...
+
+    # docstr-coverage:excused `overload`
+    @overload
+    def parse_curie(
+        self,
+        curie: str,
+        *,
+        sep: str = ...,
         use_preferred: bool = ...,
         on_failure_return_type: Literal[FailureReturnType.single] = FailureReturnType.single,
+        strict: Literal[False] = False,
     ) -> ReferenceTuple | None: ...
 
     # docstr-coverage:excused `overload`
@@ -493,9 +507,10 @@ class Manager:
         self,
         curie: str,
         *,
-        sep: str = ":",
+        sep: str = ...,
         use_preferred: bool = ...,
         on_failure_return_type: Literal[FailureReturnType.pair] = FailureReturnType.pair,
+        strict: Literal[False] = False,
     ) -> ReferenceTuple | tuple[None, None]: ...
 
     def parse_curie(
@@ -505,44 +520,79 @@ class Manager:
         sep: str = ":",
         use_preferred: bool = False,
         on_failure_return_type: FailureReturnType = FailureReturnType.pair,
+        strict: bool = False,
     ) -> MaybeCURIE:
         """Parse a CURIE and normalize its prefix and identifier."""
-        try:
-            prefix, identifier = curie.split(sep, 1)
-        except ValueError:
+        prefix, _delimiter, identifier = curie.partition(sep)
+        if not _delimiter:
+            if strict:
+                raise NoCURIEDelimiterError(curie)
             return get_failure_return_type(on_failure_return_type)
 
         if on_failure_return_type == FailureReturnType.single:
-            return self.normalize_parsed_curie(
-                prefix,
-                identifier,
-                use_preferred=use_preferred,
-                on_failure_return_type=FailureReturnType.single,
-            )
+            if strict:
+                return self.normalize_parsed_curie(
+                    prefix,
+                    identifier,
+                    use_preferred=use_preferred,
+                    on_failure_return_type=FailureReturnType.single,
+                    strict=strict,
+                )
+            else:
+                return self.normalize_parsed_curie(
+                    prefix,
+                    identifier,
+                    use_preferred=use_preferred,
+                    on_failure_return_type=FailureReturnType.single,
+                    strict=strict,
+                )
         elif on_failure_return_type == FailureReturnType.pair:
-            return self.normalize_parsed_curie(
-                prefix,
-                identifier,
-                use_preferred=use_preferred,
-                on_failure_return_type=FailureReturnType.pair,
-            )
+            if strict:
+                return self.normalize_parsed_curie(
+                    prefix,
+                    identifier,
+                    use_preferred=use_preferred,
+                    on_failure_return_type=FailureReturnType.pair,
+                    strict=strict,
+                )
+            else:
+                return self.normalize_parsed_curie(
+                    prefix,
+                    identifier,
+                    use_preferred=use_preferred,
+                    on_failure_return_type=FailureReturnType.pair,
+                    strict=strict,
+                )
         else:
             raise TypeError
 
     def normalize_curie(
-        self, curie: str, *, sep: str = ":", use_preferred: bool = False
+        self,
+        curie: str,
+        *,
+        sep: str = ":",
+        use_preferred: bool = False,
+        strict: bool = False,
     ) -> str | None:
         """Normalize the prefix and identifier in the CURIE."""
+        if strict:
+            return self.parse_curie(
+                curie,
+                sep=sep,
+                use_preferred=use_preferred,
+                on_failure_return_type=FailureReturnType.single,
+                strict=True,
+            ).curie
         reference = self.parse_curie(
             curie,
             sep=sep,
             use_preferred=use_preferred,
             on_failure_return_type=FailureReturnType.single,
+            strict=strict,
         )
-        if reference is None:
-            return None
-        else:
+        if reference is not None:
             return reference.curie
+        return None
 
     # docstr-coverage:excused `overload`
     @overload
@@ -552,8 +602,9 @@ class Manager:
         identifier: str,
         *,
         use_preferred: bool = ...,
-        on_failure_return_type: Literal[FailureReturnType.pair],
-    ) -> ReferenceTuple | tuple[None, None]: ...
+        on_failure_return_type: FailureReturnType = ...,
+        strict: Literal[True] = True,
+    ) -> ReferenceTuple: ...
 
     # docstr-coverage:excused `overload`
     @overload
@@ -564,7 +615,20 @@ class Manager:
         *,
         use_preferred: bool = ...,
         on_failure_return_type: Literal[FailureReturnType.single],
+        strict: Literal[False] = False,
     ) -> ReferenceTuple | None: ...
+
+    # docstr-coverage:excused `overload`
+    @overload
+    def normalize_parsed_curie(
+        self,
+        prefix: str,
+        identifier: str,
+        *,
+        use_preferred: bool = ...,
+        on_failure_return_type: Literal[FailureReturnType.pair],
+        strict: Literal[False] = False,
+    ) -> ReferenceTuple | tuple[None, None]: ...
 
     def normalize_parsed_curie(
         self,
@@ -573,6 +637,7 @@ class Manager:
         *,
         use_preferred: bool = False,
         on_failure_return_type: FailureReturnType = FailureReturnType.pair,
+        strict: bool = False,
     ) -> MaybeCURIE:
         """Normalize a prefix/identifier pair.
 
@@ -584,9 +649,13 @@ class Manager:
         :param on_failure_return_type: whether to return a single None or a pair of None's
         :return: A normalized prefix/identifier pair, conforming to Bioregistry standards. This means no redundant
             prefixes or bananas, all lowercase.
+
+        :raises PrefixStandardizationError: If strict is set to true and the prefix could not be standardized
         """
-        norm_prefix = self.normalize_prefix(prefix)
+        norm_prefix = self.normalize_prefix(prefix, strict=False)
         if not norm_prefix:
+            if strict:
+                raise PrefixStandardizationError(prefix)
             return get_failure_return_type(on_failure_return_type)
         resource = self.registry[norm_prefix]
         norm_identifier = resource.standardize_identifier(identifier)


### PR DESCRIPTION
This PR adds the `strict` option to the `parse_curie` function