### PR TITLE
Add mouseover text explaining "first party" in collection

### DIFF
--- a/src/bioregistry/app/templates/collection.html
+++ b/src/bioregistry/app/templates/collection.html
@@ -139,7 +139,8 @@
                         {{ resource.get_name() }} {{ utils.render_resource_warnings(resource) }}
                     </a>
                     {%- if first_party[resource.prefix] %}
-                    <span class="badge badge-primary">First Party <i class="bi bi-check-circle-fill"></i></span>
+                    <span class="badge badge-primary" title="This resource is maintained by the same people/organizations that maintain this collection">
+                        First Party <i class="bi bi-check-circle-fill"></i></span>
                     {%- endif %}
                     {%- if annotated_prefix.comment %}
                     <br><small>{{ annotated_prefix.comment}}</small>


### PR DESCRIPTION
This PR adds a `title` attribute to the span that includes the first party badge for resources that are maintained by the same maintainers/organizations as the collection where they're listed. Now, if you mouse over the badge, it will explain what this means.