### PR TITLE
Add PIDA prefix and PID4NFDI Collection

### DIFF
--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -2530,6 +2530,33 @@
       "resources": [
         "bioregistry"
       ]
+    },
+    {
+      "contributors": [
+        {
+          "email": "cthoyt@gmail.com",
+          "github": "cthoyt",
+          "name": "Charles Tapley Hoyt",
+          "orcid": "0000-0003-4423-4370"
+        }
+      ],
+      "description": "PID4NFDI is a Base4NFDI service that maintains documentation about select PID systems. This collection reflects their [PID Providers](https://pid.services.base4nfdi.de/get-pid/providers/) page.\n\nNotes\n\n- Crossref and DataCite are both providers as part of the DOI system and therefore do not have their own entries.\n- ePIC is built on the Handle system\n- PIDINST is built on the DOI system through DataCite / ePIC",
+      "identifier": "0000044",
+      "name": "PID4NFDI Prefixes",
+      "resources": [
+        "ark",
+        "doi",
+        "factgrid",
+        "gnd",
+        "hdl",
+        "igsn",
+        "orcid",
+        "pida",
+        "raid",
+        "ror",
+        "swh",
+        "wikidata"
+      ]
     }
   ]
 }

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -2540,7 +2540,7 @@
           "orcid": "0000-0003-4423-4370"
         }
       ],
-      "description": "PID4NFDI is a Base4NFDI service that maintains documentation about select PID systems. This collection reflects their [PID Providers](https://pid.services.base4nfdi.de/get-pid/providers/) page.\n\nNotes\n\n- Crossref and DataCite are both providers as part of the DOI system and therefore do not have their own entries.\n- ePIC is built on the Handle system\n- PIDINST is built on the DOI system through DataCite / ePIC",
+      "description": "[PID4NFDI](https://pid.services.base4nfdi.de) is a Base4NFDI service that provides documentation about a small number of well-known identifier schemes (e.g., DOI) and services for registering identifiers within them (e.g., DataCite). This collection reflects their [PID Providers](https://pid.services.base4nfdi.de/get-pid/providers/) page. This comes with the following caveats:\n\n- Crossref and DataCite are services that mint DOIs. Since DOIs are the identifier space, only `doi` appears in this collection.\n- ePIC is a service that mints Handle system. Since Handles are the identifier space, only `hdl` appears in this collection\n- PIDINST is an abstraction on top of DataCite / ePIC, which is covered by `doi` and `hdl` as described above",
       "identifier": "0000044",
       "name": "PID4NFDI Prefixes",
       "resources": [

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -2542,7 +2542,7 @@
       ],
       "description": "[PID4NFDI](https://pid.services.base4nfdi.de) is a Base4NFDI service that provides documentation about a small number of well-known identifier schemes (e.g., DOI) and services for registering identifiers within them (e.g., DataCite). This collection reflects their [PID Providers](https://pid.services.base4nfdi.de/get-pid/providers/) page. This comes with the following caveats:\n\n- Crossref and DataCite are services that mint DOIs. Since DOIs are the identifier space, only `doi` appears in this collection.\n- ePIC is a service that mints Handle system. Since Handles are the identifier space, only `hdl` appears in this collection\n- PIDINST is an abstraction on top of DataCite / ePIC, which is covered by `doi` and `hdl` as described above",
       "identifier": "0000044",
-      "name": "PID4NFDI Prefixes",
+      "name": "PID4NFDI Providers",
       "resources": [
         "ark",
         "doi",


### PR DESCRIPTION
Part of https://github.com/biopragmatics/bioregistry/issues/1845

This pull request adds a collection to Semantic Farm that reflects the PID4NFDI's [PID Providers](https://pid.services.base4nfdi.de/get-pid/providers/) page. 

Note that entries in Semantic Farm correspond to identifier spaces, and not providers. This is why DataCite and Crossref do not appear, but rather `doi` does, along a few other similar cases.

Here's what the collection will look like when it's live on http://semantic.farm/collection/0000044 (after this PR is accepted and the service is re-deployed with new data):

<img width="930" height="727" alt="Screenshot 2026-05-19 at 14 43 58" src="https://github.com/user-attachments/assets/100d9ba7-75b1-4ac5-a5bd-7534aba804ca" />

cc @kahlertt @AntoniaCami @osoml @stephw-tib @jboehm1911 @FSpringerTIB

I want to make sure the PID4NFDI team knows this is here. It's also possible to list "maintainers" if you want to have those explicitly written for more visibility