### PR TITLE
Update PaNET

### DIFF
--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -1539,7 +1539,8 @@
         "https://go.rocket.chat/invite?host=all-chat.nfdi.de&path=invite%2FZvh5e3"
       ],
       "resources": [
-        "emg"
+        "emg",
+        "panet"
       ]
     },
     {

--- a/src/bioregistry/schema/schema.json
+++ b/src/bioregistry/schema/schema.json
@@ -1817,7 +1817,8 @@
                 "experiment",
                 "genetic code",
                 "mathematics",
-                "registry"
+                "registry",
+                "equipment"
               ],
               "type": "string"
             },
@@ -1870,7 +1871,8 @@
             "experiment",
             "genetic code",
             "mathematics",
-            "registry"
+            "registry",
+            "equipment"
           ],
           "title": "Domain"
         },

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -136,6 +136,7 @@ Domain: TypeAlias = Literal[
     "genetic code",
     "mathematics",
     "registry",
+    "equipment",
 ]
 
 


### PR DESCRIPTION
cc @kara-mela @hgoerzig

this PR adds an explicit download URL for the PaNET OWL, which enables tools like sssom-curator to automatically find, index, and propose mappings for it

this PR also improves several other metadata in this ontology