### PR TITLE
Update homd.seq pattern, example, and URI format

### DIFF
--- a/src/bioregistry/constants.py
+++ b/src/bioregistry/constants.py
@@ -139,6 +139,8 @@ MIRIAM_BLACKLIST = {
     # Miriam pattern/example combo is broken
     # See https://github.com/biopragmatics/bioregistry/issues/1588
     "hogenom",
+    # Miriam pattern/example combo is broken
+    "homd.seq",
 }
 IDENTIFIERS_ORG_URL_PREFIX = "https://identifiers.org/"
 


### PR DESCRIPTION
The pattern for `homd.seq` identifiers appears to have changed to include a trailing number, e.g., `SEQF1003.1` resolves but the old example/pattern `SEQF1003` does not resolve. Identifiers.org changed the example to the new convention but hasn't changed the pattern leading to the update pipeline erroring. This PR updates the pattern and example for the current working version as well as the URI format since the old one is not working anymore.