### PR TITLE
Enable displaying tags as columns

### DIFF
--- a/src/bioregistry/app/templates/collection.html
+++ b/src/bioregistry/app/templates/collection.html
@@ -125,6 +125,11 @@
                 <th scope="col">Name</th>
                 <th scope="col">License</th>
                 <th scope="col">Download</th>
+                {%- for tag in entry.tags %}
+                {%- if tags[tag].display == "column" %}
+                <th scope="col">{{ tags[tag].name }}</th>
+                {%- endif %}
+                {%- endfor %}
             </tr>
             </thead>
             <tbody>
@@ -148,7 +153,9 @@
                     {%- endif %}
                     {%- if annotated_prefix.tags %}
                     {%- for tag in annotated_prefix.tags %}
+                    {%- if tag.display == "badge" %}
                     <span class="badge badge-secondary" {% if tags[tag].description %}title="{{ tags[tag].description }}"{% endif %}>{{ tags[tag].name }}</span>
+                    {%- endif %}
                     {%- endfor %}
                     {%- endif %}
                     {%- endif %}
@@ -167,6 +174,11 @@
                     <a href="{{ resource.get_download() }}"><i class="bi bi-download"></i></a>
                     {%- endif %}
                 </td>
+                {%- for tag in annotated_prefix.tags %}
+                {%- if tags[tag].display == "column" %}
+                {{ tags[tag].name }}
+                {%- endif %}
+                {%- endfor %}
             </tr>
             {% endfor %}
             </tbody>

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -3259,6 +3259,7 @@ class Tag(BaseModel):
     code: str
     name: str
     description: str | None = None
+    display: Literal["column", "badge"] = "badge"
 
 
 class Collection(BaseModel):


### PR DESCRIPTION
requested by @FederalGobbo 

This PR enables marking individual tags in a collection as whether they should be displayed as a badge (inline in the description) or as its own column

