### PR TITLE
Add NFDI4Microbiota collection maintainers

### DIFF
--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -2200,6 +2200,13 @@
       "description": "A placeholder collection of ontologies, controlled vocabularies, and schemas relevant for the NFDI4Microbiota Consortium created by the [NFDI Section Metadata WG Ontology Harmonization and Mapping](https://github.com/nfdi-de/section-metadata-wg-onto/). The working group is in the process of identifying NFDI4Microbiota Consortium members appropriate for maintaining this collection.",
       "identifier": "0000042",
       "logo": "https://www.nfdi.de/wp-content/uploads/2021/12/nfdi4microbiota_Logo_.png",
+      "maintainers": [
+        {
+          "github": "anandhi-iyappan",
+          "name": "Anandhi Iyappan",
+          "orcid": "0000-0002-5571-4962"
+        }
+      ],
       "name": "NFDI4Microbiota Collection",
       "organizations": [
         {

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -2205,6 +2205,15 @@
           "github": "anandhi-iyappan",
           "name": "Anandhi Iyappan",
           "orcid": "0000-0002-5571-4962"
+        },
+        {
+          "name": "Noriko Cassman",
+          "orcid": "0000-0003-1655-0931"
+        },
+        {
+          "github": "magelm",
+          "name": "Maja Magel",
+          "orcid": "0009-0004-2517-0791"
         }
       ],
       "name": "NFDI4Microbiota Collection",


### PR DESCRIPTION
This PR adds @anandhi-iyappan as the maintainer of the stub collection for the NFDI4Microbiota Consortium. Ideally, one or more of Noriko, Ulisses, Martin, and Maja will also agree to be listed here.

We can iteratively add ontologies, controlled vocabularies, etc. in successive PRs.