### PR TITLE
Add Github Actions for testing Dockerized service

### DIFF
--- a/.github/workflows/service_test.yml
+++ b/.github/workflows/service_test.yml
@@ -1,4 +1,4 @@
-name: Docker Build and Test
+name: Docker build and web service test
 
 on:
   push:


### PR DESCRIPTION
This PR adds a Github Actions configuration to test whether there are any breaking changes to the Dockerized service. The approach is to take the version-controlled Dockerfile and modify it to do a local install from the branch being tested, then run the service, and verify that requests resolve. I did a regression test and verified that the workflow fails, as expected, on v0.12.34 but succeeds on the latest main. This should help avoid issues that have periodically come up with broken Docker builds for the service.