### PR TITLE
Fill the NFDI4BIOIMAGE collection

### DIFF
--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -1483,10 +1483,10 @@
     {
       "authors": [
         {
-          "email": "cthoyt@gmail.com",
-          "github": "cthoyt",
-          "name": "Charles Tapley Hoyt",
-          "orcid": "0000-0003-4423-4370"
+          "email": "damien@gerbi-gmb.de",
+          "github": "gouttegd",
+          "name": "Damien Goutte-Gattat",
+          "orcid": "0000-0002-6095-8718"
         }
       ],
       "description": "A collection of ontologies, controlled vocabularies, database, and schemas relevant for NFDI4BIOIMAGE",


### PR DESCRIPTION
This PR updates the recently created NFDI4BIOIMAGE collection with the resources relevant for that consortium.

The list of resources is largely derived from the work previously done in the [FoundingGIDE project](https://founding-gide.eurobioimaging.eu), which surveyed the controlled vocabularies used in the bioimaging domain.

Related to https://github.com/nfdi-de/section-metadata-wg-onto/issues/32