### PR TITLE
Improve usability of derived Pydantic models

### DIFF
--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -18,8 +18,13 @@ __all__ = [
 ]
 
 
-def _normalize_values(values: dict[str, str]) -> dict[str, str]:
+def _normalize_values(values: dict[str, str] | str) -> dict[str, str]:
     """Validate the identifier."""
+    if isinstance(values, str):
+        prefix_, _, identifier_ = values.partition(":")
+        if not identifier_:
+            raise ValueError("not formatted as a CURIE")
+        values = {"prefix": prefix_, "identifier": identifier_}
     prefix, identifier = values.get("prefix"), values.get("identifier")
     if prefix is None or identifier is None:
         raise RuntimeError(f"missing prefix/identifier from values: {values}")
@@ -37,8 +42,13 @@ def _normalize_values(values: dict[str, str]) -> dict[str, str]:
     return values
 
 
-def _standardize_values(values: dict[str, str]) -> dict[str, str]:
+def _standardize_values(values: dict[str, str] | str) -> dict[str, str]:
     """Validate the identifier."""
+    if isinstance(values, str):
+        prefix_, _, identifier_ = values.partition(":")
+        if not identifier_:
+            raise ValueError("not formatted as a CURIE")
+        values = {"prefix": prefix_, "identifier": identifier_}
     prefix, identifier = values.get("prefix"), values.get("identifier")
     if prefix is None or identifier is None:
         raise RuntimeError(f"missing prefix/identifier from values: {values}")
@@ -77,10 +87,18 @@ class NormalizedReference(curies.Reference):
 
     >>> NormalizedReference(prefix="GOBP", identifier="0032571")
     NormalizedReference(prefix='go', identifier='0032571')
+
+    If you're deriving a model, then pass a string, this can still work
+
+    >>> from pydantic import BaseModel
+    >>> class Derived(BaseModel):
+    ...     reference: NormalizedReference
+    >>> Derived(reference="go:0032571")
+
     """
 
     @model_validator(mode="before")
-    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
+    def validate_identifier(cls, values: dict[str, str] | str) -> dict[str, str]:  # noqa
         """Validate the identifier."""
         return _normalize_values(values)
 
@@ -144,7 +162,7 @@ class StandardReference(curies.Reference):
     """
 
     @model_validator(mode="before")
-    def validate_identifier(cls, values: dict[str, str]) -> dict[str, str]:  # noqa
+    def validate_identifier(cls, values: dict[str, str] | str) -> dict[str, str]:  # noqa
         """Validate the identifier."""
         return _standardize_values(values)
 

--- a/src/bioregistry/reference.py
+++ b/src/bioregistry/reference.py
@@ -94,6 +94,7 @@ class NormalizedReference(curies.Reference):
     >>> class Derived(BaseModel):
     ...     reference: NormalizedReference
     >>> Derived(reference="go:0032571")
+    Derived(reference=NormalizedReference(prefix='go', identifier='0032571'))
 
     """
 
@@ -159,6 +160,15 @@ class StandardReference(curies.Reference):
 
     >>> StandardReference(prefix="GOBP", identifier="0032571")
     StandardReference(prefix='GO', identifier='0032571')
+
+    If you're deriving a model, then pass a string, this can still work
+
+    >>> from pydantic import BaseModel
+    >>> class Derived(BaseModel):
+    ...     reference: StandardReference
+    >>> Derived(reference="go:0032571")
+    Derived(reference=StandardReference(prefix='GO', identifier='0032571'))
+
     """
 
     @model_validator(mode="before")

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -3,7 +3,7 @@
 import unittest
 
 import curies
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from bioregistry.reference import (
     NormalizedNamableReference,
@@ -138,6 +138,18 @@ class TestNormalizedReference(unittest.TestCase):
         self.assertNotEqual(r2, r3)
         self.assertNotEqual(r2, r4)
 
+    def test_derived_with_normalized(self) -> None:
+        """Test derived."""
+
+        class DerivedWithNormalizedReference(BaseModel):
+            """A derived class with a normalized reference."""
+
+            reference: NormalizedReference
+
+        derived = DerivedWithNormalizedReference(reference="GO:0032571")
+        self.assertEqual("go", derived.reference.prefix)
+        self.assertEqual("0032571", derived.reference.identifier)
+
 
 class TestStandardizeReference(unittest.TestCase):
     """Test standardized references, which use preferred prefixes."""
@@ -203,3 +215,15 @@ class TestStandardizeReference(unittest.TestCase):
                 self.assertEqual(TEST_LUID, r4.identifier)
                 self.assertTrue(hasattr(r4, "name"))
                 self.assertEqual(TEST_NAME, r4.name)
+
+    def test_derived_with_standard(self) -> None:
+        """Test derived."""
+
+        class DerivedWithStandardReference(BaseModel):
+            """A derived class with a standard reference."""
+
+            reference: StandardReference
+
+        derived = DerivedWithStandardReference(reference="go:0032571")
+        self.assertEqual("GO", derived.reference.prefix)
+        self.assertEqual("0032571", derived.reference.identifier)


### PR DESCRIPTION
This enables the following usage:

```python
from bioregistry import NormalizedReference
from pydantic import BaseModel

class Derived(BaseModel):
    reference: NormalizedReference

>>> Derived(reference="go:0032571")
Derived(reference=NormalizedReference(prefix='go', identifier='0032571'))
```