### PR TITLE
New provider: oprlm

### DIFF
--- a/src/bioregistry/data/curated_papers.tsv
+++ b/src/bioregistry/data/curated_papers.tsv
@@ -247,3 +247,4 @@ pubmed	relevant	orcid	date_curated	relevancy_type	pr_added	notes
 39877976	0	0009-0008-8406-631X	2025-01-21	irrelevant_other	1431	
 39882309	0	0009-0008-8406-631X	2025-01-18	non_resource_paper	1431	unable to resolve identifiers bc format is tsv
 39977364	1	0009-0008-8406-631X	2025-03-07	new_prefix	1452	
+40133776	1	0009-0008-8406-631X	2025-03-07	new_provider	1558	


### PR DESCRIPTION
This PR curates a new provider for Protein Data Bank. OPRLM uses PDB identifiers in its database. 

Pubmed: https://pubmed.ncbi.nlm.nih.gov/40133776/
Website: https://oprlm.org/