### PR TITLE
New provider: cyfidb

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -247,3 +247,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39877976	0	0009-0008-8406-631X	2025-01-21	irrelevant_other	1431	
 39882309	0	0009-0008-8406-631X	2025-01-18	non_resource_paper	1431	unable to resolve identifiers bc format is tsv
 39977364	1	0009-0008-8406-631X	2025-03-07	new_prefix	1452	
+40148144	1	0009-0008-8406-631X	2025-03-07	new_provider	1549	Provider for GenBank, Ensemble, Uniprot, and HGNC


### PR DESCRIPTION
CyFidb is is a resource related to cyctic fibrosis. It allows searching from 67 variants and more than 100 types of cells and tissues used in research. The database also references the studies that each part of the database came from. It uses GenBank, Ensembl, Uniprot, and HGNC identifiers for each entry. This PR adds cyfidb as a provider for GenBank, Ensembl, and HGNC. It was unclear to me which branch of Uniprot this resource should go under, further discussion there would be helpful. 

Pubmed: https://pubmed.ncbi.nlm.nih.gov/40148144/
Website: https://cyfidb.di.fc.ul.pt/
