### PR TITLE
Refactor YAML serialization in web app

### DIFF
--- a/src/bioregistry/app/api.py
+++ b/src/bioregistry/app/api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated
+from typing import Annotated, Any
 
 import yaml
 from curies import Reference
@@ -60,6 +60,7 @@ class YAMLResponse(Response):
 
     def render(self, content: BaseModel | Mapping[str, BaseModel]) -> bytes:
         """Render content as YAML."""
+        data: dict[str, Any]
         if isinstance(content, BaseModel):
             data = content.model_dump(
                 exclude_none=True,

--- a/src/bioregistry/schema/utils.py
+++ b/src/bioregistry/schema/utils.py
@@ -31,6 +31,6 @@ def sanitize_model(base_model: BaseModel, **kwargs: Any) -> Mapping[str, Any]:
     return sanitize_dict(base_model.model_dump(**kwargs))
 
 
-def sanitize_mapping(mapping: Mapping[str, BaseModel]) -> Mapping[str, Mapping[str, Any]]:
+def sanitize_mapping(mapping: Mapping[str, BaseModel]) -> dict[str, Mapping[str, Any]]:
     """Sanitize a dictionary whose values are Pydantic models."""
     return {key: sanitize_model(base_model) for key, base_model in mapping.items()}


### PR DESCRIPTION
This PR refactors the YAML response class to automatically run `sanitize_models()`. All uses are already tested.