### PR TITLE
Improve Orphanet and display of canonical

### DIFF
--- a/src/bioregistry/app/templates/macros.html
+++ b/src/bioregistry/app/templates/macros.html
@@ -57,8 +57,14 @@
     {% elif resource.provides %}
         <a class="badge badge-danger" style="display: inline-block;" data-toggle="tooltip"
            href="{{ url_for("metaregistry_ui.resource", prefix=resource.provides) }}"
-           title="{{ manager.get_name(resource.provides) }} ({{ resource.provides }})">
+           title="You should use {{ manager.get_name(resource.provides) }} ({{ resource.provides }}) instead">
             Provider <i class="bi bi-exclamation-triangle"></i>
+        </a>
+    {% elif resource.has_canonical %}
+        <a class="badge badge-danger" style="display: inline-block;" data-toggle="tooltip"
+           href="{{ url_for("metaregistry_ui.resource", prefix=resource.has_canonical) }}"
+           title="You should use {{ manager.get_name(resource.has_canonical) }} ({{ resource.has_canonical }}) instead">
+            Not Canonical <i class="bi bi-exclamation-triangle"></i>
         </a>
     {% endif %}
     {% if resource.proprietary %}


### PR DESCRIPTION
Closes #1873

This PR does the following:

1. Improves the UI to show a warning for records that point to a canonical one
2. Moves the OLS linking from `orphanet.ordo` to `orpha` (canonical)