### PR TITLE
Update LinkML import

### DIFF
--- a/src/bioregistry/curation/add_linkml.py
+++ b/src/bioregistry/curation/add_linkml.py
@@ -74,6 +74,7 @@ def get_resource_from_linkml(url: str) -> bioregistry.Resource:
         uri_format=f"{uri_prefix}$1",
         example=first_class,
         version=data.pop("version", None),
+        homepage=data.pop("id", None),
     )
     return rv
 

--- a/tests/test_curation/test_add_linkml.py
+++ b/tests/test_curation/test_add_linkml.py
@@ -11,7 +11,7 @@ class TestImportLinkML(unittest.TestCase):
 
     def test_catcore(self) -> None:
         """Test getting CatCore."""
-        url = "https://github.com/HendrikBorgelt/CatCore/raw/refs/heads/main/src/catcore/schema/catcore.yaml"
+        url = "https://github.com/nfdi4cat/CoreMeta4Cat/raw/20996ec5266fa5e199f10bbff18857db66dc5042/src/catcore/schema/catcore.yaml"
         resource = bioregistry.Resource(
             prefix="catcore",
             name="CatCore Metadata Reference Model",
@@ -20,6 +20,7 @@ class TestImportLinkML(unittest.TestCase):
             version="1.0.0",
             uri_format="https://w3id.org/nfdi4cat/catcore/$1",
             example="CatCoreEntity",
+            homepage="https://w3id.org/nfdi4cat/catcore",
             # TODO add depends_on from the `prefixes` list?
         )
         self.assertEqual(


### PR DESCRIPTION
This PR pins the YAML data for the CatCore example (since it's been updated) and additionally adds homepage extraction.