### PR TITLE
Add DataPLANT maintainers

### DIFF
--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -1279,6 +1279,12 @@
           "github": "AngelaKranz",
           "name": "Angela Kranz",
           "orcid": "0000-0002-8000-0400"
+        },
+        {
+          "email": "h.doerpholz@fz-juelich.de",
+          "github": "Hannah-Doerpholz",
+          "name": "Hannah Dörpholz",
+          "orcid": "0000-0002-0476-9699"
         }
       ],
       "mappings": [

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -1267,6 +1267,20 @@
       "description": "A placeholder collection of ontologies, controlled vocabularies, and schemas relevant for the DataPLANT Consortium seeded from corresponding the [TIB OLS collection](https://service.tib.eu/terminology/collections/dataplant). The [NFDI Section Metadata WG Ontology Harmonization and Mapping](https://github.com/nfdi-de/section-metadata-wg-onto/) is in the process of identifying DataPLANT Consortium members appropriate for maintaining this collection.",
       "identifier": "0000023",
       "logo": "https://www.nfdi.de/wp-content/uploads/2021/05/DataPLANT_logo_square_bg_transparent.svg",
+      "maintainers": [
+        {
+          "email": "k.dumschott@fz-juelich.de",
+          "github": "kdumschott",
+          "name": "Kathryn Dumschott",
+          "orcid": "0000-0002-9905-4011"
+        },
+        {
+          "email": "a.kranz@fz-juelich.de",
+          "github": "AngelaKranz",
+          "name": "Angela Kranz",
+          "orcid": "0000-0002-8000-0400"
+        }
+      ],
       "mappings": [
         {
           "identifier": "dataplant",


### PR DESCRIPTION
Hi @kdumschott @AngelaKranz, we're porting the Section Metadata WG Ontology Harmonization survey of ontology usage for DataPLANT into this repository. Can we keep listing you as contacts/responsible people in the consortium for the ontology usage list? We can add more / change this over time as well.

Here's how your consortium's list looks: https://bioregistry.io/collection/0000023
