### PR TITLE
Reduce minimum metadata requirements for metaregistry

### DIFF
--- a/src/bioregistry/app/templates/meta/related.html
+++ b/src/bioregistry/app/templates/meta/related.html
@@ -99,7 +99,8 @@
         </tr>
         </thead>
         <tbody>
-        {% for registry in registries %}
+        {%- for registry in registries %}
+        {%- if registry.availability %}
             <tr>
                 <td>
                     <a href="{{ url_for('metaregistry_ui.metaresource', metaprefix=registry.prefix) }}">{{ registry.get_short_name() }}</a>
@@ -117,7 +118,8 @@
                 <td style="text-align: center;">{{ render_circle(registry.availability.version) }}</td>
                 <td style="text-align: center;">{{ render_circle(registry.availability.contact) }}</td>
             </tr>
-        {% endfor %}
+        {%- endif %}
+        {%- endfor %}
         </tbody>
     </table>
 
@@ -294,7 +296,8 @@
         </tr>
         </thead>
         <tbody>
-        {% for registry in registries %}
+        {%- for registry in registries %}
+        {%- if registry.governance %}
             <tr>
                 <td>
                     <a href="{{ url_for('metaregistry_ui.metaresource', metaprefix=registry.prefix) }}">{{ registry.get_short_name() }}</a>
@@ -313,7 +316,8 @@
                 <td>{{ registry.governance.scope }}</td>
                 <td>{{ registry.governance.status }}</td>
             </tr>
-        {% endfor %}
+        {%- endif %}
+        {%- endfor %}
         </tbody>
     </table>
 

--- a/src/bioregistry/export/tables_export.py
+++ b/src/bioregistry/export/tables_export.py
@@ -78,7 +78,7 @@ def _get_governance_df() -> pd.DataFrame:
     rows = []
     keep_metaprefixes = set(count_mappings())
     for registry in sorted(read_metaregistry().values(), key=_sort_key):
-        if registry.prefix not in keep_metaprefixes:
+        if registry.prefix not in keep_metaprefixes or registry.governance is None:
             continue
         rows.append(
             (
@@ -125,7 +125,11 @@ def _get_metadata_df() -> pd.DataFrame:
     rows = []
     keep_metaprefixes = set(count_mappings())
     for registry in sorted(read_metaregistry().values(), key=_sort_key):
-        if registry.prefix not in keep_metaprefixes:
+        if (
+            registry.prefix not in keep_metaprefixes
+            or registry.availability is None
+            or registry.qualities is None
+        ):
             continue
         rows.append(
             (

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -798,15 +798,39 @@
           "title": "Bibtex"
         },
         "availability": {
-          "$ref": "#/$defs/RegistrySchema",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RegistrySchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "A structured description of the metadata that the registry collects"
         },
         "qualities": {
-          "$ref": "#/$defs/RegistryQualities",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RegistryQualities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "A structured description of the registry's qualities"
         },
         "governance": {
-          "$ref": "#/$defs/RegistryGovernance",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RegistryGovernance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "A structured description of the governance for the registry"
         },
         "download": {
@@ -937,9 +961,6 @@
         "description",
         "homepage",
         "example",
-        "availability",
-        "qualities",
-        "governance",
         "contact"
       ],
       "title": "Registry",

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -2904,14 +2904,14 @@ class Registry(BaseModel):
     bibtex: str | None = Field(
         default=None, description="Citation key used in BibTex for this registry."
     )
-    availability: RegistrySchema = Field(
-        ..., description="A structured description of the metadata that the registry collects"
+    availability: RegistrySchema | None = Field(
+        None, description="A structured description of the metadata that the registry collects"
     )
-    qualities: RegistryQualities = Field(
-        ..., description="A structured description of the registry's qualities"
+    qualities: RegistryQualities | None = Field(
+        None, description="A structured description of the registry's qualities"
     )
-    governance: RegistryGovernance = Field(
-        ..., description="A structured description of the governance for the registry"
+    governance: RegistryGovernance | None = Field(
+        None, description="A structured description of the governance for the registry"
     )
     download: str | None = Field(
         default=None, description="A download link for the data contained in the registry"
@@ -2947,8 +2947,10 @@ class Registry(BaseModel):
         default=None, description="A short name for the resource, e.g., for use in charts"
     )
 
-    def score(self) -> int:
+    def score(self) -> int | None:
         """Calculate a metadata score/goodness for this registry."""
+        if self.availability is None or self.qualities is None:
+            return None
         return (
             (
                 int(self.provider_uri_format is not None)
@@ -3092,8 +3094,10 @@ class Registry(BaseModel):
         """Check if the registry is a prefix provider."""
         return self.provider_uri_format is not None
 
-    def get_quality_score(self) -> int:
+    def get_quality_score(self) -> int | None:
         """Get the quality score for this registry."""
+        if self.qualities is None or self.availability is None:
+            return None
         return self.qualities.score() + sum(
             [self.availability.search, self.is_prefix_provider, self.has_permissive_license]
         )

--- a/tests/test_metaregistry.py
+++ b/tests/test_metaregistry.py
@@ -83,10 +83,11 @@ class TestMetaregistry(unittest.TestCase):
 
                 invalid_keys = set(registry.model_dump()).difference(Registry.model_fields)
                 self.assertEqual(set(), invalid_keys, msg="invalid metadata")
-                self.assertIsNotNone(registry.qualities)
-                self.assertIsInstance(registry.qualities.bulk_data, bool)
 
-                if registry.governance.public_version_controlled_data:
+                if (
+                    registry.governance is not None
+                    and registry.governance.public_version_controlled_data
+                ):
                     self.assertIsNotNone(registry.governance.data_repository)
                     self.assertIsNotNone(registry.governance.issue_tracker)
 


### PR DESCRIPTION
as I'm getting ready to add BiodivPortal, I want to reduce the need to curate the governance and accessibility of a new resource. If they aren't curated, then they just won't get shown in the summary tables/exports