### PR TITLE
Make type checking strict in main codebase

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -412,11 +412,10 @@ acceptance and merge into the main branch. This has several benefits:
 
 ### Code Style
 
-This project encourages the use of optional static typing. It uses
-[`mypy`](http://mypy-lang.org/) as a type checker and
-[`sphinx_autodoc_typehints`](https://github.com/agronholm/sphinx-autodoc-typehints)
-to automatically generate documentation based on type hints. You can check if
-your code passes `mypy` with `tox -e mypy`.
+This project requires the use of static typing, which has the dual benefits of
+being implicit documentation as well as enable comprehensive static analysis of
+the code. It uses [`mypy`](http://mypy-lang.org/) as a type checker. You can
+check if your code passes `mypy` with `tox -e mypy`.
 
 This project uses [`black`](https://github.com/psf/black) to automatically
 enforce a consistent code style. You can apply `black` and other pre-configured

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Any, NamedTuple, TypeAlias, cast
+from typing import Any, NamedTuple, cast
 
 import click
 import matplotlib.pyplot as plt
@@ -12,6 +12,7 @@ import pandas as pd
 import requests
 from dateutil import tz
 from dateutil.parser import isoparse
+from typing_extensions import TypeAlias
 
 logger = logging.getLogger(__name__)
 

--- a/src/bioregistry/analysis/bioregistry_diff.py
+++ b/src/bioregistry/analysis/bioregistry_diff.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Any
+from typing import Any, NamedTuple, TypeAlias
 
 import click
 import matplotlib.pyplot as plt
@@ -13,7 +13,6 @@ import requests
 from dateutil import tz
 from dateutil.parser import isoparse
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Constants for the GitHub repository information and API URL
@@ -43,20 +42,22 @@ def get_commit_before_date(
     response = requests.get(url, params=params, timeout=15)
     response.raise_for_status()
     commits = response.json()
-    if commits:
-        first_commit = commits[0]
-        if "sha" in first_commit:
-            return first_commit["sha"]
-        else:
-            logger.warning("No 'sha' field found in the first commit.")
-    else:
+    if not commits:
         logger.warning(f"No commits found before {date}")
-    return None
+        return None
+    first_commit = commits[0]
+    if "sha" not in first_commit:
+        logger.warning("No 'sha' field found in the first commit.")
+        return None
+    return first_commit["sha"]
+
+
+BioregistryDataHint: TypeAlias = dict[str, Any]
 
 
 def get_file_at_commit(
     file_path: str, commit_sha: str, owner: str = REPO_OWNER, name: str = REPO_NAME
-) -> dict[str, Any]:
+) -> BioregistryDataHint:
     """Return the content of a given file at a specific commit.
 
     :param file_path: The file path in the repository.
@@ -76,7 +77,21 @@ def get_file_at_commit(
     return res.json()
 
 
-def compare_bioregistry(old_data, new_data):
+ComparsionHint: TypeAlias = dict[str, tuple[Any, Any]]
+
+
+class CompareBioregistryResult(NamedTuple):
+    """A comparison between two different states of the Bioregistry."""
+
+    added_prefixes: set[str]
+    deleted_prefixes: set[str]
+    updated_prefixes: int
+    update_details: list[tuple[str, ComparsionHint]]
+
+
+def compare_bioregistry(
+    old_data: dict[str, dict[str, Any]], new_data: dict[str, dict[str, Any]]
+) -> CompareBioregistryResult:
     """Return comparison of two versions of the bioregistry data.
 
     :param old_data: The old bioregistry data.
@@ -97,10 +112,12 @@ def compare_bioregistry(old_data, new_data):
             changes = compare_entries(old_data[prefix], new_data[prefix])
             update_details.append((prefix, changes))
 
-    return added_prefixes, deleted_prefixes, updated_prefixes, update_details
+    return CompareBioregistryResult(
+        added_prefixes, deleted_prefixes, updated_prefixes, update_details
+    )
 
 
-def compare_entries(old_entry, new_entry):
+def compare_entries(old_entry: dict[str, Any], new_entry: dict[str, Any]) -> ComparsionHint:
     """Return detailed changes within individual entries.
 
     :param old_entry: The old entry data.
@@ -114,58 +131,59 @@ def compare_entries(old_entry, new_entry):
     return changes
 
 
-def get_all_mapping_keys(data):
+def get_all_mapping_keys(data) -> set[str]:
     """Return all unique mapping keys from the bioregistry data.
 
     :param data: The bioregistry data.
     :returns: A set of all unique mapping keys.
     """
-    mapping_keys = set()
+    mapping_keys: set[str] = set()
     for prefix in data:
         if "mappings" in data[prefix]:
             mapping_keys.update(data[prefix]["mappings"].keys())
     return mapping_keys
 
 
-def get_data(date1, date2):
+class DataResult(NamedTuple):
+    """Results from comparison between two dates."""
+
+    comparison: CompareBioregistryResult
+    old_bioregistry: BioregistryDataHint
+    new_bioregistry: BioregistryDataHint
+    all_mapping_keys: set[str]
+
+
+def get_data(old_date_str: str, new_date_str: str) -> DataResult | None:
     """Retrieve and compare bioregistry data between two dates.
 
-    :param date1: The starting date in ISO format.
-    :param date2: The ending date in ISO format.
+    :param old_date_str: The starting date in ISO format.
+    :param new_date_str: The ending date in ISO format.
     :returns: Data on added, deleted, and updated prefixes, update details, and old and new bioregistry data.
     """
-    date1 = isoparse(date1).astimezone(tz.tzutc())
-    date2 = isoparse(date2).astimezone(tz.tzutc())
+    old_date = isoparse(old_date_str).astimezone(tz.tzutc())
+    date2 = isoparse(new_date_str).astimezone(tz.tzutc())
 
-    old_commit = get_commit_before_date(date1, REPO_OWNER, REPO_NAME, BRANCH)
+    old_commit = get_commit_before_date(old_date, REPO_OWNER, REPO_NAME, BRANCH)
     new_commit = get_commit_before_date(date2, REPO_OWNER, REPO_NAME, BRANCH)
 
     if not old_commit:
-        logger.error(f"Couldn't find commit before {date1}")
-        return None, None, None, None, None
+        logger.error(f"Couldn't find commit before {old_date}")
+        return None
 
     if not new_commit:
         logger.error(f"Couldn't find commit before {date2}")
-        return None, None, None, None, None
+        return None
 
     old_bioregistry = get_file_at_commit(FILE_PATH, old_commit, REPO_OWNER, REPO_NAME)
     new_bioregistry = get_file_at_commit(FILE_PATH, new_commit, REPO_OWNER, REPO_NAME)
 
-    added, deleted, updated, update_details = compare_bioregistry(old_bioregistry, new_bioregistry)
+    compare_bioregistry_rv = compare_bioregistry(old_bioregistry, new_bioregistry)
 
     old_mapping_keys = get_all_mapping_keys(old_bioregistry)
     new_mapping_keys = get_all_mapping_keys(new_bioregistry)
     all_mapping_keys = old_mapping_keys.union(new_mapping_keys)
 
-    return (
-        added,
-        deleted,
-        updated,
-        update_details,
-        old_bioregistry,
-        new_bioregistry,
-        all_mapping_keys,
-    )
+    return DataResult(compare_bioregistry_rv, old_bioregistry, new_bioregistry, all_mapping_keys)
 
 
 def summarize_changes(added, deleted, updated):
@@ -180,7 +198,7 @@ def summarize_changes(added, deleted, updated):
     logger.info(f"Total Updated Prefixes: {updated}")
 
 
-def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
+def visualize_changes(update_details, start_date, end_date, all_mapping_keys) -> None:
     """Display plots of changes in the bioregistry data.
 
     :param update_details: List of update details.
@@ -188,7 +206,7 @@ def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
     :param end_date: The ending date.
     :param all_mapping_keys: Set of all mapping keys.
     """
-    main_fields = {}
+    main_fields: dict[str, int] = {}
     mapping_fields = dict.fromkeys(all_mapping_keys, 0)
 
     if update_details:
@@ -250,18 +268,20 @@ def visualize_changes(update_details, start_date, end_date, all_mapping_keys):
 @click.command()
 @click.argument("date1")
 @click.argument("date2")
-def compare_dates(date1, date2):
+def compare_dates(date1: str, date2: str) -> None:
     """Process and visualize changes in Bioregistry data between two dates.
 
     :param date1: The starting date in the format YYYY-MM-DD.
     :param date2: The ending date in the format YYYY-MM-DD.
     """
-    added, deleted, updated, update_details, _old_data, _new_data, all_mapping_keys = get_data(
-        date1, date2
-    )
-    if added is not None and updated is not None:
-        summarize_changes(added, deleted, updated)
-        visualize_changes(update_details, date1, date2, all_mapping_keys)
+    data = get_data(date1, date2)
+    if data is not None:
+        summarize_changes(
+            data.comparison.added_prefixes,
+            data.comparison.deleted_prefixes,
+            data.comparison.updated_prefixes,
+        )
+        visualize_changes(data.comparison.update_details, date1, date2, data.all_mapping_keys)
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/analysis/mapping_checking.py
+++ b/src/bioregistry/analysis/mapping_checking.py
@@ -141,7 +141,7 @@ def _get_mismatch_entries() -> dict[str, Any]:
     # For all the curated mismatches, read the external registry involved
     # and extract the part relevant for the curated mismatch, then add it to
     # the raw registry for scoring
-    mismatch_entries: defaultdict[str, Any] = defaultdict(dict)
+    mismatch_entries: defaultdict[str, dict[str, Any]] = defaultdict(dict)
     # We compile content from external registries directly to be able
     # to access known mismatches that are otherwise not propagated to the
     # bioregistry

--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 import yaml
 from curies import Reference
 from curies.mapping_service.utils import handle_header
-from fastapi import APIRouter, Body, Header, HTTPException, Path, Query, Request
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Path, Query, Request
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, Field
 
@@ -36,7 +36,14 @@ __all__ = [
 api_router = APIRouter(prefix="/api")
 
 
-class UnhandledFormat(HTTPException):  # type:ignore
+def _get_manager(request: Request) -> Manager:
+    return request.app.manager  # type:ignore
+
+
+DependsManager = Annotated[Manager, Depends(_get_manager)]
+
+
+class UnhandledFormat(HTTPException):
     """An exception for an unhandled format."""
 
     def __init__(self, fmt: str) -> None:
@@ -47,7 +54,7 @@ class UnhandledFormat(HTTPException):  # type:ignore
         super().__init__(400, f"Bad Accept header: {fmt}")
 
 
-class YAMLResponse(Response):  # type:ignore
+class YAMLResponse(Response):
     """A custom response encoded in YAML."""
 
     media_type = "application/yaml"
@@ -102,16 +109,16 @@ def _handle_formats(accept: str | None, fmt: str | None) -> str:
 
 @api_router.get("/registry", response_model=Mapping[str, Resource], tags=["resource"])
 def get_resources(
-    request: Request,
+    manager: DependsManager,
     accept: str | None = ACCEPT_HEADER,
     format: str | None = FORMAT_QUERY,
 ) -> Response | dict[str, Resource]:
     """Get all resources."""
     accept = _handle_formats(accept, format)
     if accept == "application/json":
-        return request.app.manager.registry
+        return manager.registry
     elif accept == "application/yaml":
-        return YAMLResponse(sanitize_mapping(request.app.manager.registry))
+        return YAMLResponse(sanitize_mapping(manager.registry))
     elif accept in RDF_MEDIA_TYPES:
         raise NotImplementedError
     else:
@@ -134,7 +141,7 @@ def get_resources(
     response_model_exclude_unset=True,
 )
 def get_resource(
-    request: Request,
+    manager: DependsManager,
     prefix: str = Path(
         title="Prefix", description="The Bioregistry prefix for the entry", examples=["doid"]
     ),
@@ -142,10 +149,10 @@ def get_resource(
     format: str = FORMAT_QUERY,
 ) -> Response | Resource:
     """Get a resource."""
-    resource = request.app.manager.get_resource(prefix)
+    resource = manager.get_resource(prefix)
     if resource is None:
         raise HTTPException(status_code=404, detail=f"Prefix not found: {prefix}")
-    resource = request.app.manager.rasterized_resource(resource)
+    resource = manager.rasterized_resource(resource)
     accept = _handle_formats(accept, format)
     if accept == "application/json":
         return resource
@@ -153,7 +160,7 @@ def get_resource(
         return YAMLResponse(resource)
     elif accept in RDF_MEDIA_TYPES:
         return Response(
-            resource_to_rdf_str(resource, fmt=RDF_MEDIA_TYPES[accept], manager=request.app.manager),
+            resource_to_rdf_str(resource, fmt=RDF_MEDIA_TYPES[accept], manager=manager),
             media_type=accept,
         )
     else:
@@ -167,16 +174,16 @@ def get_resource(
     description="Get all metaresource representing registries.",
 )
 def get_metaresources(
-    request: Request,
+    manager: DependsManager,
     accept: str | None = ACCEPT_HEADER,
     format: str | None = FORMAT_QUERY,
 ) -> Response | Mapping[str, Registry]:
     """Get all registries."""
     accept = _handle_formats(accept, format)
     if accept == "application/json":
-        return request.app.manager.metaregistry
+        return manager.metaregistry
     elif accept == "application/yaml":
-        return YAMLResponse(sanitize_mapping(request.app.manager.metaregistry))
+        return YAMLResponse(sanitize_mapping(manager.metaregistry))
     elif accept in RDF_MEDIA_TYPES:
         raise NotImplementedError
     else:
@@ -207,13 +214,12 @@ METAPREFIX_PATH = Path(
     response_model_exclude_unset=True,
 )
 def get_metaresource(
-    request: Request,
+    manager: DependsManager,
     metaprefix: str = METAPREFIX_PATH,
     accept: str = ACCEPT_HEADER,
     format: str = FORMAT_QUERY,
 ) -> Response | Registry:
     """Get all registries."""
-    manager = request.app.manager
     metaresource = manager.get_registry(metaprefix)
     if metaresource is None:
         raise HTTPException(status_code=404, detail=f"Registry not found: {metaprefix}")
@@ -241,11 +247,10 @@ def get_metaresource(
     tags=["metaresource"],
 )
 def get_external_registry_slim(
-    request: Request,
+    manager: DependsManager,
     metaprefix: str = METAPREFIX_PATH,
 ) -> dict[str, Resource]:
     """Get a slim version of the registry with only resources mapped to the given external registry."""
-    manager = request.app.manager
     return {
         resource_.prefix: manager.rasterized_resource(resource_)
         for resource_ in manager.registry.values()
@@ -279,12 +284,11 @@ class MappingResponse(BaseModel):
     description="Get mappings from the given metaresource to another",
 )
 def get_metaresource_external_mappings(
-    request: Request,
+    manager: DependsManager,
     metaprefix: str = METAPREFIX_PATH,
     target: str = Path(title="target metaprefix"),
 ) -> MappingResponse | tuple[dict[str, str], int]:
     """Get mappings between two external prefixes."""
-    manager = request.app.manager
     try:
         diff = manager.get_external_mappings(metaprefix, target)
     except KeyError as e:
@@ -309,10 +313,9 @@ def get_metaresource_external_mappings(
     tags=["metaresource"],
 )
 def get_metaresource_mappings(
-    request: Request, metaprefix: str = METAPREFIX_PATH
+    manager: DependsManager, metaprefix: str = METAPREFIX_PATH
 ) -> dict[str, str]:
     """Get mappings from the Bioregistry to an external registry."""
-    manager: Manager = request.app.manager
     if metaprefix not in manager.metaregistry:
         raise HTTPException(404, detail=f"Invalid metaprefix: {metaprefix}")
     return manager.get_registry_map(metaprefix)
@@ -320,16 +323,16 @@ def get_metaresource_mappings(
 
 @api_router.get("/collection", response_model=Mapping[str, Collection], tags=["collection"])
 def get_collections(
-    request: Request,
+    manager: DependsManager,
     accept: str | None = ACCEPT_HEADER,
     format: str | None = FORMAT_QUERY,
 ) -> Response | dict[str, Collection]:
     """Get all collections."""
     accept = _handle_formats(accept, format)
     if accept == "application/json":
-        return request.app.manager.collections
+        return manager.collections
     elif accept == "application/yaml":
-        return YAMLResponse(sanitize_mapping(request.app.manager.collections))
+        return YAMLResponse(sanitize_mapping(manager.collections))
     elif accept in RDF_MEDIA_TYPES:
         raise NotImplementedError
     else:
@@ -352,7 +355,7 @@ def get_collections(
     response_model_exclude_unset=True,
 )
 def get_collection(
-    request: Request,
+    manager: DependsManager,
     identifier: str = Path(
         title="Collection Identifier",
         description="The 7-digit collection identifier",
@@ -362,7 +365,6 @@ def get_collection(
     format: str | None = FORMAT_QUERY,
 ) -> Response | Collection:
     """Get a collection."""
-    manager = request.app.manager
     collection = manager.collections.get(identifier)
     if collection is None:
         raise HTTPException(status_code=404, detail=f"Collection not found: {identifier}")
@@ -388,27 +390,27 @@ def get_collection(
 
 @api_router.get("/context", response_model=Mapping[str, Context], tags=["context"])
 def get_contexts(
-    request: Request,
+    manager: DependsManager,
     accept: str | None = ACCEPT_HEADER,
     format: str | None = FORMAT_QUERY,
 ) -> Response | dict[str, Context]:
     """Get all context."""
     accept = _handle_formats(accept, format)
     if accept == "application/json":
-        return request.app.manager.contexts
+        return manager.contexts
     elif accept == "application/yaml":
-        return YAMLResponse(sanitize_mapping(request.app.manager.contexts))
+        return YAMLResponse(sanitize_mapping(manager.contexts))
     else:
         raise HTTPException(400, f"Bad Accept header: {accept}")
 
 
 @api_router.get("/context/{identifier}", response_model=Context, tags=["context"])
 def get_context(
-    request: Request,
+    manager: DependsManager,
     identifier: str = Path(title="Context Key", description="The context key", examples=["obo"]),
 ) -> Context:
     """Get a context."""
-    context: Context | None = request.app.manager.contexts.get(identifier)
+    context: Context | None = manager.contexts.get(identifier)
     if context is None:
         raise HTTPException(status_code=404, detail=f"Context not found: {identifier}")
     return context
@@ -416,12 +418,12 @@ def get_context(
 
 @api_router.get("/contributors", response_model=Mapping[str, Attributable], tags=["contributor"])
 def get_contributors(
-    request: Request,
+    manager: DependsManager,
     accept: str | None = ACCEPT_HEADER,
     format: str | None = FORMAT_QUERY,
-) -> Response | dict[str, Attributable]:
+) -> Response | Mapping[str, Attributable]:
     """Get all context."""
-    contributors = request.app.manager.read_contributors()
+    contributors = manager.read_contributors()
     accept = _handle_formats(accept, format)
     if accept == "application/json":
         return contributors
@@ -444,10 +446,10 @@ class ContributorResponse(BaseModel):
 
 @api_router.get("/contributor/{orcid}", response_model=ContributorResponse, tags=["contributor"])
 def get_contributor(
-    request: Request, orcid: str = Path(title="Open Researcher and Contributor Identifier")
+    manager: DependsManager,
+    orcid: Annotated[str, Path(..., title="Open Researcher and Contributor Identifier")],
 ) -> ContributorResponse:
     """Get all context."""
-    manager = request.app.manager
     author = manager.read_contributors().get(orcid)
     if author is None:
         raise HTTPException(404, f"No contributor with orcid: {orcid}")
@@ -471,11 +473,10 @@ class IdentifierResponse(BaseModel):
 @api_router.get(
     "/reference/{prefix}:{identifier:path}", response_model=IdentifierResponse, tags=["reference"]
 )
-def get_reference(request: Request, prefix: str, identifier: str) -> IdentifierResponse:
+def get_reference(manager: DependsManager, prefix: str, identifier: str) -> IdentifierResponse:
     """Look up information on the reference."""
     # see https://fastapi.tiangolo.com/tutorial/path-params/#path-parameters-containing-paths
     # for more understanding on how the identifier:path handling works
-    manager = request.app.manager
     resource = manager.get_resource(prefix)
     if resource is None:
         raise HTTPException(404, f"invalid prefix: {prefix}")
@@ -529,15 +530,14 @@ class URIQuery(BaseModel):
     "/uri/parse/", response_model=URIResponse, tags=["reference"], summary="Parse a URI"
 )
 def post_parse_uri(
-    request: Request,
+    manager: DependsManager,
     query: Annotated[
         URIQuery, Body(..., examples=[URIQuery(uri="http://id.nlm.nih.gov/mesh/C063233")])
     ],
 ) -> URIResponse:
     """Parse a URI, return a CURIE, and all equivalent URIs."""
-    manager = request.app.manager
     prefix, identifier = manager.parse_uri(query.uri)
-    if prefix is None:
+    if prefix is None or identifier is None:
         raise HTTPException(404, f"can't parse URI: {query.uri}")
     return URIResponse(
         uri=query.uri,
@@ -549,7 +549,7 @@ def post_parse_uri(
 
 @api_router.get("/context.jsonld", tags=["resource"])
 def generate_context_json_ld(
-    request: Request,
+    manager: DependsManager,
     prefix: Annotated[
         list[str], Query(..., description="The prefix for the entry. Can be given multiple.")
     ],
@@ -564,7 +564,6 @@ def generate_context_json_ld(
 
     https://bioregistry.io/api/context.jsonld?prefix=go&prefix=doid&prefix=oa
     """
-    manager = request.app.manager
     prefix_map = {}
     for value in prefix:
         for prefix_ in value.split(","):
@@ -585,17 +584,17 @@ def generate_context_json_ld(
 
 @api_router.get("/autocomplete", tags=["search"])
 def autocomplete(
-    request: Request,
+    manager: DependsManager,
     q: Annotated[str, Query(description="A query for the prefix")],
 ) -> JSONResponse:
     """Complete a resolution query."""
-    return JSONResponse(_autocomplete(request.app.manager, q))
+    return JSONResponse(_autocomplete(manager, q))
 
 
 @api_router.get("/search", tags=["search"])
 def search(
-    request: Request,
+    manager: DependsManager,
     q: Annotated[str, Query(description="A query for the prefix")],
 ) -> JSONResponse:
     """Search for a prefix."""
-    return JSONResponse(_search(request.app.manager, q))
+    return JSONResponse(_search(manager, q))

--- a/src/bioregistry/app/cli.py
+++ b/src/bioregistry/app/cli.py
@@ -70,5 +70,6 @@ def web(
         and metaregistry is None
         and collections is None
         and contexts is None,
+        return_flask=False,
     )
     uvicorn.run(app, host=host, port=int(port), workers=workers)

--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -236,7 +236,7 @@ SELECT ?s ?o WHERE {
 def _get_sparql_router(app: Flask) -> APIRouter:
     sparql_graph = MappingServiceGraph(converter=app.manager.converter)
     sparql_processor = MappingServiceSPARQLProcessor(graph=sparql_graph)
-    sparql_router = SparqlRouter(
+    sparql_router: APIRouter = SparqlRouter(
         path="/sparql",
         title=f"{app.config['METAREGISTRY_TITLE']} SPARQL Service",
         description="An identifier mapping service",

--- a/src/bioregistry/app/impl.py
+++ b/src/bioregistry/app/impl.py
@@ -205,7 +205,7 @@ def get_app(
             "url": conf["METAREGISTRY_LICENSE_URL"],
         },
     )
-    fast_api.manager = manager
+    fast_api.manager = manager  # type:ignore
     fast_api.include_router(api_router)
     fast_api.include_router(_get_sparql_router(app))
     fast_api.mount("/", WSGIMiddleware(app))

--- a/src/bioregistry/app/ui.py
+++ b/src/bioregistry/app/ui.py
@@ -448,7 +448,7 @@ def metaresolve(
 
 
 @ui_blueprint.route("/resolve/github/issue/<owner>/<repository>/<int:issue>")
-def github_resolve_issue(owner, repository, issue) -> werkzeug.Response:
+def github_resolve_issue(owner: str, repository: str, issue: str) -> werkzeug.Response:
     """Redirect to an issue on GitHub."""
     return redirect(f"https://github.com/{owner}/{repository}/issues/{issue}")
 
@@ -620,7 +620,7 @@ def schema() -> str:
 @ui_blueprint.route("/schema.json")
 def json_schema() -> werkzeug.Response:
     """Return the JSON schema."""
-    return jsonify(get_json_schema())
+    return jsonify(get_json_schema())  # type:ignore
 
 
 @ui_blueprint.route("/highlights/twitter")

--- a/src/bioregistry/app/wsgi.py
+++ b/src/bioregistry/app/wsgi.py
@@ -2,7 +2,7 @@
 
 from bioregistry.app.impl import get_app
 
-app = get_app()
+app = get_app(return_flask=False)
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/bioregistry/benchmarks/curie_parsing.py
+++ b/src/bioregistry/benchmarks/curie_parsing.py
@@ -5,6 +5,7 @@ import random
 import time
 from collections.abc import Iterable
 from statistics import mean
+from typing import TypeAlias, cast
 
 import click
 import matplotlib.pyplot as plt
@@ -15,19 +16,22 @@ import bioregistry
 from bioregistry import manager
 from bioregistry.constants import CURIE_PARSING_DATA_PATH, CURIE_PARSING_SVG_PATH
 
+Row: TypeAlias = tuple[str, str, str, str, str]
 
-def get_curies(rebuild: bool = True):
+
+def get_curies(rebuild: bool = True) -> list[Row]:
     """Get prefix-identifier-banana-curie tuples for benchmarking."""
     if CURIE_PARSING_DATA_PATH.is_file() and not rebuild:
         return [
-            line.strip().split("\t") for line in CURIE_PARSING_DATA_PATH.read_text().splitlines()
+            cast(Row, line.strip().split("\t"))
+            for line in CURIE_PARSING_DATA_PATH.read_text().splitlines()
         ]
     rows = sorted(set(iter_curies()))
     CURIE_PARSING_DATA_PATH.write_text("\n".join("\t".join(line) for line in rows))
     return rows
 
 
-def iter_curies() -> Iterable[tuple[str, str, str, str, str]]:
+def iter_curies() -> Iterable[Row]:
     """Generate prefix-identifier-banana-curie tuples for benchmarking."""
     for prefix, resource in tqdm(
         manager.registry.items(), desc="Generating test CURIEs", unit="prefix"
@@ -58,7 +62,7 @@ def iter_curies() -> Iterable[tuple[str, str, str, str, str]]:
 @click.command()
 @click.option("--rebuild", is_flag=True)
 @click.option("--replicates", type=int, default=10)
-def main(rebuild: bool, replicates: int):
+def main(rebuild: bool, replicates: int) -> None:
     """Test parsing CURIEs."""
     curies = get_curies(rebuild=rebuild)
 

--- a/src/bioregistry/benchmarks/curie_parsing.py
+++ b/src/bioregistry/benchmarks/curie_parsing.py
@@ -5,12 +5,13 @@ import random
 import time
 from collections.abc import Iterable
 from statistics import mean
-from typing import TypeAlias, cast
+from typing import cast
 
 import click
 import matplotlib.pyplot as plt
 import seaborn as sns
 from tqdm import tqdm, trange
+from typing_extensions import TypeAlias
 
 import bioregistry
 from bioregistry import manager

--- a/src/bioregistry/benchmarks/curie_validation.py
+++ b/src/bioregistry/benchmarks/curie_validation.py
@@ -3,6 +3,7 @@
 import random
 import time
 from collections.abc import Iterable
+from typing import TypeAlias, cast
 
 import click
 import matplotlib.pyplot as plt
@@ -15,19 +16,22 @@ from bioregistry import manager
 from bioregistry.constants import CURIE_VALIDATION_DATA_PATH, CURIE_VALIDATION_SVG_PATH
 from bioregistry.utils import curie_to_str
 
+Row: TypeAlias = tuple[str, str, str, str]
 
-def get_curies(rebuild: bool = True):
+
+def get_curies(rebuild: bool = True) -> list[Row]:
     """Get prefix-identifier-banana-curie tuples for benchmarking."""
     if CURIE_VALIDATION_DATA_PATH.is_file() and not rebuild:
         return [
-            line.strip().split("\t") for line in CURIE_VALIDATION_DATA_PATH.read_text().splitlines()
+            cast(Row, line.strip().split("\t"))
+            for line in CURIE_VALIDATION_DATA_PATH.read_text().splitlines()
         ]
     rows = sorted(set(iter_curies()))
     CURIE_VALIDATION_DATA_PATH.write_text("\n".join("\t".join(line) for line in rows))
     return rows
 
 
-def iter_curies() -> Iterable[tuple[str, str, str, str]]:
+def iter_curies() -> Iterable[Row]:
     """Generate prefix-identifier-banana-curie tuples for benchmarking."""
     for prefix, resource in tqdm(
         manager.registry.items(), desc="Generating test CURIEs", unit="prefix"
@@ -62,7 +66,7 @@ def iter_curies() -> Iterable[tuple[str, str, str, str]]:
 @click.command()
 @click.option("--rebuild", is_flag=True)
 @click.option("--replicates", type=int, default=10)
-def main(rebuild: bool, replicates: int):
+def main(rebuild: bool, replicates: int) -> None:
     """Test validating CURIEs."""
     curies = get_curies(rebuild=rebuild)
 

--- a/src/bioregistry/benchmarks/curie_validation.py
+++ b/src/bioregistry/benchmarks/curie_validation.py
@@ -3,13 +3,14 @@
 import random
 import time
 from collections.abc import Iterable
-from typing import TypeAlias, cast
+from typing import cast
 
 import click
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 from tqdm import tqdm, trange
+from typing_extensions import TypeAlias
 
 import bioregistry
 from bioregistry import manager

--- a/src/bioregistry/benchmarks/uri_parsing.py
+++ b/src/bioregistry/benchmarks/uri_parsing.py
@@ -3,12 +3,13 @@
 import time
 from collections.abc import Iterable
 from statistics import mean
-from typing import TypeAlias, cast
+from typing import cast
 
 import click
 import matplotlib.pyplot as plt
 import seaborn as sns
 from tqdm import tqdm, trange
+from typing_extensions import TypeAlias
 
 import bioregistry
 from bioregistry import manager

--- a/src/bioregistry/benchmarks/uri_parsing.py
+++ b/src/bioregistry/benchmarks/uri_parsing.py
@@ -3,6 +3,7 @@
 import time
 from collections.abc import Iterable
 from statistics import mean
+from typing import TypeAlias, cast
 
 import click
 import matplotlib.pyplot as plt
@@ -13,17 +14,22 @@ import bioregistry
 from bioregistry import manager
 from bioregistry.constants import URI_PARSING_DATA_PATH, URI_PARSING_SVG_PATH
 
+Row: TypeAlias = tuple[str, str, str, str]
 
-def get_uris(rebuild: bool = True):
+
+def get_uris(rebuild: bool = True) -> list[Row]:
     """Get prefix-identifier-metaprefix-url quads for benchmarking."""
     if URI_PARSING_DATA_PATH.is_file() and not rebuild:
-        return [line.strip().split("\t") for line in URI_PARSING_DATA_PATH.read_text().splitlines()]
+        return [
+            cast(Row, line.strip().split("\t"))
+            for line in URI_PARSING_DATA_PATH.read_text().splitlines()
+        ]
     uris = sorted(set(iter_uris()))
     URI_PARSING_DATA_PATH.write_text("\n".join("\t".join(line) for line in uris))
     return uris
 
 
-def iter_uris() -> Iterable[tuple[str, str, str, str]]:
+def iter_uris() -> Iterable[Row]:
     """Generate prefix-identifier-metaprefix-url quads for benchmarking."""
     for prefix, resource in tqdm(
         manager.registry.items(), desc="Generating test URIs", unit="prefix"
@@ -43,7 +49,7 @@ def iter_uris() -> Iterable[tuple[str, str, str, str]]:
 @click.command()
 @click.option("--rebuild", is_flag=True)
 @click.option("--replicates", type=int, default=10)
-def main(rebuild: bool, replicates: int):
+def main(rebuild: bool, replicates: int) -> None:
     """Test parsing IRIs."""
     uris = get_uris(rebuild=rebuild)
 

--- a/src/bioregistry/curation/add_examples.py
+++ b/src/bioregistry/curation/add_examples.py
@@ -37,11 +37,11 @@ def _get_example(prefix: str) -> str | None:
         return None
     if not x:
         return None
-    x = list(x)
+    y: list[str] = list(x)
     try:
-        rv = x[random.randint(0, len(x))]  # noqa:S311
+        rv: str = y[random.randint(0, len(x))]  # noqa:S311
     except IndexError:
-        click.echo(f"failed {prefix} {x}")
+        click.echo(f"failed {prefix} {y}")
         return None
     else:
         click.echo(f"adding {prefix} {rv}")

--- a/src/bioregistry/curation/add_examples_from_ols.py
+++ b/src/bioregistry/curation/add_examples_from_ols.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from typing import cast
 
 import requests
 from tqdm import tqdm
@@ -28,7 +29,7 @@ def _get_example_helper(prefix: str, url: str) -> str:
         raise KeyError
     for term in embedded["terms"]:
         if term["short_form"].startswith(prefix.upper()):
-            return term["short_form"]
+            return cast(str, term["short_form"])
     next_url = res["_links"]["next"]["href"]
     return _get_example_helper(prefix, next_url)
 

--- a/src/bioregistry/curation/enrich_publications.py
+++ b/src/bioregistry/curation/enrich_publications.py
@@ -6,7 +6,7 @@ Run this script with python -m bioregistry.curation.clean_publications.
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any, cast
+from typing import Any
 
 from manubot.cite.doi import get_doi_csl_item
 from manubot.cite.pubmed import get_pmid_for_doi, get_pubmed_csl_item
@@ -20,28 +20,28 @@ from bioregistry.utils import removeprefix
 @lru_cache(None)
 def _get_pubmed_csl_item(pubmed_id: str) -> dict[str, Any] | None:
     try:
-        return get_pubmed_csl_item(pubmed_id)
+        return get_pubmed_csl_item(pubmed_id)  # type:ignore
     except Exception:
         return None
 
 
 @lru_cache(None)
-def _get_doi_csl_item(pubmed_id) -> dict[str, Any] | None:
-    return get_doi_csl_item(pubmed_id)
+def _get_doi_csl_item(pubmed_id: str) -> dict[str, Any] | None:
+    return get_doi_csl_item(pubmed_id)  # type:ignore
 
 
 @lru_cache(None)
 def _get_pubmed_from_doi(doi: str) -> str | None:
     tqdm.write(f"getting pubmed from DOI:{doi}")
-    doi = cast(str, removeprefix(doi, "https://doi.org/"))
-    return get_pmid_for_doi(doi)
+    doi = removeprefix(doi, "https://doi.org/")
+    return get_pmid_for_doi(doi)  # type:ignore
 
 
 def _clean_doi(doi: str) -> str:
     doi = doi.lower()
-    doi = cast(str, removeprefix(doi, "https://doi.org/"))
-    doi = cast(str, removeprefix(doi, "http://doi.org/"))
-    doi = cast(str, removeprefix(doi, "doi:"))
+    doi = removeprefix(doi, "https://doi.org/")
+    doi = removeprefix(doi, "http://doi.org/")
+    doi = removeprefix(doi, "doi:")
     return doi
 
 

--- a/src/bioregistry/export/rdf_export.py
+++ b/src/bioregistry/export/rdf_export.py
@@ -114,7 +114,7 @@ def collection_to_rdf_str(
     """Get a collection as an RDF string."""
     graph = _graph(manager=manager)
     collection.add_triples(graph)
-    return graph.serialize(format=fmt or "turtle")
+    return cast(str, graph.serialize(format=fmt or "turtle"))
 
 
 def metaresource_to_rdf_str(
@@ -125,7 +125,7 @@ def metaresource_to_rdf_str(
     """Get a collection as an RDF string."""
     graph = _graph(manager=manager)
     registry.add_triples(graph)
-    return graph.serialize(format=fmt or "turtle")
+    return cast(str, graph.serialize(format=fmt or "turtle"))
 
 
 def resource_to_rdf_str(
@@ -136,7 +136,7 @@ def resource_to_rdf_str(
     """Get a collection as an RDF string."""
     graph = _graph(manager=manager)
     _add_resource(resource, manager=manager, graph=graph)
-    return graph.serialize(format=fmt or "turtle")
+    return cast(str, graph.serialize(format=fmt or "turtle"))
 
 
 def _get_resource_functions() -> list[tuple[str | URIRef, Callable[[Resource], Any], URIRef]]:

--- a/src/bioregistry/external/__init__.py
+++ b/src/bioregistry/external/__init__.py
@@ -1,6 +1,6 @@
 """Acquisition, processing, and alignment of external registries."""
 
-from typing import Callable
+from typing import Any, Callable
 
 from .aberowl import get_aberowl
 from .bartoc import get_bartoc
@@ -62,7 +62,7 @@ __all__ = [
     "get_zazuko",
 ]
 
-GETTERS: list[tuple[str, str, Callable]] = [
+GETTERS: list[tuple[str, str, Callable[..., dict[str, dict[str, Any]]]]] = [
     ("obofoundry", "OBO", get_obofoundry),
     ("ols", "OLS", get_ols),
     ("miriam", "MIRIAM", get_miriam),

--- a/src/bioregistry/external/aberowl/__init__.py
+++ b/src/bioregistry/external/aberowl/__init__.py
@@ -9,7 +9,7 @@ import yaml
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "AberOWLAligner",
@@ -25,8 +25,7 @@ ABEROWL_URL = "http://aber-owl.net/api/ontology/?drf_fromat=json&format=json"
 def get_aberowl(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the AberOWL registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=ABEROWL_URL, path=RAW_PATH, force=True)
     with RAW_PATH.open() as file:

--- a/src/bioregistry/external/alignment_utils.py
+++ b/src/bioregistry/external/alignment_utils.py
@@ -1,7 +1,9 @@
 """Utilities for registry alignment."""
 
 import csv
+import json
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
 from typing import Any, Callable, ClassVar, Optional
 
 import click
@@ -16,6 +18,7 @@ from ..utils import norm
 
 __all__ = [
     "Aligner",
+    "load_processed",
 ]
 
 
@@ -284,3 +287,9 @@ class Aligner:
         s = self.get_curation_table(**kwargs)
         if s:
             print(s)  # noqa:T201
+
+
+def load_processed(path: Path) -> dict[str, dict[str, Any]]:
+    """Load a processed."""
+    with path.open() as file:
+        return json.load(file)

--- a/src/bioregistry/external/alignment_utils.py
+++ b/src/bioregistry/external/alignment_utils.py
@@ -292,4 +292,4 @@ class Aligner:
 def load_processed(path: Path) -> dict[str, dict[str, Any]]:
     """Load a processed."""
     with path.open() as file:
-        return json.load(file)
+        return json.load(file)  # type:ignore

--- a/src/bioregistry/external/bartoc/__init__.py
+++ b/src/bioregistry/external/bartoc/__init__.py
@@ -1,7 +1,7 @@
 """Download the BARTOC registry."""
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from bioregistry.constants import URI_FORMAT_KEY
 from bioregistry.license_standardizer import standardize_license
 
-from ..alignment_utils import Aligner
+from ..alignment_utils import Aligner, load_processed
 
 __all__ = [
     "BartocAligner",
@@ -23,7 +23,7 @@ PROCESSED_PATH = HERE / "processed.json"
 URL = "https://bartoc.org/data/dumps/latest.ndjson"
 
 
-def get_bartoc(force_download: bool = True) -> Mapping[str, Mapping[str, Any]]:
+def get_bartoc(*, force_download: bool = True) -> dict[str, dict[str, Any]]:
     """Get the BARTOC registry.
 
     :param force_download: If true, forces download. If false and the file
@@ -33,7 +33,7 @@ def get_bartoc(force_download: bool = True) -> Mapping[str, Mapping[str, Any]]:
     .. seealso:: https://bartoc.org/
     """
     if PROCESSED_PATH.is_file() and not force_download:
-        return json.loads(PROCESSED_PATH.read_text())
+        return load_processed(PROCESSED_PATH)
     rv = {}
     for line in requests.get(URL, timeout=15).iter_lines():
         record = json.loads(line)

--- a/src/bioregistry/external/biocontext/__init__.py
+++ b/src/bioregistry/external/biocontext/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "BioContextAligner",
@@ -22,7 +22,7 @@ URL = "https://raw.githubusercontent.com/prefixcommons/biocontext/master/registr
 SKIP_PARTS = {"identifiers.org", "purl.obolibrary.org"}
 
 
-def get_biocontext(force_download: bool = False) -> Mapping[str, Mapping[str, Any]]:
+def get_biocontext(*, force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the BioContext context map.
 
     :param force_download: If true, forces download. If false and the file
@@ -32,8 +32,7 @@ def get_biocontext(force_download: bool = False) -> Mapping[str, Mapping[str, An
     .. seealso:: https://github.com/prefixcommons/biocontext
     """
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
     download(url=URL, path=RAW_PATH, force=force_download)
     with RAW_PATH.open() as file:
         data = json.load(file)

--- a/src/bioregistry/external/biolink/__init__.py
+++ b/src/bioregistry/external/biolink/__init__.py
@@ -9,7 +9,7 @@ import yaml
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "BiolinkAligner",
@@ -28,8 +28,7 @@ PROCESSING_BIOLINK_PATH = DIRECTORY / "processing_biolink.json"
 def get_biolink(force_download: bool = False) -> dict[str, dict[str, str]]:
     """Get Biolink."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
     download(url=URL, path=RAW_PATH, force=True)
     with RAW_PATH.open() as file:
         data = yaml.safe_load(file)

--- a/src/bioregistry/external/biolink/__init__.py
+++ b/src/bioregistry/external/biolink/__init__.py
@@ -54,7 +54,7 @@ class BiolinkAligner(Aligner):
             j = json.load(file)
         return {entry["prefix"]: entry["reason"] for entry in j["skip"]}
 
-    def prepare_external(self, external_id: str, external_entry) -> dict[str, Any]:
+    def prepare_external(self, external_id: str, external_entry: dict[str, Any]) -> dict[str, Any]:
         """Prepare Biolink data to be added to the Biolink for each BioPortal registry entry."""
         uri_format = external_entry[URI_FORMAT_KEY]
         return {
@@ -63,7 +63,7 @@ class BiolinkAligner(Aligner):
             "is_obo": uri_format.startswith("http://purl.obolibrary.org"),
         }
 
-    def get_curation_row(self, external_id, external_entry) -> Sequence[str]:
+    def get_curation_row(self, external_id: str, external_entry: dict[str, Any]) -> Sequence[str]:
         """Prepare curation rows for unaligned Biolink registry entries."""
         uri_format = external_entry[URI_FORMAT_KEY]
         return [

--- a/src/bioregistry/external/bioportal/__init__.py
+++ b/src/bioregistry/external/bioportal/__init__.py
@@ -46,7 +46,7 @@ class OntoPortalClient:
         self.raw_path = RAW_DIRECTORY.joinpath(self.metaprefix).with_suffix(".json")
         self.processed_path = DIRECTORY.joinpath(self.metaprefix).with_suffix(".json")
 
-    def query(self, url: str, **params) -> requests.Response:
+    def query(self, url: str, **params: Any) -> requests.Response:
         """Query the given endpoint on the OntoPortal site.
 
         :param url: URL to query
@@ -69,7 +69,7 @@ class OntoPortalClient:
         # see https://data.bioontology.org/documentation#Ontology
         res = self.query(self.base_url + "/ontologies", summaryOnly=False, notes=True)
         records = res.json()
-        records = thread_map(
+        records = thread_map(  # type:ignore
             self._preprocess,
             records,
             unit="ontology",
@@ -79,7 +79,7 @@ class OntoPortalClient:
         with self.raw_path.open("w") as file:
             json.dump(records, file, indent=2, sort_keys=True, ensure_ascii=False)
 
-        records = thread_map(
+        records = thread_map(  # type:ignore
             self.process, records, disable=True, description=f"Processing {self.metaprefix}"
         )
         rv = {result["prefix"]: result for result in records}

--- a/src/bioregistry/external/bioportal/__init__.py
+++ b/src/bioregistry/external/bioportal/__init__.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from tqdm.contrib.concurrent import thread_map
 
 from bioregistry.constants import EMAIL_RE, RAW_DIRECTORY
+from bioregistry.external.alignment_utils import load_processed
 from bioregistry.license_standardizer import standardize_license
 from bioregistry.utils import removeprefix
 
@@ -63,8 +64,7 @@ class OntoPortalClient:
     def download(self, force_download: bool = False) -> dict[str, dict[str, Any]]:
         """Get the full dump of the OntoPortal site's registry."""
         if self.processed_path.exists() and not force_download:
-            with self.processed_path.open() as file:
-                return json.load(file)
+            return load_processed(self.processed_path)
 
         # see https://data.bioontology.org/documentation#Ontology
         res = self.query(self.base_url + "/ontologies", summaryOnly=False, notes=True)

--- a/src/bioregistry/external/cellosaurus/__init__.py
+++ b/src/bioregistry/external/cellosaurus/__init__.py
@@ -61,9 +61,11 @@ def get_cellosaurus(
             if mapped_key is None:
                 continue
             if mapped_key == URI_FORMAT_KEY:
-                value = _process_db_url(d["prefix"], value)
-                if value is None:
+                value_tmp = _process_db_url(d["prefix"], value)
+                if value_tmp is None:
                     continue
+                else:
+                    value = value_tmp
             d[mapped_key] = value
         if not keep_missing_uri and URI_FORMAT_KEY not in d:
             continue
@@ -75,9 +77,9 @@ def get_cellosaurus(
     return rv
 
 
-def _process_db_url(key, value):
+def _process_db_url(key: str, value: str) -> str | None:
     if value in {"https://%s", "None"}:
-        return
+        return None
     if value.endswith("http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252F%s") or value.endswith(
         "http://purl.obolibrary.org/obo/%s"
     ):
@@ -86,7 +88,7 @@ def _process_db_url(key, value):
             "See discussion at https://github.com/biopragmatics/bioregistry/issues/1259.",
             key,
         )
-        return
+        return None
     return value.rstrip("/").replace("%s", "$1")
 
 

--- a/src/bioregistry/external/cellosaurus/__init__.py
+++ b/src/bioregistry/external/cellosaurus/__init__.py
@@ -1,5 +1,7 @@
 """Download the Cellosaurus registry."""
 
+from __future__ import annotations
+
 import itertools as itt
 import json
 import logging

--- a/src/bioregistry/external/cellosaurus/__init__.py
+++ b/src/bioregistry/external/cellosaurus/__init__.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "CellosaurusAligner",
@@ -37,8 +37,7 @@ def get_cellosaurus(
 ) -> dict[str, dict[str, Any]]:
     """Get the Cellosaurus registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=URL, path=RAW_PATH, force=True)
     with RAW_PATH.open(encoding="ISO8859-1") as file:

--- a/src/bioregistry/external/cheminf/__init__.py
+++ b/src/bioregistry/external/cheminf/__init__.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, ClassVar
 
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.utils import get_ols_descendants
 
 __all__ = [
@@ -36,8 +36,7 @@ SKIP = {
 def get_cheminf(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the Chemical Information Ontology registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
     rv = get_ols_descendants(ontology="cheminf", uri=BASE_URL, force_download=force_download)
     with PROCESSED_PATH.open("w") as file:
         json.dump(rv, file, indent=2, sort_keys=True)

--- a/src/bioregistry/external/cropoct/__init__.py
+++ b/src/bioregistry/external/cropoct/__init__.py
@@ -3,7 +3,7 @@
 import io
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -60,7 +60,7 @@ def get_cropoct(force_download: bool = False) -> dict[str, dict[str, Any]]:
     return rv
 
 
-def _process(record):
+def _process(record: Mapping[str, Any]) -> dict[str, Any]:
     rv = {
         "prefix": record["id"],
         "name": record["title"],

--- a/src/bioregistry/external/cropoct/__init__.py
+++ b/src/bioregistry/external/cropoct/__init__.py
@@ -11,7 +11,7 @@ import yaml
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "CropOCTAligner",
@@ -29,8 +29,7 @@ CROPOCT_URL = "https://cropontology.org/metadata"
 def get_cropoct(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the CropOCT registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=CROPOCT_URL, path=RAW_PATH, force=True)
 

--- a/src/bioregistry/external/edam/__init__.py
+++ b/src/bioregistry/external/edam/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, ClassVar
 
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.utils import get_ols_descendants
 
 __all__ = [
@@ -22,7 +22,7 @@ EDAM_PARENT_IRI = "http%253A%252F%252Fedamontology.org%252Fdata_2091"
 def get_edam(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the EDAM registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        return json.loads(PROCESSED_PATH.read_text())
+        return load_processed(PROCESSED_PATH)
 
     rv = get_ols_descendants(
         ontology="edam",

--- a/src/bioregistry/external/edam/__init__.py
+++ b/src/bioregistry/external/edam/__init__.py
@@ -35,7 +35,7 @@ def get_edam(force_download: bool = False) -> dict[str, dict[str, Any]]:
     return rv
 
 
-def _get_identifier(term, ontology: str) -> str:
+def _get_identifier(term: dict[str, str], ontology: str) -> str:
     # note that this prefix doesn't match the ontology name
     return term["obo_id"][len("data:") :]
 

--- a/src/bioregistry/external/fairsharing/__init__.py
+++ b/src/bioregistry/external/fairsharing/__init__.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from bioregistry.constants import ORCID_PATTERN
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.license_standardizer import standardize_license
 from bioregistry.utils import removeprefix, removesuffix
 
@@ -44,8 +44,7 @@ def get_fairsharing(
 ) -> dict[str, dict[str, Any]]:
     """Get the FAIRsharing registry."""
     if PROCESSED_PATH.exists() and not force_download and not force_reload:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     from fairsharing_client import load_fairsharing
 

--- a/src/bioregistry/external/fairsharing/__init__.py
+++ b/src/bioregistry/external/fairsharing/__init__.py
@@ -145,7 +145,7 @@ def _process_record(record: MutableMapping[str, Any]) -> dict[str, Any] | None:
 SKIP_LICENSES: set[str] = set()
 
 
-def _process_publication(publication):
+def _process_publication(publication: dict[str, Any]) -> dict[str, Any] | None:
     rv = {}
     doi = publication.get("doi")
     if doi:
@@ -160,7 +160,7 @@ def _process_publication(publication):
     if pubmed:
         rv["pubmed"] = str(pubmed)
     if not doi and not pubmed:
-        return
+        return None
     title = publication.get("title")
     if title:
         title = title.replace("  ", " ").rstrip(".")

--- a/src/bioregistry/external/go/__init__.py
+++ b/src/bioregistry/external/go/__init__.py
@@ -10,7 +10,7 @@ import yaml
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "GoAligner",
@@ -46,8 +46,7 @@ PROCESSING_GO_PATH = DIRECTORY / "processing_go.json"
 def get_go(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the GO registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=GO_URL, path=RAW_PATH, force=True)
     with RAW_PATH.open() as file:

--- a/src/bioregistry/external/go/__init__.py
+++ b/src/bioregistry/external/go/__init__.py
@@ -73,7 +73,7 @@ class GoAligner(Aligner):
         """Get the skipped GO identifiers."""
         with PROCESSING_GO_PATH.open() as file:
             j = json.load(file)
-        return j["skip"]
+        return j["skip"]  # type:ignore
 
     def prepare_external(
         self, external_id: str, external_entry: Mapping[str, Any]

--- a/src/bioregistry/external/hl7/__init__.py
+++ b/src/bioregistry/external/hl7/__init__.py
@@ -6,7 +6,6 @@
 """
 
 import csv
-from collections.abc import Mapping
 from pathlib import Path
 
 __all__ = [
@@ -33,7 +32,7 @@ COLUMNS = {
 }
 
 
-def get_hl7(force_download: bool = False) -> Mapping[str, Mapping[str, str]]:
+def get_hl7(*, force_download: bool = False) -> dict[str, dict[str, str]]:
     """Get HL7 OIDs."""
     rv = {}
     with DATA.open() as file:

--- a/src/bioregistry/external/integbio/__init__.py
+++ b/src/bioregistry/external/integbio/__init__.py
@@ -64,7 +64,9 @@ def get_url() -> str:
     res = requests.get(base, timeout=15)
     soup = BeautifulSoup(res.text, "html.parser")
     for anchor in soup.find_all("a"):
-        href = anchor.attrs["href"]
+        href: str | None = anchor.attrs["href"]
+        if href is None:
+            continue
         if href.startswith(download_prefix) and href.endswith(download_suffix):
             return "https://catalog.integbio.jp" + href
     raise ValueError(f"unable to find Integbio download link on {base}")

--- a/src/bioregistry/external/lov/__init__.py
+++ b/src/bioregistry/external/lov/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar, Union, cast
 
 from pystow.utils import download, read_rdf
 
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "LOVAligner",
@@ -46,7 +46,7 @@ def get_lov(
 ) -> dict[str, dict[str, Any]]:
     """Get the LOV data cloud registry."""
     if PROCESSED_PATH.exists() and not force_download and not force_refresh:
-        return json.loads(PROCESSED_PATH.read_text())
+        return load_processed(PROCESSED_PATH)
 
     with tempfile.TemporaryDirectory() as dir:
         path = Path(dir).joinpath("lov.n3.gz")

--- a/src/bioregistry/external/miriam/__init__.py
+++ b/src/bioregistry/external/miriam/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "MiriamAligner",
@@ -38,8 +38,7 @@ def get_miriam(
 ) -> dict[str, dict[str, Any]]:
     """Get the MIRIAM registry."""
     if PROCESSED_PATH.exists() and not force_download and not force_process:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=MIRIAM_URL, path=RAW_PATH, force=force_download)
     with open(RAW_PATH) as file:

--- a/src/bioregistry/external/miriam/__init__.py
+++ b/src/bioregistry/external/miriam/__init__.py
@@ -69,7 +69,7 @@ PROVIDER_BLACKLIST = {
 }
 
 
-def _process(record):
+def _process(record: dict[str, Any]) -> dict[str, Any]:
     prefix = record["prefix"]
     rv = {
         "prefix": prefix,
@@ -118,7 +118,7 @@ SKIP_PROVIDERS = {
 }
 
 
-def _preprocess_resource(resource):
+def _preprocess_resource(resource: dict[str, Any]) -> dict[str, Any]:
     rv = {
         "official": resource["official"],
         "homepage": resource["resourceHomeUrl"],

--- a/src/bioregistry/external/n2t/__init__.py
+++ b/src/bioregistry/external/n2t/__init__.py
@@ -1,5 +1,7 @@
 """Download registry information from N2T."""
 
+from __future__ import annotations
+
 import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path

--- a/src/bioregistry/external/n2t/__init__.py
+++ b/src/bioregistry/external/n2t/__init__.py
@@ -57,7 +57,7 @@ def get_n2t(force_download: bool = False) -> dict[str, dict[str, Any]]:
     return rv
 
 
-def _process(record):
+def _process(record: dict[str, Any]) -> dict[str, Any]:
     rv = {
         "name": record.get("name"),
         URI_FORMAT_KEY: _get_uri_format(record),
@@ -70,8 +70,8 @@ def _process(record):
     return {k: v for k, v in rv.items() if v is not None}
 
 
-def _get_uri_format(record):
-    raw_redirect = record.get("redirect")
+def _get_uri_format(record: dict[str, Any]) -> str | None:
+    raw_redirect: str | None = record.get("redirect")
     if raw_redirect is None:
         return None
     uri_format = raw_redirect.replace("$id", "$1")

--- a/src/bioregistry/external/n2t/__init__.py
+++ b/src/bioregistry/external/n2t/__init__.py
@@ -9,7 +9,7 @@ import yaml
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "N2TAligner",
@@ -39,8 +39,7 @@ SKIP_URI_FORMATS = {
 def get_n2t(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the N2T registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=URL, path=RAW_PATH, force=True)
     # they give malformed YAML so time to write a new parser

--- a/src/bioregistry/external/ncbi/__init__.py
+++ b/src/bioregistry/external/ncbi/__init__.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "NcbiAligner",
@@ -57,8 +57,7 @@ OBSOLETE = {
 def get_ncbi(force_download: bool = False) -> dict[str, dict[str, str]]:
     """Get the NCBI data."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=URL, path=RAW_PATH, force=True)
     with RAW_PATH.open() as file:

--- a/src/bioregistry/external/ncbi/__init__.py
+++ b/src/bioregistry/external/ncbi/__init__.py
@@ -158,12 +158,12 @@ class NcbiAligner(Aligner):
     getter_kwargs: ClassVar[dict[str, Any]] = {"force_download": False}
     curation_header: ClassVar[Sequence[str]] = ("name", "example", "homepage")
 
-    def get_curation_row(self, external_id, external_entry) -> Sequence[str]:
+    def get_curation_row(self, external_id: str, external_entry: dict[str, Any]) -> Sequence[str]:
         """Return the relevant fields from an NCBI entry for pretty-printing."""
         return [
             textwrap.shorten(external_entry["name"], 50),
-            external_entry.get("example"),
-            external_entry.get("homepage"),
+            external_entry.get("example", ""),
+            external_entry.get("homepage", ""),
         ]
 
 

--- a/src/bioregistry/external/obofoundry/__init__.py
+++ b/src/bioregistry/external/obofoundry/__init__.py
@@ -57,10 +57,9 @@ def get_obofoundry(
     return rv
 
 
-def _process(record):
+def _process(record: dict[str, Any]) -> dict[str, Any]:
     for key in ("browsers", "usages", "build", "layout", "taxon"):
-        if key in record:
-            del record[key]
+        record.pop(key, None)
 
     oid = record["id"].lower()
 
@@ -119,7 +118,7 @@ def get_obofoundry_example(prefix: str) -> Optional[str]:
     """Get an example identifier from the OBO Library PURL configuration."""
     url = f"https://raw.githubusercontent.com/OBOFoundry/purl.obolibrary.org/master/config/{prefix}.yml"
     data = yaml.safe_load(requests.get(url, timeout=15).content)
-    examples = data.get("example_terms")
+    examples: list[str] | None = data.get("example_terms")
     if not examples:
         return None
     return examples[0].rsplit("_")[-1]
@@ -138,7 +137,9 @@ class OBOFoundryAligner(Aligner):
         """Get the prefixes in the OBO Foundry that should be skipped."""
         return SKIP
 
-    def _align_action(self, bioregistry_id, external_id, external_entry):
+    def _align_action(
+        self, bioregistry_id: str, external_id: str, external_entry: dict[str, Any]
+    ) -> None:
         super()._align_action(bioregistry_id, external_id, external_entry)
         if (
             self.manager.get_example(bioregistry_id)

--- a/src/bioregistry/external/obofoundry/__init__.py
+++ b/src/bioregistry/external/obofoundry/__init__.py
@@ -11,7 +11,7 @@ import yaml
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "OBOFoundryAligner",
@@ -36,8 +36,7 @@ def get_obofoundry(
 ) -> dict[str, dict[str, Any]]:
     """Get the OBO Foundry registry."""
     if PROCESSED_PATH.exists() and not force_download and not force_process:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=OBOFOUNDRY_URL, path=RAW_PATH, force=force_download)
     with RAW_PATH.open() as file:

--- a/src/bioregistry/external/obofoundry/__init__.py
+++ b/src/bioregistry/external/obofoundry/__init__.py
@@ -1,10 +1,12 @@
 """Download registry information from the OBO Foundry."""
 
+from __future__ import annotations
+
 import json
 import logging
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 import requests
 import yaml
@@ -114,7 +116,7 @@ def _process(record: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in rv.items() if v is not None}
 
 
-def get_obofoundry_example(prefix: str) -> Optional[str]:
+def get_obofoundry_example(prefix: str) -> str | None:
     """Get an example identifier from the OBO Library PURL configuration."""
     url = f"https://raw.githubusercontent.com/OBOFoundry/purl.obolibrary.org/master/config/{prefix}.yml"
     data = yaml.safe_load(requests.get(url, timeout=15).content)

--- a/src/bioregistry/external/ols/__init__.py
+++ b/src/bioregistry/external/ols/__init__.py
@@ -18,7 +18,7 @@ import requests
 from pydantic import BaseModel
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.parse_version_iri import parse_obo_version_iri
 from bioregistry.utils import OLSBrokenError
 
@@ -49,8 +49,7 @@ OLS_SKIP = {
 def get_ols(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the OLS registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     data = requests.get(URL, timeout=15).json()
     if "_embedded" not in data:

--- a/src/bioregistry/external/ols/__init__.py
+++ b/src/bioregistry/external/ols/__init__.py
@@ -120,7 +120,7 @@ def _get_email(ols_id: str, config: dict[str, Any]) -> str | None:
     return email
 
 
-def _get_license(ols_id, config) -> str | None:
+def _get_license(ols_id: str, config: dict[str, Any]) -> str | None:
     license_value = (config.get("annotations") or {}).get("license", [None])[0]
     if license_value == "Unspecified":
         logger.info("[%s] unspecified license in OLS. Contact: %s", ols_id, config["mailingList"])
@@ -130,14 +130,14 @@ def _get_license(ols_id, config) -> str | None:
     return license_value
 
 
-def _get_version(ols_id, config, processing: OLSConfig) -> str | None:
+def _get_version(ols_id: str, config: dict[str, Any], processing: OLSConfig) -> str | None:
     version_iri = config.get("versionIri")
     if version_iri:
         _, _, version = parse_obo_version_iri(version_iri, ols_id)
         if version:
             return version
 
-    version = config.get("version")
+    version: str | None = config.get("version")
     if version is None and processing.version_iri_prefix:
         if not version_iri.startswith(processing.version_iri_prefix):
             logger.info("[%s] version IRI does not start with appropriate prefix", ols_id)

--- a/src/bioregistry/external/ontobee/__init__.py
+++ b/src/bioregistry/external/ontobee/__init__.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "OntobeeAligner",
@@ -32,8 +32,7 @@ LEGEND = {
 def get_ontobee(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the OntoBee registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=URL, path=RAW_PATH, force=True)
     with RAW_PATH.open() as f:

--- a/src/bioregistry/external/ontobee/__init__.py
+++ b/src/bioregistry/external/ontobee/__init__.py
@@ -68,11 +68,11 @@ class OntobeeAligner(Aligner):
     getter = get_ontobee
     curation_header: ClassVar[Sequence[str]] = ("name", "url")
 
-    def get_curation_row(self, external_id, external_entry) -> Sequence[str]:
+    def get_curation_row(self, external_id: str, external_entry: dict[str, Any]) -> Sequence[str]:
         """Return the relevant fields from an OntoBee entry for pretty-printing."""
         return [
             textwrap.shorten(external_entry["name"], 50),
-            external_entry.get("url"),
+            external_entry.get("url", ""),
         ]
 
 

--- a/src/bioregistry/external/prefixcommons/__init__.py
+++ b/src/bioregistry/external/prefixcommons/__init__.py
@@ -114,7 +114,7 @@ def get_prefixcommons(
     return rows
 
 
-def _process_row(line: str):
+def _process_row(line: str) -> tuple[str, dict[str, Any]] | tuple[None, None]:
     cells = line.strip().split("\t")
     prefix = cells[0]
     cells_processed = [None if cell in {"N/A"} else cell for cell in cells]
@@ -178,11 +178,11 @@ def _process_row(line: str):
     return prefix, rv
 
 
-def _get_uri_formats(rv, key) -> list[str]:
-    uri_formats = rv.pop(key, None)
+def _get_uri_formats(iv: dict[str, Any], key: str) -> list[str]:
+    uri_formats: str | None = iv.pop(key, None)
     if not uri_formats:
         return []
-    rv = []
+    rv: list[str] = []
     for uri_format in uri_formats.split(","):
         uri_format = uri_format.strip()
         if not uri_format:
@@ -293,7 +293,7 @@ class PrefixCommonsAligner(Aligner):
         """Get skip prefixes."""
         return {**SKIP, **PROVIDERS}
 
-    def get_curation_row(self, external_id, external_entry) -> Sequence[str]:
+    def get_curation_row(self, external_id: str, external_entry: dict[str, Any]) -> Sequence[str]:
         """Prepare curation rows for unaligned Prefix Commons registry entries."""
         return [
             external_entry["name"],

--- a/src/bioregistry/external/prefixcommons/__init__.py
+++ b/src/bioregistry/external/prefixcommons/__init__.py
@@ -6,6 +6,8 @@
       https://docs.google.com/spreadsheets/d/1cDGJcRteb9F5-jbw7Q7np0kk4hfWhdBHNYRIg3LXDrs/edit#gid=0
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from collections.abc import Mapping, Sequence

--- a/src/bioregistry/external/prefixcommons/__init__.py
+++ b/src/bioregistry/external/prefixcommons/__init__.py
@@ -15,7 +15,7 @@ from typing import Any, ClassVar
 from pystow.utils import download
 
 from bioregistry.constants import RAW_DIRECTORY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.license_standardizer import standardize_license
 
 __all__ = [
@@ -98,8 +98,7 @@ def get_prefixcommons(
 ) -> dict[str, dict[str, Any]]:
     """Get the Life Science Registry."""
     if PROCESSED_PATH.exists() and not (force_download or force_process):
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     download(url=URL, path=RAW_PATH, force=force_download)
     rows = {}

--- a/src/bioregistry/external/re3data/__init__.py
+++ b/src/bioregistry/external/re3data/__init__.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree
 import requests
 from tqdm.contrib.concurrent import thread_map
 
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.utils import removeprefix
 
 __all__ = [
@@ -39,8 +39,7 @@ def get_re3data(force_download: bool = False) -> dict[str, dict[str, Any]]:
     :returns: The re3data pre-processed data
     """
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     res = requests.get(f"{BASE_URL}/api/v1/repositories", timeout=15)
     tree = ElementTree.fromstring(res.text)

--- a/src/bioregistry/external/re3data/__init__.py
+++ b/src/bioregistry/external/re3data/__init__.py
@@ -87,7 +87,7 @@ def _get_record(identifier: str) -> tuple[str, Mapping[str, Any]]:
     return identifier, _process_record(identifier, tree)
 
 
-def _process_record(identifier: str, tree_inner):
+def _process_record(identifier: str, tree_inner: ElementTree) -> dict[str, Any]:
     xrefs = (
         _clean_xref(element.text.strip())
         for element in tree_inner.findall(f"{SCHEMA}repositoryIdentifier")

--- a/src/bioregistry/external/rrid/__init__.py
+++ b/src/bioregistry/external/rrid/__init__.py
@@ -46,7 +46,7 @@ UNCURATABLE = {
 }
 
 
-def get_rrid(force_download: bool = False) -> Mapping[str, Mapping[str, str]]:
+def get_rrid(*, force_download: bool = False) -> dict[str, dict[str, str]]:
     """Get RRIDs."""
     rv = {}
     with PATH.open() as file:

--- a/src/bioregistry/external/rrid/__init__.py
+++ b/src/bioregistry/external/rrid/__init__.py
@@ -89,7 +89,7 @@ def get_rrid(*, force_download: bool = False) -> dict[str, dict[str, str]]:
     return rv
 
 
-def _split(s: str):
+def _split(s: str) -> list[str]:
     return [c.strip() for c in s.split(",")]
 
 

--- a/src/bioregistry/external/togoid/__init__.py
+++ b/src/bioregistry/external/togoid/__init__.py
@@ -9,7 +9,7 @@ import requests
 import yaml
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "TogoIDAligner",
@@ -84,8 +84,7 @@ def get_togoid(
 ) -> dict[str, dict[str, Any]]:
     """Get the TogoID data."""
     if PROCESSED_PATH.exists() and not force_refresh:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     key_to_prefix = _get_ontology()
     key_to_description = _get_descriptions()

--- a/src/bioregistry/external/uniprot/__init__.py
+++ b/src/bioregistry/external/uniprot/__init__.py
@@ -2,14 +2,14 @@
 
 import json
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import ClassVar
 
 import requests
 
 from bioregistry.constants import RAW_DIRECTORY, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.utils import removeprefix
 
 __all__ = [
@@ -35,11 +35,10 @@ skip_prefixes = {
 }
 
 
-def get_uniprot(force_download: bool = True) -> Mapping[str, Mapping[str, str]]:
+def get_uniprot(*, force_download: bool = True) -> dict[str, dict[str, str]]:
     """Get the UniProt registry."""
     if PROCESSED_PATH.is_file() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     RAW_PATH.write_text(
         json.dumps(

--- a/src/bioregistry/external/uniprot/__init__.py
+++ b/src/bioregistry/external/uniprot/__init__.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import requests
 
@@ -60,7 +60,7 @@ def get_uniprot(*, force_download: bool = True) -> dict[str, dict[str, str]]:
     return rv
 
 
-def _process_record(record):
+def _process_record(record: dict[str, Any]) -> dict[str, Any] | None:
     rv = {
         "prefix": record.pop("id"),
         "name": record.pop("name"),
@@ -68,15 +68,15 @@ def _process_record(record):
         "homepage": record.pop("servers")[0],
         "category": record.pop("category"),
     }
-    doi = record.pop("doiId", None)
-    pubmed = record.pop("pubMedId", None)
     publication = {}
-    if doi:
+    doi: str | None = record.pop("doiId", None)
+    if doi is not None:
         doi = doi.lower().rstrip(".")
         doi = removeprefix(doi, "doi:")
         doi = removeprefix(doi, "https://doi.org/")
         if "/" in doi:
             publication["doi"] = doi
+    pubmed = record.pop("pubMedId", None)
     if pubmed:
         publication["pubmed"] = str(pubmed)
     if publication:

--- a/src/bioregistry/external/uniprot/__init__.py
+++ b/src/bioregistry/external/uniprot/__init__.py
@@ -1,5 +1,7 @@
 """Download and parse the UniProt Cross-ref database."""
 
+from __future__ import annotations
+
 import json
 import logging
 from collections.abc import Sequence

--- a/src/bioregistry/external/wikidata/__init__.py
+++ b/src/bioregistry/external/wikidata/__init__.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 from typing import Any, ClassVar
 
 from bioregistry.constants import BIOREGISTRY_PATH, URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 from bioregistry.utils import query_wikidata, removeprefix
 
 __all__ = [
@@ -309,8 +309,7 @@ def _get_wikidata() -> dict[str, dict[str, Any]]:
 def get_wikidata(force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the wikidata registry."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     data = _get_wikidata()
     with PROCESSED_PATH.open("w") as file:

--- a/src/bioregistry/external/zazuko/__init__.py
+++ b/src/bioregistry/external/zazuko/__init__.py
@@ -1,14 +1,14 @@
 """Download Zazuko."""
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, ClassVar
 
 import requests
 
 from bioregistry.constants import URI_FORMAT_KEY
-from bioregistry.external.alignment_utils import Aligner
+from bioregistry.external.alignment_utils import Aligner, load_processed
 
 __all__ = [
     "ZazukoAligner",
@@ -22,11 +22,10 @@ PROCESSED_PATH = DIRECTORY / "processed.json"
 URL = "https://prefix.zazuko.com/api/v1/prefixes"
 
 
-def get_zazuko(force_download: bool = False) -> Mapping[str, Mapping[str, Any]]:
+def get_zazuko(*, force_download: bool = False) -> dict[str, dict[str, Any]]:
     """Get the Zazuko context map."""
     if PROCESSED_PATH.exists() and not force_download:
-        with PROCESSED_PATH.open() as file:
-            return json.load(file)
+        return load_processed(PROCESSED_PATH)
 
     data = requests.get(URL, timeout=15).json()
     rv = {

--- a/src/bioregistry/gh/github_client.py
+++ b/src/bioregistry/gh/github_client.py
@@ -7,7 +7,7 @@ import logging
 import os
 from collections.abc import Iterable, Mapping
 from subprocess import CalledProcessError, check_output
-from typing import Any
+from typing import Any, cast
 
 import more_itertools
 import pystow
@@ -71,7 +71,7 @@ def list_pulls(
         you make many more queries before getting rate limited.
     :returns: JSON response from GitHub
     """
-    return requests_get(f"repos/{owner}/{repo}/pulls", token=token)
+    return cast(list[dict[str, Any]], requests_get(f"repos/{owner}/{repo}/pulls", token=token))
 
 
 def open_bioregistry_pull_request(
@@ -122,12 +122,13 @@ def open_pull_request(
     }
     if body:
         data["body"] = body
-    return requests.post(
+    res = requests.post(
         f"https://api.github.com/repos/{owner}/{repo}/pulls",
         headers=get_headers(token=token),
         json=data,
         timeout=15,
-    ).json()
+    )
+    return res.json()  # type:ignore
 
 
 def get_bioregistry_form_data(
@@ -245,7 +246,7 @@ def status_porcelain() -> str | None:
     return _git("status", "--porcelain")
 
 
-def push(*args) -> str | None:
+def push(*args: str) -> str | None:
     """Push the git repo."""
     return _git("push", *args)
 

--- a/src/bioregistry/gh/new_prefix.py
+++ b/src/bioregistry/gh/new_prefix.py
@@ -225,7 +225,7 @@ def process_all_relevant_issues() -> dict[int, Resource]:
     return issue_to_resource
 
 
-def _yield_publications(data) -> Iterable[Publication]:
+def _yield_publications(data: dict[str, Any]) -> Iterable[Publication]:
     for curie in data.pop("publications", "").split("|"):
         curie = curie.strip().lower()
         try:
@@ -251,7 +251,7 @@ def _trim_orcid(orcid: str) -> str:
     return orcid
 
 
-def _join(x: Iterable[int], sep=", ") -> str:
+def _join(x: Iterable[int], sep: str = ", ") -> str:
     return sep.join(map(str, sorted(x)))
 
 
@@ -273,8 +273,8 @@ def make_title(prefixes: Sequence[str]) -> str:
 @click.option(
     "--issue", type=int, help="Specific issue to process rather than finding all relevant ones"
 )
-@force_option
-@verbose_option
+@force_option  # type:ignore
+@verbose_option  # type:ignore
 def main(dry: bool, github: bool, force: bool, issue: int | None = None) -> None:
     """Run the automatic curator."""
     click.echo(

--- a/src/bioregistry/health/check_homepages.py
+++ b/src/bioregistry/health/check_homepages.py
@@ -62,7 +62,7 @@ def main() -> None:
             continue
         homepage_to_prefixes[homepage].add(prefix)
 
-    rv = thread_map(_process, list(homepage_to_prefixes.items()), desc="Checking homepages")
+    rv = thread_map(_process, list(homepage_to_prefixes.items()), desc="Checking homepages")  # type:ignore[no-untyped-call]
 
     failed = sum(failed for _, _, failed, _ in rv)
     click.secho(

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -127,7 +127,7 @@ def main() -> None:
         queue.append(QueueTuple(resource.prefix, example, url))
 
     with logging_redirect_tqdm():
-        results = thread_map(_process, queue, desc="Checking providers", unit="prefix")
+        results = thread_map(_process, queue, desc="Checking providers", unit="prefix")  # type:ignore[no-untyped-call]
 
     total = len(results)
     total_failed = sum(result.failed for result in results)

--- a/src/bioregistry/pandas.py
+++ b/src/bioregistry/pandas.py
@@ -290,7 +290,7 @@ def validate_identifiers(
             raise ValueError(f"No prefixes found in column {prefix_column}")
         if 1 == len(prefixes):
             return _help_validate_identifiers(df, column, next(iter(prefixes)))
-        patterns: dict[str, Pattern | None] = {}
+        patterns: dict[str, Pattern[str] | None] = {}
         for prefix in df[prefix_column].unique():
             if pd.isna(prefix):
                 continue
@@ -462,7 +462,11 @@ def identifiers_to_iris(
 
 
 def _multi_column_map(
-    df: pd.DataFrame, columns: list[str], func: Callable, *, use_tqdm: bool = False
+    df: pd.DataFrame,
+    columns: list[str],
+    func: Callable,  # type:ignore
+    *,
+    use_tqdm: bool = False,
 ) -> pd.Series:
     rows = df[columns].values
     if use_tqdm:

--- a/src/bioregistry/parse_version_iri.py
+++ b/src/bioregistry/parse_version_iri.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import typing as t
 from urllib.parse import urlparse
 
 from tqdm import tqdm
@@ -30,7 +31,7 @@ def _contains_date(iri: str) -> bool:
     return _match_any_part(iri, DATE_PATTERN)
 
 
-def _match_any_part(iri: str, pattern: re.Pattern) -> bool:
+def _match_any_part(iri: str, pattern: t.Pattern[str]) -> bool:
     parse_result = urlparse(iri)
     return any(bool(pattern.match(part)) for part in parse_result.path.split("/"))
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -2321,7 +2321,7 @@ class Resource(BaseModel):
         import markupsafe
         from markdown import markdown
 
-        rv = cast(str, removesuffix(removeprefix(markdown(rv), "<p>"), "</p>"))
+        rv = removesuffix(removeprefix(markdown(rv), "<p>"), "</p>")
         return markupsafe.Markup(rv)
 
     def get_bioschemas_jsonld(self) -> dict[str, Any]:

--- a/src/bioregistry/upload_ndex.py
+++ b/src/bioregistry/upload_ndex.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import click
 import pystow
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 @click.command()
-@verbose_option
+@verbose_option  # type:ignore
 def main() -> None:
     """Upload the Bioregistry KG to NDEx."""
     try:
@@ -120,9 +120,12 @@ def upload() -> None:
 
 def make_registry_node(cx: ndex2.NiceCXBuilder, metaprefix: str) -> int:
     """Generate a CX node for a registry."""
-    node = cx.add_node(
-        name=bioregistry.get_registry_name(metaprefix),
-        represents=f"bioregistry.registry:{metaprefix}",
+    node = cast(
+        int,
+        cx.add_node(
+            name=bioregistry.get_registry_name(metaprefix),
+            represents=f"bioregistry.registry:{metaprefix}",
+        ),
     )
     homepage = bioregistry.get_registry_homepage(metaprefix)
     if homepage:
@@ -135,9 +138,12 @@ def make_registry_node(cx: ndex2.NiceCXBuilder, metaprefix: str) -> int:
 
 def make_resource_node(cx: ndex2.NiceCXBuilder, prefix: str) -> int:
     """Generate a CX node for a resource."""
-    node = cx.add_node(
-        name=bioregistry.get_name(prefix),
-        represents=f"bioregistry:{prefix}",
+    node = cast(
+        int,
+        cx.add_node(
+            name=bioregistry.get_name(prefix),
+            represents=f"bioregistry:{prefix}",
+        ),
     )
     homepage = bioregistry.get_homepage(prefix)
     if homepage:

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -14,6 +14,7 @@ from typing import (
     Callable,
     TypeVar,
     cast,
+    overload,
 )
 
 import click
@@ -44,6 +45,14 @@ def secho(s: str, fg: str = "cyan", bold: bool = True, **kwargs: Any) -> None:
     click.echo(
         f"[{datetime.now().strftime('%H:%M:%S')}] " + click.style(s, fg=fg, bold=bold, **kwargs)
     )
+
+
+@overload
+def removeprefix(s: str, prefix: str) -> str: ...
+
+
+@overload
+def removeprefix(s: None, prefix: str) -> None: ...
 
 
 def removeprefix(s: str | None, prefix: str) -> str | None:

--- a/src/bioregistry/utils.py
+++ b/src/bioregistry/utils.py
@@ -47,10 +47,12 @@ def secho(s: str, fg: str = "cyan", bold: bool = True, **kwargs: Any) -> None:
     )
 
 
+# docstr-coverage:excused `overload`
 @overload
 def removeprefix(s: str, prefix: str) -> str: ...
 
 
+# docstr-coverage:excused `overload`
 @overload
 def removeprefix(s: None, prefix: str) -> None: ...
 
@@ -62,6 +64,16 @@ def removeprefix(s: str | None, prefix: str) -> str | None:
     if s.startswith(prefix):
         return s[len(prefix) :]
     return s
+
+
+# docstr-coverage:excused `overload`
+@overload
+def removesuffix(s: str, suffix: str) -> str: ...
+
+
+# docstr-coverage:excused `overload`
+@overload
+def removesuffix(s: None, suffix: str) -> None: ...
 
 
 def removesuffix(s: str | None, suffix: str) -> str | None:
@@ -217,9 +229,9 @@ def _get_identifier(term: dict[str, Any], ontology: str) -> str:
 
 
 def _clean(s: str) -> str:
-    s = cast(str, removesuffix(s, "identifier")).strip()
-    s = cast(str, removesuffix(s, "ID")).strip()
-    s = cast(str, removesuffix(s, "accession")).strip()
+    s = removesuffix(s, "identifier").strip()
+    s = removesuffix(s, "ID").strip()
+    s = removesuffix(s, "accession").strip()
     return s
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -135,9 +135,17 @@ deps =
     types-Markdown
     pystow
     curies
+    fastapi[all]
 extras =
     web
     charts
+    tests
+    align
+    gha
+    export
+    health
+    paper-ranking
+    mapping-checking
 skip_install = true
 commands =
     mypy --ignore-missing-imports src/bioregistry/

--- a/tox.ini
+++ b/tox.ini
@@ -148,8 +148,7 @@ extras =
     mapping-checking
 skip_install = true
 commands =
-    mypy --ignore-missing-imports src/bioregistry/
-    mypy --ignore-missing-imports --strict src/bioregistry/analysis/paper_ranking.py
+    mypy --ignore-missing-imports --strict src/bioregistry/
 description = Run the mypy tool to check static typing on the project.
 
 [testenv:pyroma]


### PR DESCRIPTION
This enables `mypy --strict` in the type checking environment in tox. This will help give external contributors more automated feedback on their code and support the maintainability of the codebase.