### PR TITLE
Update Hogenom examples and pattern

### DIFF
--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -136,6 +136,9 @@ MIRIAM_BLACKLIST = {
     "ccds",
     # Miriam completely misses the actual usage
     "agricola",
+    # Miriam pattern/example combo is broken
+    # See https://github.com/biopragmatics/bioregistry/issues/1588
+    "hogenom",
 }
 IDENTIFIERS_ORG_URL_PREFIX = "https://identifiers.org/"
 


### PR DESCRIPTION
This PR addresses the issues discussed in #1588 related to inconsistent identifier examples and patterns for the `hogenom` prefix. This is also a blocker for the automated update pipeline.