### PR TITLE
Improve OBO, OLS, and BioPortal URI prefix generation

### DIFF
--- a/exports/raw/obofoundry.yaml
+++ b/exports/raw/obofoundry.yaml
@@ -4726,6 +4726,19 @@ ontologies:
     label: Homo sapiens
   title: Ontology for General Medical Science
   tracker: https://github.com/OGMS/ogms/issues
+  usages:
+  - description: Multiple ontologies using OGMS terms, such as the Ontology for Biomedical
+      Investigations (OBI), Relation Ontology (RO), Infectious Disease Ontology (IDO),
+      Representation of Social Entities (OMRSE), and Mental Disease Ontology (MFOMD).
+      OGMS has been extended to create various OBO ontologies, including the IDO and
+      its extensions, as well as the OMRSE, MFOMD, Oral Health and Disease ontology
+      (OHD), and Cardiovascular Disease Ontology (CVDO).
+    examples:
+    - description: List of ontologies using at least one OGMS term
+      url: http://dashboard.obofoundry.org/dashboard/ogms/dashboard.html
+    - description: List of ontologies using the term "disease"
+      url: https://ontobee.org/ontology/OGMS?iri=http://purl.obolibrary.org/obo/OGMS_0000031
+    user: (multiple)
 - activity_status: active
   contact:
     email: wdduncan@gmail.com

--- a/src/bioregistry/curation/add_linkml.py
+++ b/src/bioregistry/curation/add_linkml.py
@@ -70,7 +70,7 @@ def _fix_github(url: str) -> str:
 def _extract_repository(url: str) -> str | None:
     """Extract a GitHub repository URL from a file URL.
 
-     >>> _extract_repository(
+    >>> _extract_repository(
     ...     "https://github.com/ghga-de/ghga-metadata-schema/blob/main/src/schema/submission.yaml"
     ... )
     'https://github.com/ghga-de/ghga-metadata-schema'

--- a/src/bioregistry/external/biocontext/__init__.py
+++ b/src/bioregistry/external/biocontext/__init__.py
@@ -20,6 +20,10 @@ RAW_PATH = RAW_DIRECTORY / "biocontext.json"
 PROCESSED_PATH = DIRECTORY / "processed.json"
 URL = "https://raw.githubusercontent.com/prefixcommons/biocontext/master/registry/commons_context.jsonld"
 
+WRONG = {
+    "CHEMINF",  # obo masquerade
+}
+
 
 def parse_biocontext_raw(path: Path) -> dict[str, Record]:
     """Parse BioContext JSON file."""
@@ -28,6 +32,7 @@ def parse_biocontext_raw(path: Path) -> dict[str, Record]:
     rv = {
         prefix: Record(uri_format=f"{uri_prefix.strip()}$1")
         for prefix, uri_prefix in data["@context"].items()
+        if prefix not in WRONG
     }
     return rv
 

--- a/src/bioregistry/external/obofoundry/__init__.py
+++ b/src/bioregistry/external/obofoundry/__init__.py
@@ -39,6 +39,9 @@ OBOFOUNDRY_URL = "https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github
 SKIP = {
     "obo_rel": "replaced",
 }
+URI_FORMAT_OVERRIDES = {
+    "cheminf": "http://semanticscience.org/resource/CHEMINF_$1",
+}
 
 
 def process_obofoundry(path: Path) -> dict[str, Record]:
@@ -130,6 +133,8 @@ def _process(record: dict[str, Any]) -> Record:
         record.pop(key, None)
 
     prefix = record["id"].lower()
+    preferred_prefix = record.get("preferredPrefix") or prefix.upper()
+
     contact = _get_contact(record)
     if record["activity_status"] == "active":
         if contact is None:
@@ -143,13 +148,18 @@ def _process(record: dict[str, Any]) -> Record:
     else:
         raise NotImplementedError(f"unhandled obo foundry status: {record['activity_status']}")
 
+    if prefix in URI_FORMAT_OVERRIDES:
+        uri_format = URI_FORMAT_OVERRIDES[prefix]
+    else:
+        uri_format = f"http://purl.obolibrary.org/obo/{preferred_prefix}_$1"
+
     rv = {
         "prefix": prefix,
         "name": record["title"],
         "description": record.get("description"),
         "status": status,
         "homepage": record.get("homepage"),
-        "preferred_prefix": record.get("preferredPrefix") or prefix.upper(),
+        "preferred_prefix": preferred_prefix,
         "contact": contact,
         "license": _get_license(record),
         "repository": record.get("repository"),
@@ -162,6 +172,8 @@ def _process(record: dict[str, Any]) -> Record:
             for product_dict in record.get("products", [])
             if (artifact := _process_product(prefix, product_dict))
         ],
+        "uri_format": uri_format,
+        "uri_format_rdf": uri_format,
     }
 
     if taxon := record.get("taxon"):

--- a/src/bioregistry/external/obofoundry/processed.json
+++ b/src/bioregistry/external/obofoundry/processed.json
@@ -14,7 +14,9 @@
       "identifier": "8292",
       "name": "Amphibia",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/AAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AAO_$1"
   },
   "ado": {
     "artifacts": [
@@ -42,14 +44,18 @@
     "name": "Alzheimer's Disease Ontology",
     "preferred_prefix": "ADO",
     "repository": "https://github.com/Fraunhofer-SCAI-Applied-Semantics/ADO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ADO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ADO_$1"
   },
   "adw": {
     "domain": "organisms",
     "homepage": "http://www.animaldiversity.org",
     "name": "Animal natural history and life history",
     "preferred_prefix": "ADW",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/ADW_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ADW_$1"
   },
   "aeo": {
     "appears_in": [
@@ -75,7 +81,9 @@
     "name": "Anatomical Entity Ontology",
     "preferred_prefix": "AEO",
     "repository": "https://github.com/obophenotype/human-developmental-anatomy-ontology",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/AEO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AEO_$1"
   },
   "aero": {
     "artifacts": [
@@ -98,7 +106,9 @@
     },
     "name": "Adverse Event Reporting Ontology",
     "preferred_prefix": "AERO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/AERO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AERO_$1"
   },
   "afpo": {
     "artifacts": [
@@ -131,7 +141,9 @@
     "name": "African Population Ontology",
     "preferred_prefix": "AfPO",
     "repository": "https://github.com/h3abionet/afpo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/AfPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AfPO_$1"
   },
   "agro": {
     "artifacts": [
@@ -178,7 +190,9 @@
       }
     ],
     "repository": "https://github.com/AgriculturalSemantics/agro",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/AGRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AGRO_$1"
   },
   "aism": {
     "appears_in": [
@@ -223,7 +237,9 @@
     "name": "Ontology for the Anatomy of the Insect SkeletoMuscular system (AISM)",
     "preferred_prefix": "AISM",
     "repository": "https://github.com/insect-morphology/aism",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/AISM_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AISM_$1"
   },
   "amphx": {
     "artifacts": [
@@ -255,7 +271,9 @@
     "name": "The Amphioxus Development and Anatomy Ontology",
     "preferred_prefix": "AMPHX",
     "repository": "https://github.com/EBISPOT/amphx_ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/AMPHX_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/AMPHX_$1"
   },
   "apo": {
     "artifacts": [
@@ -295,7 +313,9 @@
       "identifier": "4890",
       "name": "Ascomycota",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/APO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/APO_$1"
   },
   "apollo_sv": {
     "appears_in": [
@@ -329,7 +349,9 @@
       }
     ],
     "repository": "https://github.com/ApolloDev/apollo-sv",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/APOLLO_SV_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/APOLLO_SV_$1"
   },
   "aro": {
     "appears_in": [
@@ -363,7 +385,9 @@
       }
     ],
     "repository": "https://github.com/arpcard/aro",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ARO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ARO_$1"
   },
   "ato": {
     "contact": {
@@ -380,7 +404,9 @@
       "identifier": "8292",
       "name": "Amphibia",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/ATO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ATO_$1"
   },
   "bcgo": {
     "artifacts": [
@@ -405,7 +431,9 @@
     "name": "Beta Cell Genomics Ontology",
     "preferred_prefix": "BCGO",
     "repository": "https://github.com/obi-bcgo/bcgo",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/BCGO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BCGO_$1"
   },
   "bco": {
     "appears_in": [
@@ -439,7 +467,9 @@
       }
     ],
     "repository": "https://github.com/BiodiversityOntologies/bco",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/BCO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BCO_$1"
   },
   "bfo": {
     "appears_in": [
@@ -492,7 +522,9 @@
     "name": "Basic Formal Ontology",
     "preferred_prefix": "BFO",
     "repository": "https://github.com/BFO-ontology/BFO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/BFO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BFO_$1"
   },
   "bila": {
     "artifacts": [
@@ -516,7 +548,9 @@
       "identifier": "33213",
       "name": "Bilateria",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/BILA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BILA_$1"
   },
   "bmont": {
     "contact": {
@@ -535,7 +569,9 @@
     "name": "Biomarker Ontology",
     "preferred_prefix": "BMONT",
     "repository": "https://github.com/SCAI-BIO/BiomarkerOntology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/BMONT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BMONT_$1"
   },
   "bootstrep": {
     "contact": {
@@ -546,7 +582,9 @@
     "homepage": "http://www.ebi.ac.uk/Rebholz-srv/GRO/GRO.html",
     "name": "Gene Regulation Ontology",
     "preferred_prefix": "BOOTSTREP",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/BOOTSTREP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BOOTSTREP_$1"
   },
   "bspo": {
     "appears_in": [
@@ -589,7 +627,9 @@
       }
     ],
     "repository": "https://github.com/obophenotype/biological-spatial-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/BSPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BSPO_$1"
   },
   "bto": {
     "artifacts": [
@@ -628,7 +668,9 @@
       }
     ],
     "repository": "https://github.com/BRENDA-Enzymes/BTO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/BTO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/BTO_$1"
   },
   "caro": {
     "appears_in": [
@@ -661,7 +703,9 @@
     "name": "Common Anatomy Reference Ontology",
     "preferred_prefix": "CARO",
     "repository": "https://github.com/obophenotype/caro",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/CARO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CARO_$1"
   },
   "cdao": {
     "artifacts": [
@@ -692,7 +736,9 @@
       }
     ],
     "repository": "https://github.com/evoinfo/cdao",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CDAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CDAO_$1"
   },
   "cdno": {
     "artifacts": [
@@ -734,7 +780,9 @@
       }
     ],
     "repository": "https://github.com/CompositionalDietaryNutritionOntology/cdno",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CDNO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CDNO_$1"
   },
   "ceph": {
     "artifacts": [
@@ -768,7 +816,9 @@
       "identifier": "6605",
       "name": "Cephalopod",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/CEPH_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CEPH_$1"
   },
   "chebi": {
     "appears_in": [
@@ -830,7 +880,9 @@
       }
     ],
     "repository": "https://github.com/ebi-chebi/ChEBI",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CHEBI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CHEBI_$1"
   },
   "cheminf": {
     "appears_in": [
@@ -864,7 +916,9 @@
       }
     ],
     "repository": "https://github.com/semanticchemistry/semanticchemistry",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://semanticscience.org/resource/CHEMINF_$1",
+    "uri_format_rdf": "http://semanticscience.org/resource/CHEMINF_$1"
   },
   "chiro": {
     "artifacts": [
@@ -908,7 +962,9 @@
       }
     ],
     "repository": "https://github.com/obophenotype/chiro",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CHIRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CHIRO_$1"
   },
   "chmo": {
     "appears_in": [
@@ -937,7 +993,9 @@
     "name": "Chemical Methods Ontology",
     "preferred_prefix": "CHMO",
     "repository": "https://github.com/rsc-ontologies/rsc-cmo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CHMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CHMO_$1"
   },
   "cido": {
     "artifacts": [
@@ -968,7 +1026,9 @@
       }
     ],
     "repository": "https://github.com/cido-ontology/cido",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CIDO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CIDO_$1"
   },
   "cio": {
     "artifacts": [
@@ -1003,7 +1063,9 @@
       }
     ],
     "repository": "https://github.com/BgeeDB/confidence-information-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CIO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CIO_$1"
   },
   "cl": {
     "appears_in": [
@@ -1067,7 +1129,9 @@
       "identifier": "33208",
       "name": "Metazoa",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/CL_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CL_$1"
   },
   "clao": {
     "artifacts": [
@@ -1099,7 +1163,9 @@
     "name": "Collembola Anatomy Ontology",
     "preferred_prefix": "CLAO",
     "repository": "https://github.com/luis-gonzalez-m/Collembola",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CLAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CLAO_$1"
   },
   "clo": {
     "appears_in": [
@@ -1139,7 +1205,9 @@
       }
     ],
     "repository": "https://github.com/CLO-Ontology/CLO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CLO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CLO_$1"
   },
   "clyh": {
     "artifacts": [
@@ -1173,7 +1241,9 @@
     "name": "Clytia hemisphaerica Development and Anatomy Ontology",
     "preferred_prefix": "CLYH",
     "repository": "https://github.com/EBISPOT/clyh_ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CLYH_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CLYH_$1"
   },
   "cmf": {
     "contact": {
@@ -1185,7 +1255,9 @@
     "homepage": "https://code.google.com/p/craniomaxillofacial-ontology/",
     "name": "CranioMaxilloFacial ontology",
     "preferred_prefix": "CMF",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/CMF_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CMF_$1"
   },
   "cmo": {
     "appears_in": [
@@ -1228,7 +1300,9 @@
       }
     ],
     "repository": "https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CMO_$1"
   },
   "cob": {
     "artifacts": [
@@ -1253,7 +1327,9 @@
     "name": "Core Ontology for Biology and Biomedicine",
     "preferred_prefix": "COB",
     "repository": "https://github.com/OBOFoundry/COB",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/COB_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/COB_$1"
   },
   "colao": {
     "artifacts": [
@@ -1291,7 +1367,9 @@
     "name": "Coleoptera Anatomy Ontology (COLAO)",
     "preferred_prefix": "COLAO",
     "repository": "https://github.com/insect-morphology/colao",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/COLAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/COLAO_$1"
   },
   "cro": {
     "artifacts": [
@@ -1316,7 +1394,9 @@
     "name": "Contributor Role Ontology",
     "preferred_prefix": "CRO",
     "repository": "https://github.com/data2health/contributor-role-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CRO_$1"
   },
   "cteno": {
     "artifacts": [
@@ -1350,7 +1430,9 @@
       "identifier": "10197",
       "name": "Ctenophore",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/CTENO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CTENO_$1"
   },
   "cto": {
     "artifacts": [
@@ -1375,7 +1457,9 @@
     "name": "CTO: Core Ontology of Clinical Trials",
     "preferred_prefix": "CTO",
     "repository": "https://github.com/ClinicalTrialOntology/CTO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CTO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CTO_$1"
   },
   "cvdo": {
     "artifacts": [
@@ -1400,7 +1484,9 @@
     "name": "Cardiovascular Disease Ontology",
     "preferred_prefix": "CVDO",
     "repository": "https://github.com/OpenLHS/CVDO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/CVDO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/CVDO_$1"
   },
   "dc_cl": {
     "contact": {
@@ -1417,7 +1503,9 @@
       "identifier": "1",
       "name": "root",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/DC_CL_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DC_CL_$1"
   },
   "ddanat": {
     "artifacts": [
@@ -1457,7 +1545,9 @@
       "identifier": "44689",
       "name": "Dictyostelium discoideum",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/DDANAT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DDANAT_$1"
   },
   "ddpheno": {
     "artifacts": [
@@ -1497,7 +1587,9 @@
       "identifier": "44689",
       "name": "Dictyostelium discoideum",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/DDPHENO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DDPHENO_$1"
   },
   "dideo": {
     "artifacts": [
@@ -1522,7 +1614,9 @@
     "name": "Drug-drug Interaction and Drug-drug Interaction Evidence Ontology",
     "preferred_prefix": "DIDEO",
     "repository": "https://github.com/DIDEO/DIDEO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/DIDEO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DIDEO_$1"
   },
   "dinto": {
     "artifacts": [
@@ -1551,7 +1645,9 @@
       }
     ],
     "repository": "https://github.com/labda/DINTO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/DINTO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DINTO_$1"
   },
   "disdriv": {
     "artifacts": [
@@ -1581,7 +1677,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/DISDRIV_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DISDRIV_$1"
   },
   "doid": {
     "appears_in": [
@@ -1630,7 +1728,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/DOID_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DOID_$1"
   },
   "dpo": {
     "artifacts": [
@@ -1674,7 +1774,9 @@
       "identifier": "7227",
       "name": "Drosophila",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FBcv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FBcv_$1"
   },
   "dron": {
     "appears_in": [
@@ -1708,7 +1810,9 @@
       }
     ],
     "repository": "https://github.com/ufbmi/dron",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/DRON_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DRON_$1"
   },
   "duo": {
     "appears_in": [
@@ -1740,7 +1844,9 @@
     "name": "Data Use Ontology",
     "preferred_prefix": "DUO",
     "repository": "https://github.com/EBISPOT/DUO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/DUO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/DUO_$1"
   },
   "ecao": {
     "artifacts": [
@@ -1774,7 +1880,9 @@
     "name": "The Echinoderm Anatomy and Development Ontology",
     "preferred_prefix": "ECAO",
     "repository": "https://github.com/echinoderm-ontology/ecao_ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ECAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ECAO_$1"
   },
   "eco": {
     "artifacts": [
@@ -1818,7 +1926,9 @@
       }
     ],
     "repository": "https://github.com/evidenceontology/evidenceontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ECO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ECO_$1"
   },
   "ecocore": {
     "artifacts": [
@@ -1859,7 +1969,9 @@
     "name": "An ontology of core ecological entities",
     "preferred_prefix": "ECOCORE",
     "repository": "https://github.com/EcologicalSemantics/ecocore",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ECOCORE_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ECOCORE_$1"
   },
   "ecto": {
     "artifacts": [
@@ -1908,7 +2020,9 @@
     "name": "Environmental conditions, treatments and exposures ontology",
     "preferred_prefix": "ECTO",
     "repository": "https://github.com/EnvironmentOntology/environmental-exposure-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ECTO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ECTO_$1"
   },
   "ehda": {
     "contact": {
@@ -1924,7 +2038,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/EHDA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EHDA_$1"
   },
   "ehdaa": {
     "contact": {
@@ -1939,7 +2055,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/EHDAA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EHDAA_$1"
   },
   "ehdaa2": {
     "artifacts": [
@@ -1982,7 +2100,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/EHDAA2_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EHDAA2_$1"
   },
   "emap": {
     "artifacts": [
@@ -2007,7 +2127,9 @@
       "identifier": "10088",
       "name": "Mus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/EMAP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EMAP_$1"
   },
   "emapa": {
     "artifacts": [
@@ -2059,7 +2181,9 @@
       "identifier": "10088",
       "name": "Mus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/EMAPA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EMAPA_$1"
   },
   "envo": {
     "appears_in": [
@@ -2125,7 +2249,9 @@
       }
     ],
     "repository": "https://github.com/EnvironmentOntology/envo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ENVO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ENVO_$1"
   },
   "eo": {
     "appears_in": [
@@ -2164,7 +2290,9 @@
       }
     ],
     "repository": "https://github.com/Planteome/plant-environment-ontology",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/EO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EO_$1"
   },
   "epio": {
     "artifacts": [
@@ -2192,7 +2320,9 @@
     "name": "Epilepsy Ontology",
     "preferred_prefix": "EPIO",
     "repository": "https://github.com/SCAI-BIO/EpilepsyOntology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/EPIO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EPIO_$1"
   },
   "epo": {
     "artifacts": [
@@ -2206,7 +2336,9 @@
     "homepage": "https://code.google.com/p/epidemiology-ontology/",
     "name": "Epidemiology Ontology",
     "preferred_prefix": "EPO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/EPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EPO_$1"
   },
   "ero": {
     "artifacts": [
@@ -2228,7 +2360,9 @@
     },
     "name": "eagle-i resource ontology",
     "preferred_prefix": "ERO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/ERO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ERO_$1"
   },
   "eupath": {
     "appears_in": [
@@ -2263,13 +2397,17 @@
       }
     ],
     "repository": "https://github.com/VEuPathDB-ontology/VEuPathDB-ontology",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/EUPATH_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EUPATH_$1"
   },
   "ev": {
     "domain": "anatomy and development",
     "name": "eVOC (Expressed Sequence Annotation for Humans)",
     "preferred_prefix": "EV",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/EV_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EV_$1"
   },
   "exmo": {
     "artifacts": [
@@ -2300,7 +2438,9 @@
       }
     ],
     "repository": "https://github.com/Exercise-Medicine-Ontology/EXMO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/EXMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/EXMO_$1"
   },
   "exo": {
     "appears_in": [
@@ -2333,7 +2473,9 @@
     "name": "Exposure ontology",
     "preferred_prefix": "ExO",
     "repository": "https://github.com/CTDbase/exposure-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ExO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ExO_$1"
   },
   "fao": {
     "artifacts": [
@@ -2367,7 +2509,9 @@
       "identifier": "4751",
       "name": "Fungal",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FAO_$1"
   },
   "fbbi": {
     "artifacts": [
@@ -2401,7 +2545,9 @@
     "name": "Biological Imaging Methods Ontology",
     "preferred_prefix": "FBbi",
     "repository": "https://github.com/foundingGIDE/fbbi",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/FBbi_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FBbi_$1"
   },
   "fbbt": {
     "artifacts": [
@@ -2457,7 +2603,9 @@
       "identifier": "7227",
       "name": "Drosophila",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FBbt_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FBbt_$1"
   },
   "fbcv": {
     "appears_in": [
@@ -2493,7 +2641,9 @@
     "name": "FlyBase Controlled Vocabulary",
     "preferred_prefix": "FBcv",
     "repository": "https://github.com/FlyBase/flybase-controlled-vocabulary",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/FBcv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FBcv_$1"
   },
   "fbdv": {
     "artifacts": [
@@ -2531,7 +2681,9 @@
       "identifier": "7227",
       "name": "Drosophila",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FBdv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FBdv_$1"
   },
   "fbsp": {
     "artifacts": [
@@ -2556,7 +2708,9 @@
       "identifier": "7227",
       "name": "Drosophila",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FBSP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FBSP_$1"
   },
   "fideo": {
     "artifacts": [
@@ -2581,7 +2735,9 @@
     "name": "Food Interactions with Drugs Evidence Ontology",
     "preferred_prefix": "FIDEO",
     "repository": "https://gitub.u-bordeaux.fr/erias/fideo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/FIDEO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FIDEO_$1"
   },
   "fix": {
     "artifacts": [
@@ -2602,7 +2758,9 @@
     "homepage": "http://www.ebi.ac.uk/chebi",
     "name": "Physico-chemical methods and properties",
     "preferred_prefix": "FIX",
-    "status": "orphaned"
+    "status": "orphaned",
+    "uri_format": "http://purl.obolibrary.org/obo/FIX_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FIX_$1"
   },
   "flopo": {
     "appears_in": [
@@ -2641,7 +2799,9 @@
       "identifier": "33090",
       "name": "Viridiplantae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FLOPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FLOPO_$1"
   },
   "flu": {
     "artifacts": [
@@ -2658,7 +2818,9 @@
     "homepage": "http://purl.obolibrary.org/obo/flu/",
     "name": "Influenza Ontology",
     "preferred_prefix": "FLU",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/FLU_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FLU_$1"
   },
   "fma": {
     "artifacts": [
@@ -2700,7 +2862,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FMA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FMA_$1"
   },
   "fobi": {
     "artifacts": [
@@ -2739,7 +2903,9 @@
       }
     ],
     "repository": "https://github.com/pcastellanoescuder/FoodBiomarkerOntology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/FOBI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FOBI_$1"
   },
   "foodon": {
     "appears_in": [
@@ -2788,7 +2954,9 @@
       }
     ],
     "repository": "https://github.com/FoodOntology/foodon",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/FOODON_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FOODON_$1"
   },
   "fovt": {
     "artifacts": [
@@ -2827,7 +2995,9 @@
     "name": "FuTRES Ontology of Vertebrate Traits",
     "preferred_prefix": "FOVT",
     "repository": "https://github.com/futres/fovt",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/FOVT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FOVT_$1"
   },
   "fypo": {
     "artifacts": [
@@ -2868,7 +3038,9 @@
       "identifier": "4896",
       "name": "S. pombe",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/FYPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/FYPO_$1"
   },
   "gallont": {
     "artifacts": [
@@ -2911,7 +3083,9 @@
     "name": "Plant Gall Ontology",
     "preferred_prefix": "GALLONT",
     "repository": "https://github.com/adeans/gallont",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GALLONT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GALLONT_$1"
   },
   "gaz": {
     "appears_in": [
@@ -2943,7 +3117,9 @@
     "name": "Gazetteer",
     "preferred_prefix": "GAZ",
     "repository": "https://github.com/EnvironmentOntology/gaz",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GAZ_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GAZ_$1"
   },
   "gecko": {
     "artifacts": [
@@ -2968,7 +3144,9 @@
     "name": "Genomics Cohorts Knowledge Ontology",
     "preferred_prefix": "GECKO",
     "repository": "https://github.com/IHCC-cohorts/GECKO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GECKO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GECKO_$1"
   },
   "genepio": {
     "artifacts": [
@@ -3000,7 +3178,9 @@
     "name": "Genomic Epidemiology Ontology",
     "preferred_prefix": "GENEPIO",
     "repository": "https://github.com/GenEpiO/genepio",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GENEPIO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GENEPIO_$1"
   },
   "geno": {
     "artifacts": [
@@ -3025,7 +3205,9 @@
     "name": "Genotype Ontology",
     "preferred_prefix": "GENO",
     "repository": "https://github.com/monarch-initiative/GENO-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GENO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GENO_$1"
   },
   "geo": {
     "artifacts": [
@@ -3050,7 +3232,9 @@
     "name": "Geographical Entity Ontology",
     "preferred_prefix": "GEO",
     "repository": "https://github.com/ufbmi/geographical-entity-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GEO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GEO_$1"
   },
   "gno": {
     "artifacts": [
@@ -3089,7 +3273,9 @@
       }
     ],
     "repository": "https://github.com/glygen-glycan-data/GNOme",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GNO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GNO_$1"
   },
   "go": {
     "appears_in": [
@@ -3159,14 +3345,18 @@
       "identifier": "1",
       "name": "root",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/GO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GO_$1"
   },
   "gro": {
     "domain": "anatomy and development",
     "homepage": "http://www.gramene.org/plant_ontology/",
     "name": "Cereal Plant Gross Anatomy",
     "preferred_prefix": "GRO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/GRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GRO_$1"
   },
   "gsso": {
     "appears_in": [
@@ -3203,7 +3393,9 @@
     "name": "Gender, Sex, and Sexual Orientation (GSSO) ontology",
     "preferred_prefix": "GSSO",
     "repository": "https://github.com/Superraptor/GSSO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/GSSO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/GSSO_$1"
   },
   "habronattus": {
     "contact": {
@@ -3215,7 +3407,9 @@
     "homepage": "http://www.mesquiteproject.org/ontology/Habronattus/index.html",
     "name": "Habronattus courtship",
     "preferred_prefix": "HABRONATTUS",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/HABRONATTUS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HABRONATTUS_$1"
   },
   "hancestro": {
     "artifacts": [
@@ -3246,7 +3440,9 @@
       }
     ],
     "repository": "https://github.com/EBISPOT/hancestro",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/HANCESTRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HANCESTRO_$1"
   },
   "hao": {
     "artifacts": [
@@ -3286,7 +3482,9 @@
       "identifier": "7399",
       "name": "Hymenoptera",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/HAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HAO_$1"
   },
   "hom": {
     "artifacts": [
@@ -3317,7 +3515,9 @@
       }
     ],
     "repository": "https://github.com/BgeeDB/homology-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/HOM_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HOM_$1"
   },
   "hp": {
     "appears_in": [
@@ -3379,7 +3579,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/HP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HP_$1"
   },
   "hsapdv": {
     "appears_in": [
@@ -3411,7 +3613,9 @@
     "name": "Human Developmental Stages",
     "preferred_prefix": "HsapDv",
     "repository": "https://github.com/obophenotype/developmental-stage-ontologies",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/HsapDv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HsapDv_$1"
   },
   "hso": {
     "artifacts": [
@@ -3443,7 +3647,9 @@
     "name": "Health Surveillance Ontology",
     "preferred_prefix": "HSO",
     "repository": "https://github.com/SVA-SE/HSO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/HSO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HSO_$1"
   },
   "htn": {
     "artifacts": [
@@ -3468,7 +3674,9 @@
     "name": "Hypertension Ontology",
     "preferred_prefix": "HTN",
     "repository": "https://github.com/aellenhicks/htn_owl",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/HTN_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/HTN_$1"
   },
   "iao": {
     "appears_in": [
@@ -3509,7 +3717,9 @@
     "name": "Information Artifact Ontology",
     "preferred_prefix": "IAO",
     "repository": "https://github.com/information-artifact-ontology/IAO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/IAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/IAO_$1"
   },
   "iceo": {
     "artifacts": [
@@ -3540,7 +3750,9 @@
       }
     ],
     "repository": "https://github.com/ontoice/ICEO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ICEO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ICEO_$1"
   },
   "ico": {
     "appears_in": [
@@ -3568,7 +3780,9 @@
     "name": "Informed Consent Ontology",
     "preferred_prefix": "ICO",
     "repository": "https://github.com/ICO-ontology/ICO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ICO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ICO_$1"
   },
   "ido": {
     "appears_in": [
@@ -3607,7 +3821,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/IDO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/IDO_$1"
   },
   "idomal": {
     "appears_in": [
@@ -3637,21 +3853,27 @@
     "name": "Malaria Ontology",
     "preferred_prefix": "IDOMAL",
     "repository": "https://github.com/VEuPathDB-ontology/IDOMAL",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/IDOMAL_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/IDOMAL_$1"
   },
   "iev": {
     "domain": "chemistry and biochemistry",
     "homepage": "http://www.inoh.org",
     "name": "Event (INOH pathway ontology)",
     "preferred_prefix": "IEV",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/IEV_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/IEV_$1"
   },
   "imr": {
     "domain": "chemistry and biochemistry",
     "homepage": "http://www.inoh.org",
     "name": "Molecule role (INOH Protein name/family name ontology)",
     "preferred_prefix": "IMR",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/IMR_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/IMR_$1"
   },
   "ino": {
     "artifacts": [
@@ -3682,14 +3904,18 @@
       }
     ],
     "repository": "https://github.com/INO-ontology/ino",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/INO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/INO_$1"
   },
   "ipr": {
     "domain": "chemistry and biochemistry",
     "homepage": "http://www.ebi.ac.uk/interpro/index.html",
     "name": "Protein Domains",
     "preferred_prefix": "IPR",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/IPR_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/IPR_$1"
   },
   "kisao": {
     "artifacts": [
@@ -3720,7 +3946,9 @@
       }
     ],
     "repository": "https://github.com/SED-ML/KiSAO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/KISAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/KISAO_$1"
   },
   "labo": {
     "artifacts": [
@@ -3764,7 +3992,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/LABO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/LABO_$1"
   },
   "lepao": {
     "artifacts": [
@@ -3802,7 +4032,9 @@
     "name": "Lepidoptera Anatomy Ontology",
     "preferred_prefix": "LEPAO",
     "repository": "https://github.com/insect-morphology/lepao",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/LEPAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/LEPAO_$1"
   },
   "lipro": {
     "contact": {
@@ -3814,7 +4046,9 @@
     "domain": "chemistry and biochemistry",
     "name": "Lipid Ontology",
     "preferred_prefix": "LIPRO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/LIPRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/LIPRO_$1"
   },
   "loggerhead": {
     "contact": {
@@ -3826,7 +4060,9 @@
     "homepage": "http://www.mesquiteproject.org/ontology/Loggerhead/index.html",
     "name": "Loggerhead nesting",
     "preferred_prefix": "LOGGERHEAD",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/LOGGERHEAD_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/LOGGERHEAD_$1"
   },
   "ma": {
     "artifacts": [
@@ -3860,7 +4096,9 @@
       "identifier": "10088",
       "name": "Mus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MA_$1"
   },
   "mamo": {
     "artifacts": [
@@ -3879,7 +4117,9 @@
     "name": "Mathematical modeling ontology",
     "preferred_prefix": "MAMO",
     "repository": "http://sourceforge.net/p/mamo-ontology",
-    "status": "orphaned"
+    "status": "orphaned",
+    "uri_format": "http://purl.obolibrary.org/obo/MAMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MAMO_$1"
   },
   "mao": {
     "contact": {
@@ -3890,7 +4130,9 @@
     "homepage": "http://www-igbmc.u-strasbg.fr/BioInfo/MAO/mao.html",
     "name": "Multiple alignment",
     "preferred_prefix": "MAO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/MAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MAO_$1"
   },
   "mat": {
     "contact": {
@@ -3900,7 +4142,9 @@
     "domain": "anatomy and development",
     "name": "Minimal anatomical terminology",
     "preferred_prefix": "MAT",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/MAT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MAT_$1"
   },
   "maxo": {
     "appears_in": [
@@ -3948,7 +4192,9 @@
     "name": "Medical Action Ontology",
     "preferred_prefix": "MAXO",
     "repository": "https://github.com/monarch-initiative/MAxO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MAXO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MAXO_$1"
   },
   "mco": {
     "artifacts": [
@@ -3993,7 +4239,9 @@
     "name": "Microbial Conditions Ontology",
     "preferred_prefix": "MCO",
     "repository": "https://github.com/microbial-conditions-ontology/microbial-conditions-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MCO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MCO_$1"
   },
   "mcro": {
     "artifacts": [
@@ -4028,7 +4276,9 @@
       }
     ],
     "repository": "https://github.com/UTHealth-Ontology/MCRO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MCRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MCRO_$1"
   },
   "mf": {
     "artifacts": [
@@ -4053,7 +4303,9 @@
     "name": "Mental Functioning Ontology",
     "preferred_prefix": "MF",
     "repository": "https://github.com/jannahastings/mental-functioning-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MF_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MF_$1"
   },
   "mfmo": {
     "artifacts": [
@@ -4086,7 +4338,9 @@
       "identifier": "40674",
       "name": "Mammalian",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MFMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MFMO_$1"
   },
   "mfo": {
     "artifacts": [
@@ -4110,7 +4364,9 @@
       "identifier": "8089",
       "name": "Oryzias",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MFO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MFO_$1"
   },
   "mfoem": {
     "artifacts": [
@@ -4135,7 +4391,9 @@
     "name": "Emotion Ontology",
     "preferred_prefix": "MFOEM",
     "repository": "https://github.com/jannahastings/emotion-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MFOEM_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MFOEM_$1"
   },
   "mfomd": {
     "artifacts": [
@@ -4160,7 +4418,9 @@
     "name": "Mental Disease Ontology",
     "preferred_prefix": "MFOMD",
     "repository": "https://github.com/jannahastings/mental-functioning-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MFOMD_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MFOMD_$1"
   },
   "mi": {
     "artifacts": [
@@ -4189,7 +4449,9 @@
     "name": "Molecular Interactions Controlled Vocabulary",
     "preferred_prefix": "MI",
     "repository": "https://github.com/HUPO-PSI/psi-mi-CV",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MI_$1"
   },
   "miapa": {
     "artifacts": [
@@ -4220,7 +4482,9 @@
       }
     ],
     "repository": "https://github.com/evoinfo/miapa",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MIAPA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MIAPA_$1"
   },
   "micro": {
     "appears_in": [
@@ -4248,7 +4512,9 @@
     "name": "Ontology of Prokaryotic Phenotypic and Metabolic Characters",
     "preferred_prefix": "MICRO",
     "repository": "https://github.com/carrineblank/MicrO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/MICRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MICRO_$1"
   },
   "mirnao": {
     "artifacts": [
@@ -4270,7 +4536,9 @@
     },
     "name": "microRNA Ontology",
     "preferred_prefix": "MIRNAO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/MIRNAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MIRNAO_$1"
   },
   "miro": {
     "artifacts": [
@@ -4297,7 +4565,9 @@
       "identifier": "44484",
       "name": "Anopheles",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MIRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MIRO_$1"
   },
   "mmo": {
     "artifacts": [
@@ -4336,7 +4606,9 @@
       }
     ],
     "repository": "https://github.com/rat-genome-database/MMO-Measurement-Method-Ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MMO_$1"
   },
   "mmusdv": {
     "artifacts": [
@@ -4365,7 +4637,9 @@
     "name": "Mouse Developmental Stages",
     "preferred_prefix": "MmusDv",
     "repository": "https://github.com/obophenotype/developmental-stage-ontologies",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MmusDv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MmusDv_$1"
   },
   "mo": {
     "artifacts": [
@@ -4384,7 +4658,9 @@
     "homepage": "http://mged.sourceforge.net/ontologies/MGEDontology.php",
     "name": "Microarray experimental conditions",
     "preferred_prefix": "MO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/MO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MO_$1"
   },
   "mod": {
     "artifacts": [
@@ -4419,7 +4695,9 @@
       }
     ],
     "repository": "https://github.com/HUPO-PSI/psi-mod-CV",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MOD_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MOD_$1"
   },
   "mondo": {
     "artifacts": [
@@ -4469,7 +4747,9 @@
       "identifier": "33208",
       "name": "Metazoa",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MONDO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MONDO_$1"
   },
   "mop": {
     "artifacts": [
@@ -4494,7 +4774,9 @@
     "name": "Molecular Process Ontology",
     "preferred_prefix": "MOP",
     "repository": "https://github.com/rsc-ontologies/rxno",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MOP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MOP_$1"
   },
   "mp": {
     "appears_in": [
@@ -4551,7 +4833,9 @@
       "identifier": "40674",
       "name": "Mammalia",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MP_$1"
   },
   "mpath": {
     "artifacts": [
@@ -4581,7 +4865,9 @@
       "identifier": "10088",
       "name": "Mus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/MPATH_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MPATH_$1"
   },
   "mpio": {
     "artifacts": [
@@ -4606,7 +4892,9 @@
     "name": "Minimum PDDI Information Ontology",
     "preferred_prefix": "MPIO",
     "repository": "https://github.com/MPIO-Developers/MPIO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MPIO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MPIO_$1"
   },
   "mro": {
     "artifacts": [
@@ -4631,7 +4919,9 @@
     "name": "MHC Restriction Ontology",
     "preferred_prefix": "MRO",
     "repository": "https://github.com/IEDB/MRO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MRO_$1"
   },
   "ms": {
     "artifacts": [
@@ -4670,7 +4960,9 @@
       }
     ],
     "repository": "https://github.com/HUPO-PSI/psi-ms-CV",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/MS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/MS_$1"
   },
   "nbo": {
     "appears_in": [
@@ -4708,7 +5000,9 @@
       }
     ],
     "repository": "https://github.com/obo-behavior/behavior-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/NBO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NBO_$1"
   },
   "ncbitaxon": {
     "appears_in": [
@@ -4760,7 +5054,9 @@
     "name": "NCBI organismal classification",
     "preferred_prefix": "NCBITaxon",
     "repository": "https://github.com/obophenotype/ncbitaxon",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/NCBITaxon_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NCBITaxon_$1"
   },
   "ncit": {
     "appears_in": [
@@ -4789,7 +5085,9 @@
     "name": "NCI Thesaurus OBO Edition",
     "preferred_prefix": "NCIT",
     "repository": "https://github.com/ncit-obo-org/ncit-obo-edition",
-    "status": "orphaned"
+    "status": "orphaned",
+    "uri_format": "http://purl.obolibrary.org/obo/NCIT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NCIT_$1"
   },
   "ncro": {
     "contact": {
@@ -4808,7 +5106,9 @@
     "name": "Non-Coding RNA Ontology",
     "preferred_prefix": "NCRO",
     "repository": "https://github.com/OmniSearch/ncro",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/NCRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NCRO_$1"
   },
   "ngbo": {
     "artifacts": [
@@ -4833,7 +5133,9 @@
     "name": "Next Generation Biobanking Ontology",
     "preferred_prefix": "NGBO",
     "repository": "https://github.com/Dalalghamdi/NGBO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/NGBO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NGBO_$1"
   },
   "nif_cell": {
     "contact": {
@@ -4846,7 +5148,9 @@
     "homepage": "http://neuinfo.org/",
     "name": "NIF Cell",
     "preferred_prefix": "NIF_CELL",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/NIF_CELL_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NIF_CELL_$1"
   },
   "nif_dysfunction": {
     "contact": {
@@ -4858,7 +5162,9 @@
     "homepage": "http://neuinfo.org/",
     "name": "NIF Dysfunction",
     "preferred_prefix": "NIF_DYSFUNCTION",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/NIF_DYSFUNCTION_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NIF_DYSFUNCTION_$1"
   },
   "nif_grossanatomy": {
     "contact": {
@@ -4870,7 +5176,9 @@
     "homepage": "http://neuinfo.org/",
     "name": "NIF Gross Anatomy",
     "preferred_prefix": "NIF_GROSSANATOMY",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/NIF_GROSSANATOMY_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NIF_GROSSANATOMY_$1"
   },
   "nmr": {
     "artifacts": [
@@ -4888,7 +5196,9 @@
     "homepage": "http://msi-ontology.sourceforge.net/",
     "name": "NMR-instrument specific component of metabolomics investigations",
     "preferred_prefix": "NMR",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/NMR_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NMR_$1"
   },
   "nomen": {
     "artifacts": [
@@ -4913,7 +5223,9 @@
     "name": "NOMEN - A nomenclatural ontology for biological names",
     "preferred_prefix": "NOMEN",
     "repository": "https://github.com/SpeciesFileGroup/nomen",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/NOMEN_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/NOMEN_$1"
   },
   "oae": {
     "artifacts": [
@@ -4948,7 +5260,9 @@
       }
     ],
     "repository": "https://github.com/OAE-ontology/OAE",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OAE_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OAE_$1"
   },
   "oarcs": {
     "artifacts": [
@@ -4973,7 +5287,9 @@
     "name": "Ontology of Arthropod Circulatory Systems",
     "preferred_prefix": "OARCS",
     "repository": "https://github.com/aszool/oarcs",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OARCS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OARCS_$1"
   },
   "oba": {
     "appears_in": [
@@ -5011,7 +5327,9 @@
       }
     ],
     "repository": "https://github.com/obophenotype/bio-attribute-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OBA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OBA_$1"
   },
   "obcs": {
     "artifacts": [
@@ -5036,7 +5354,9 @@
     "name": "Ontology of Biological and Clinical Statistics",
     "preferred_prefix": "OBCS",
     "repository": "https://github.com/obcs/obcs",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OBCS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OBCS_$1"
   },
   "obi": {
     "appears_in": [
@@ -5086,7 +5406,9 @@
       }
     ],
     "repository": "https://github.com/obi-ontology/obi",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OBI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OBI_$1"
   },
   "obib": {
     "artifacts": [
@@ -5111,7 +5433,9 @@
     "name": "Ontology for Biobanking",
     "preferred_prefix": "OBIB",
     "repository": "https://github.com/biobanking/biobanking",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OBIB_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OBIB_$1"
   },
   "occo": {
     "artifacts": [
@@ -5136,7 +5460,9 @@
     "name": "Occupation Ontology",
     "preferred_prefix": "OCCO",
     "repository": "https://github.com/Occupation-Ontology/OccO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OCCO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OCCO_$1"
   },
   "ogg": {
     "artifacts": [
@@ -5161,7 +5487,9 @@
     "name": "The Ontology of Genes and Genomes",
     "preferred_prefix": "OGG",
     "repository": "https://bitbucket.org/hegroup/ogg",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OGG_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OGG_$1"
   },
   "ogi": {
     "artifacts": [
@@ -5181,7 +5509,9 @@
     "homepage": "https://code.google.com/p/ontology-for-genetic-interval/",
     "name": "Ontology for genetic interval",
     "preferred_prefix": "OGI",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/OGI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OGI_$1"
   },
   "ogms": {
     "appears_in": [
@@ -5226,7 +5556,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/OGMS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OGMS_$1"
   },
   "ogsf": {
     "artifacts": [
@@ -5251,7 +5583,9 @@
     "name": "Ontology of Genetic Susceptibility Factor",
     "preferred_prefix": "OGSF",
     "repository": "https://github.com/linikujp/OGSF",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/OGSF_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OGSF_$1"
   },
   "ohd": {
     "artifacts": [
@@ -5282,7 +5616,9 @@
       }
     ],
     "repository": "https://github.com/oral-health-and-disease-ontologies/ohd-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OHD_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OHD_$1"
   },
   "ohmi": {
     "artifacts": [
@@ -5307,7 +5643,9 @@
     "name": "Ontology of Host-Microbiome Interactions",
     "preferred_prefix": "OHMI",
     "repository": "https://github.com/ohmi-ontology/ohmi",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OHMI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OHMI_$1"
   },
   "ohpi": {
     "artifacts": [
@@ -5338,7 +5676,9 @@
       }
     ],
     "repository": "https://github.com/OHPI/ohpi",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OHPI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OHPI_$1"
   },
   "olatdv": {
     "artifacts": [
@@ -5367,7 +5707,9 @@
     "name": "Medaka Developmental Stages",
     "preferred_prefix": "OlatDv",
     "repository": "https://github.com/obophenotype/developmental-stage-ontologies",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/OlatDv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OlatDv_$1"
   },
   "omiabis": {
     "appears_in": [
@@ -5394,7 +5736,9 @@
     "name": "Ontologized MIABIS",
     "preferred_prefix": "OMIABIS",
     "repository": "https://github.com/OMIABIS/omiabis-dev",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/OMIABIS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OMIABIS_$1"
   },
   "omit": {
     "appears_in": [
@@ -5422,7 +5766,9 @@
     "name": "Ontology for MIRNA Target",
     "preferred_prefix": "OMIT",
     "repository": "https://github.com/OmniSearch/omit",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OMIT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OMIT_$1"
   },
   "omo": {
     "appears_in": [
@@ -5453,7 +5799,9 @@
     "name": "OBO Metadata Ontology",
     "preferred_prefix": "OMO",
     "repository": "https://github.com/information-artifact-ontology/ontology-metadata",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OMO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OMO_$1"
   },
   "omp": {
     "appears_in": [
@@ -5491,7 +5839,9 @@
       }
     ],
     "repository": "https://github.com/microbialphenotypes/OMP-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OMP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OMP_$1"
   },
   "omrse": {
     "appears_in": [
@@ -5530,7 +5880,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/OMRSE_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OMRSE_$1"
   },
   "one": {
     "artifacts": [
@@ -5560,7 +5912,9 @@
     "name": "Ontology for Nutritional Epidemiology",
     "preferred_prefix": "ONE",
     "repository": "https://github.com/cyang0128/Nutritional-epidemiologic-ontologies",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ONE_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ONE_$1"
   },
   "ons": {
     "appears_in": [
@@ -5604,7 +5958,9 @@
       }
     ],
     "repository": "https://github.com/enpadasi/Ontology-for-Nutritional-Studies",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ONS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ONS_$1"
   },
   "ontoavida": {
     "artifacts": [
@@ -5646,7 +6002,9 @@
       }
     ],
     "repository": "https://gitlab.com/fortunalab/ontoavida",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ONTOAVIDA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ONTOAVIDA_$1"
   },
   "ontoneo": {
     "artifacts": [
@@ -5681,7 +6039,9 @@
       }
     ],
     "repository": "https://github.com/ontoneo-project/Ontoneo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ONTONEO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ONTONEO_$1"
   },
   "oostt": {
     "artifacts": [
@@ -5706,7 +6066,9 @@
     "name": "Ontology of Organizational Structures of Trauma centers and Trauma systems",
     "preferred_prefix": "OOSTT",
     "repository": "https://github.com/OOSTT/OOSTT",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OOSTT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OOSTT_$1"
   },
   "opl": {
     "artifacts": [
@@ -5731,7 +6093,9 @@
     "name": "Ontology for Parasite LifeCycle",
     "preferred_prefix": "OPL",
     "repository": "https://github.com/OPL-ontology/OPL",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OPL_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OPL_$1"
   },
   "opmi": {
     "appears_in": [
@@ -5760,7 +6124,9 @@
     "name": "Ontology of Precision Medicine and Investigation",
     "preferred_prefix": "OPMI",
     "repository": "https://github.com/OPMI/opmi",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OPMI_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OPMI_$1"
   },
   "ornaseq": {
     "artifacts": [
@@ -5785,7 +6151,9 @@
     "name": "Ontology of RNA Sequencing",
     "preferred_prefix": "ORNASEQ",
     "repository": "https://github.com/safisher/ornaseq",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ORNASEQ_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ORNASEQ_$1"
   },
   "ovae": {
     "artifacts": [
@@ -5810,7 +6178,9 @@
     "name": "Ontology of Vaccine Adverse Events",
     "preferred_prefix": "OVAE",
     "repository": "https://github.com/OVAE-Ontology/ovae",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/OVAE_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/OVAE_$1"
   },
   "pao": {
     "contact": {
@@ -5828,7 +6198,9 @@
       "identifier": "33090",
       "name": "Viridiplantae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/PAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PAO_$1"
   },
   "pato": {
     "appears_in": [
@@ -5894,7 +6266,9 @@
       }
     ],
     "repository": "https://github.com/pato-ontology/pato",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PATO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PATO_$1"
   },
   "pbpko": {
     "artifacts": [
@@ -5927,7 +6301,9 @@
     "name": "Physiologically-Based Pharmacokinetic Ontology",
     "preferred_prefix": "PBPKO",
     "repository": "https://github.com/InSilicoVida-Research-Lab/pbpko",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PBPKO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PBPKO_$1"
   },
   "pcl": {
     "artifacts": [
@@ -5974,7 +6350,9 @@
     "name": "Provisional Cell Ontology",
     "preferred_prefix": "PCL",
     "repository": "https://github.com/obophenotype/provisional_cell_ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PCL_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PCL_$1"
   },
   "pco": {
     "appears_in": [
@@ -6013,7 +6391,9 @@
     "name": "Population and Community Ontology",
     "preferred_prefix": "PCO",
     "repository": "https://github.com/PopulationAndCommunityOntology/pco",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PCO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PCO_$1"
   },
   "pd_st": {
     "contact": {
@@ -6031,7 +6411,9 @@
       "identifier": "6358",
       "name": "Platynereis",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/PD_ST_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PD_ST_$1"
   },
   "pdro": {
     "artifacts": [
@@ -6062,7 +6444,9 @@
       }
     ],
     "repository": "https://github.com/OpenLHS/PDRO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PDRO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PDRO_$1"
   },
   "pdumdv": {
     "artifacts": [
@@ -6091,7 +6475,9 @@
     "name": "Platynereis Developmental Stages",
     "preferred_prefix": "PdumDv",
     "repository": "https://github.com/obophenotype/developmental-stage-ontologies",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/PdumDv_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PdumDv_$1"
   },
   "peco": {
     "appears_in": [
@@ -6131,7 +6517,9 @@
       }
     ],
     "repository": "https://github.com/Planteome/plant-experimental-conditions-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PECO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PECO_$1"
   },
   "pgdso": {
     "contact": {
@@ -6147,7 +6535,9 @@
       "identifier": "33090",
       "name": "Viridiplantae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/PGDSO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PGDSO_$1"
   },
   "phipo": {
     "artifacts": [
@@ -6185,7 +6575,9 @@
       }
     ],
     "repository": "https://github.com/PHI-base/phipo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PHIPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PHIPO_$1"
   },
   "plana": {
     "appears_in": [
@@ -6227,7 +6619,9 @@
       }
     ],
     "repository": "https://github.com/obophenotype/planaria-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PLANA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PLANA_$1"
   },
   "planp": {
     "artifacts": [
@@ -6262,7 +6656,9 @@
     "name": "Planarian Phenotype Ontology",
     "preferred_prefix": "PLANP",
     "repository": "https://github.com/obophenotype/planarian-phenotype-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PLANP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PLANP_$1"
   },
   "plo": {
     "contact": {
@@ -6273,7 +6669,9 @@
     "homepage": "http://www.sanger.ac.uk/Users/mb4/PLO/",
     "name": "Plasmodium life cycle",
     "preferred_prefix": "PLO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/PLO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PLO_$1"
   },
   "po": {
     "appears_in": [
@@ -6325,7 +6723,9 @@
       "identifier": "33090",
       "name": "Viridiplantae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/PO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PO_$1"
   },
   "poro": {
     "appears_in": [
@@ -6372,7 +6772,9 @@
       "identifier": "6040",
       "name": "Porifera",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/PORO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PORO_$1"
   },
   "ppo": {
     "artifacts": [
@@ -6402,7 +6804,9 @@
       "identifier": "33090",
       "name": "Viridiplantae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/PPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PPO_$1"
   },
   "pr": {
     "appears_in": [
@@ -6445,7 +6849,9 @@
       }
     ],
     "repository": "https://github.com/PROconsortium/PRoteinOntology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PR_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PR_$1"
   },
   "prefer": {
     "artifacts": [
@@ -6484,7 +6890,9 @@
       }
     ],
     "repository": "https://github.com/Multiomics-Analytics-Group/prefer_ontology/",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PREFER_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PREFER_$1"
   },
   "proco": {
     "artifacts": [
@@ -6517,7 +6925,9 @@
     "name": "Process Chemistry Ontology",
     "preferred_prefix": "PROCO",
     "repository": "https://github.com/proco-ontology/PROCO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PROCO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PROCO_$1"
   },
   "propreo": {
     "contact": {
@@ -6528,7 +6938,9 @@
     "homepage": "http://lsdis.cs.uga.edu/projects/glycomics/propreo/",
     "name": "Proteomics data and process provenance",
     "preferred_prefix": "PROPREO",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/PROPREO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PROPREO_$1"
   },
   "psdo": {
     "artifacts": [
@@ -6559,7 +6971,9 @@
     "name": "Performance Summary Display Ontology",
     "preferred_prefix": "PSDO",
     "repository": "https://github.com/Display-Lab/psdo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PSDO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PSDO_$1"
   },
   "pso": {
     "artifacts": [
@@ -6598,7 +7012,9 @@
       }
     ],
     "repository": "https://github.com/Planteome/plant-stress-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PSO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PSO_$1"
   },
   "pw": {
     "artifacts": [
@@ -6638,7 +7054,9 @@
       }
     ],
     "repository": "https://github.com/rat-genome-database/PW-Pathway-Ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/PW_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/PW_$1"
   },
   "rbo": {
     "artifacts": [
@@ -6680,7 +7098,9 @@
     "name": "Radiation Biology Ontology",
     "preferred_prefix": "RBO",
     "repository": "https://github.com/Radiobiology-Informatics-Consortium/RBO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/RBO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/RBO_$1"
   },
   "resid": {
     "contact": {
@@ -6693,7 +7113,9 @@
     "homepage": "http://www.ebi.ac.uk/RESID/",
     "name": "Protein covalent bond",
     "preferred_prefix": "RESID",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/RESID_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/RESID_$1"
   },
   "rex": {
     "artifacts": [
@@ -6706,7 +7128,9 @@
     "domain": "chemistry and biochemistry",
     "name": "Physico-chemical process",
     "preferred_prefix": "REX",
-    "status": "orphaned"
+    "status": "orphaned",
+    "uri_format": "http://purl.obolibrary.org/obo/REX_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/REX_$1"
   },
   "rnao": {
     "artifacts": [
@@ -6734,7 +7158,9 @@
     "name": "RNA ontology",
     "preferred_prefix": "RNAO",
     "repository": "https://github.com/BGSU-RNA/rnao",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/RNAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/RNAO_$1"
   },
   "ro": {
     "appears_in": [
@@ -6805,7 +7231,9 @@
     "name": "Relation Ontology",
     "preferred_prefix": "RO",
     "repository": "https://github.com/oborel/obo-relations",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/RO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/RO_$1"
   },
   "rs": {
     "artifacts": [
@@ -6846,7 +7274,9 @@
       "identifier": "10114",
       "name": "Rattus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/RS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/RS_$1"
   },
   "rxno": {
     "artifacts": [
@@ -6871,7 +7301,9 @@
     "name": "Name Reaction Ontology",
     "preferred_prefix": "RXNO",
     "repository": "https://github.com/rsc-ontologies/rxno",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/RXNO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/RXNO_$1"
   },
   "sao": {
     "contact": {
@@ -6887,7 +7319,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/SAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SAO_$1"
   },
   "sbo": {
     "appears_in": [
@@ -6916,7 +7350,9 @@
     "name": "Systems Biology Ontology",
     "preferred_prefix": "SBO",
     "repository": "https://github.com/EBI-BioModels/SBO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/SBO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SBO_$1"
   },
   "scdo": {
     "artifacts": [
@@ -6992,7 +7428,9 @@
       }
     ],
     "repository": "https://github.com/scdodev/scdo-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/SCDO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SCDO_$1"
   },
   "sep": {
     "artifacts": [
@@ -7006,7 +7444,9 @@
     "homepage": "http://psidev.info/index.php?q=node/312",
     "name": "Sample processing and separation techniques",
     "preferred_prefix": "SEP",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/SEP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SEP_$1"
   },
   "sepio": {
     "artifacts": [
@@ -7032,7 +7472,9 @@
     "name": "Scientific Evidence and Provenance Information Ontology",
     "preferred_prefix": "SEPIO",
     "repository": "https://github.com/monarch-initiative/SEPIO-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/SEPIO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SEPIO_$1"
   },
   "sibo": {
     "artifacts": [
@@ -7060,7 +7502,9 @@
     "name": "Social Insect Behavior Ontology",
     "preferred_prefix": "SIBO",
     "repository": "https://github.com/obophenotype/sibo",
-    "status": "orphaned"
+    "status": "orphaned",
+    "uri_format": "http://purl.obolibrary.org/obo/SIBO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SIBO_$1"
   },
   "slso": {
     "artifacts": [
@@ -7093,7 +7537,9 @@
     "name": "Space Life Sciences Ontology",
     "preferred_prefix": "SLSO",
     "repository": "https://github.com/nasa/LSDAO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/SLSO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SLSO_$1"
   },
   "so": {
     "appears_in": [
@@ -7136,7 +7582,9 @@
       }
     ],
     "repository": "https://github.com/The-Sequence-Ontology/SO-Ontologies",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/SO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SO_$1"
   },
   "sopharm": {
     "contact": {
@@ -7152,7 +7600,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/SOPHARM_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SOPHARM_$1"
   },
   "spd": {
     "artifacts": [
@@ -7188,7 +7638,9 @@
       "identifier": "6893",
       "name": "spiders",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/SPD_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SPD_$1"
   },
   "stato": {
     "appears_in": [
@@ -7229,7 +7681,9 @@
       }
     ],
     "repository": "https://github.com/ISA-tools/stato",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/STATO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/STATO_$1"
   },
   "swo": {
     "appears_in": [
@@ -7267,7 +7721,9 @@
       }
     ],
     "repository": "https://github.com/allysonlister/swo",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/SWO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SWO_$1"
   },
   "symp": {
     "appears_in": [
@@ -7314,7 +7770,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/SYMP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/SYMP_$1"
   },
   "t4fs": {
     "artifacts": [
@@ -7353,7 +7811,9 @@
       }
     ],
     "repository": "https://github.com/terms4fairskills/FAIRterminology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/T4FS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/T4FS_$1"
   },
   "tads": {
     "artifacts": [
@@ -7385,7 +7845,9 @@
       "identifier": "6939",
       "name": "Ixodidae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TADS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TADS_$1"
   },
   "tahe": {
     "contact": {
@@ -7400,7 +7862,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TAHE_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TAHE_$1"
   },
   "tahh": {
     "contact": {
@@ -7415,7 +7879,9 @@
       "identifier": "9606",
       "name": "Homo sapiens",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TAHH_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TAHH_$1"
   },
   "tao": {
     "artifacts": [
@@ -7449,7 +7915,9 @@
       "identifier": "32443",
       "name": "Teleostei",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TAO_$1"
   },
   "taxrank": {
     "artifacts": [
@@ -7484,7 +7952,9 @@
       }
     ],
     "repository": "https://github.com/phenoscape/taxrank",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/TAXRANK_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TAXRANK_$1"
   },
   "tgma": {
     "artifacts": [
@@ -7516,7 +7986,9 @@
       "identifier": "44484",
       "name": "Anopheles",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TGMA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TGMA_$1"
   },
   "to": {
     "appears_in": [
@@ -7560,7 +8032,9 @@
       "identifier": "33090",
       "name": "Viridiplantae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TO_$1"
   },
   "trans": {
     "artifacts": [
@@ -7599,7 +8073,9 @@
       }
     ],
     "repository": "https://github.com/DiseaseOntology/PathogenTransmissionOntology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/TRANS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TRANS_$1"
   },
   "tto": {
     "artifacts": [
@@ -7639,7 +8115,9 @@
       "identifier": "32443",
       "name": "Teleostei",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/TTO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TTO_$1"
   },
   "txpo": {
     "artifacts": [
@@ -7670,7 +8148,9 @@
       }
     ],
     "repository": "https://github.com/txpo-ontology/TXPO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/TXPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/TXPO_$1"
   },
   "uberon": {
     "appears_in": [
@@ -7753,7 +8233,9 @@
       "identifier": "33208",
       "name": "Metazoa",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/UBERON_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/UBERON_$1"
   },
   "uo": {
     "appears_in": [
@@ -7798,7 +8280,9 @@
       }
     ],
     "repository": "https://github.com/bio-ontology-research-group/unit-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/UO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/UO_$1"
   },
   "upa": {
     "artifacts": [
@@ -7836,7 +8320,9 @@
       }
     ],
     "repository": "https://github.com/geneontology/unipathway",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/UPA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/UPA_$1"
   },
   "upheno": {
     "artifacts": [
@@ -7875,7 +8361,9 @@
       }
     ],
     "repository": "https://github.com/obophenotype/upheno",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/UPHENO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/UPHENO_$1"
   },
   "vario": {
     "artifacts": [
@@ -7917,7 +8405,9 @@
         "title": "Types and effects of protein variations"
       }
     ],
-    "status": "orphaned"
+    "status": "orphaned",
+    "uri_format": "http://purl.obolibrary.org/obo/VariO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VariO_$1"
   },
   "vbo": {
     "artifacts": [
@@ -7960,7 +8450,9 @@
       }
     ],
     "repository": "https://github.com/monarch-initiative/vertebrate-breed-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/VBO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VBO_$1"
   },
   "vhog": {
     "artifacts": [
@@ -7973,7 +8465,9 @@
     "logo": "http://bgee.org/img/logo/bgee13_logo.png",
     "name": "Vertebrate Homologous Ontology Group Ontology",
     "preferred_prefix": "VHOG",
-    "status": "inactive"
+    "status": "inactive",
+    "uri_format": "http://purl.obolibrary.org/obo/VHOG_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VHOG_$1"
   },
   "vo": {
     "appears_in": [
@@ -8011,7 +8505,9 @@
       }
     ],
     "repository": "https://github.com/vaccineontology/VO",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/VO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VO_$1"
   },
   "vsao": {
     "artifacts": [
@@ -8035,7 +8531,9 @@
       "identifier": "7742",
       "name": "Vertebrata",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/VSAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VSAO_$1"
   },
   "vt": {
     "appears_in": [
@@ -8063,7 +8561,9 @@
     "name": "Vertebrate trait ontology",
     "preferred_prefix": "VT",
     "repository": "https://github.com/AnimalGenome/vertebrate-trait-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/VT_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VT_$1"
   },
   "vto": {
     "artifacts": [
@@ -8098,7 +8598,9 @@
       }
     ],
     "repository": "https://github.com/phenoscape/vertebrate-taxonomy-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/VTO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/VTO_$1"
   },
   "wbbt": {
     "artifacts": [
@@ -8138,7 +8640,9 @@
       "identifier": "6237",
       "name": "Caenorhabditis",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/WBbt_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/WBbt_$1"
   },
   "wbls": {
     "artifacts": [
@@ -8178,7 +8682,9 @@
       "identifier": "6237",
       "name": "Caenorhabditis",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/WBls_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/WBls_$1"
   },
   "wbphenotype": {
     "artifacts": [
@@ -8218,7 +8724,9 @@
       "identifier": "6237",
       "name": "Caenorhabditis",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/WBPhenotype_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/WBPhenotype_$1"
   },
   "xao": {
     "appears_in": [
@@ -8265,7 +8773,9 @@
       "identifier": "8353",
       "name": "Xenopus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/XAO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/XAO_$1"
   },
   "xco": {
     "appears_in": [
@@ -8309,7 +8819,9 @@
       }
     ],
     "repository": "https://github.com/rat-genome-database/XCO-experimental-condition-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/XCO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/XCO_$1"
   },
   "xlmod": {
     "artifacts": [
@@ -8338,7 +8850,9 @@
     "name": "HUPO-PSI cross-linking and derivatization reagents controlled vocabulary",
     "preferred_prefix": "XLMOD",
     "repository": "https://github.com/HUPO-PSI/xlmod-CV",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/XLMOD_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/XLMOD_$1"
   },
   "xpo": {
     "artifacts": [
@@ -8388,7 +8902,9 @@
       "identifier": "8353",
       "name": "Xenopus",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/XPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/XPO_$1"
   },
   "ypo": {
     "contact": {
@@ -8405,7 +8921,9 @@
       "identifier": "4932",
       "name": "Saccharomyces cerevisiae",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/YPO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/YPO_$1"
   },
   "zea": {
     "contact": {
@@ -8422,7 +8940,9 @@
       "identifier": "4575",
       "name": "Zea",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/ZEA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ZEA_$1"
   },
   "zeco": {
     "appears_in": [
@@ -8463,7 +8983,9 @@
       "identifier": "7954",
       "name": "Danio",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/ZECO_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ZECO_$1"
   },
   "zfa": {
     "appears_in": [
@@ -8506,7 +9028,9 @@
       "identifier": "7954",
       "name": "Danio",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/ZFA_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ZFA_$1"
   },
   "zfs": {
     "artifacts": [
@@ -8540,7 +9064,9 @@
       "identifier": "7954",
       "name": "Danio",
       "prefix": "NCBITaxon"
-    }
+    },
+    "uri_format": "http://purl.obolibrary.org/obo/ZFS_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ZFS_$1"
   },
   "zp": {
     "artifacts": [
@@ -8578,6 +9104,8 @@
     "name": "Zebrafish Phenotype Ontology",
     "preferred_prefix": "ZP",
     "repository": "https://github.com/obophenotype/zebrafish-phenotype-ontology",
-    "status": "active"
+    "status": "active",
+    "uri_format": "http://purl.obolibrary.org/obo/ZP_$1",
+    "uri_format_rdf": "http://purl.obolibrary.org/obo/ZP_$1"
   }
 }

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -1614,8 +1614,16 @@ class Manager:
 
         >>> manager.get_obofoundry_iri("fbbt", "00007294")
         'http://purl.obolibrary.org/obo/FBbt_00007294'
+
+        For entries with an explicit override, respect it.
+
+        >>> manager.get_obofoundry_iri("cheminf", "000410")
+        'http://semanticscience.org/resource/CHEMINF_000410'
         """
-        return self.get_formatted_iri("obofoundry", prefix, identifier)
+        resource = self.get_resource(prefix)
+        if resource is None:
+            return None
+        return resource.get_obofoundry_iri(identifier)
 
     def get_n2t_iri(self, prefix: str, identifier: str) -> str | None:
         """Get the name-to-thing URL for the given CURIE.

--- a/src/bioregistry/resource_manager.py
+++ b/src/bioregistry/resource_manager.py
@@ -48,6 +48,7 @@ from .schema import (
     record_accumulator,
     sanitize_model,
 )
+from .schema.struct import OlsVersion
 from .schema_utils import (
     _collections_from_path,
     _contexts_from_path,
@@ -1559,21 +1560,17 @@ class Manager:
         >>> manager.get_bioportal_iri("chebi", "24431")
         'https://bioportal.bioontology.org/ontologies/CHEBI/?p=classes&conceptid=http://purl.obolibrary.org/obo/CHEBI_24431'
         """
-        bioportal_prefix = self.get_mapped_prefix(prefix, "bioportal")
-        if bioportal_prefix is None:
+        resource = self.get_resource(prefix)
+        if resource is None:
             return None
-        obo_link = self.get_obofoundry_iri(prefix, identifier)
-        if obo_link is not None:
-            return f"https://bioportal.bioontology.org/ontologies/{bioportal_prefix}/?p=classes&conceptid={obo_link}"
-        return None
+        return resource.get_bioportal_iri(identifier)
 
-    def get_ols_iri(self, prefix: str, identifier: str) -> str | None:
+    def get_ols_iri(self, prefix: str, identifier: str, *, version: OlsVersion = "3") -> str | None:
         """Get the OLS URL if possible."""
-        ols_prefix = self.get_mapped_prefix(prefix, "ols")
-        obo_iri = self.get_obofoundry_iri(prefix, identifier)
-        if ols_prefix is None or obo_iri is None:
+        resource = self.get_resource(prefix)
+        if resource is None:
             return None
-        return f"https://www.ebi.ac.uk/ols4/ontologies/{ols_prefix}/terms?iri={obo_iri}"
+        return resource.get_ols_iri(identifier, version=version)
 
     def get_formatted_iri(self, metaprefix: str, prefix: str, identifier: str) -> str | None:
         """Get an IRI using the format in the metaregistry.

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1973,6 +1973,13 @@ class Resource(BaseModel):
             return f"https://bioportal.bioontology.org/ontologies/{bioportal_prefix}/?p=classes&conceptid={rdf_uri}"
         return None
 
+    def get_obofoundry_iri(self, identifier: str) -> str | None:
+        """Get the OBO Foundry URL for the given local unique identifier, if possible."""
+        uri_format = self.get_obofoundry_uri_format()
+        if uri_format is None:
+            return None
+        return uri_format.replace("$1", identifier)
+
     def get_rrid_uri_format(self) -> str | None:
         """Get the RRID URI format.
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1929,7 +1929,6 @@ class Resource(BaseModel):
             return None
         if rdf_uri_prefix := self.get_rdf_uri_prefix():
             return f"https://www.ebi.ac.uk/ols/ontologies/{ols_prefix}/terms?iri={rdf_uri_prefix}"
-        # TODO find examples, like for EFO on when it's not based on OBO Foundry PURLs
         return None
 
     def get_ols_uri_format(self) -> str | None:
@@ -1975,9 +1974,9 @@ class Resource(BaseModel):
             return self.rdf_uri_format
         if self.obofoundry:
             return self.get_obofoundry_uri_format()
-        if self.wikidata and "uri_format_rdf" in self.wikidata:
-            return cast(str, self.wikidata["uri_format_rdf"])
-        # TODO also pull from Prefix Commons
+        for metaprefix in ["wikidata", "prefixcommons"]:
+            if v := self.get_external(metaprefix).get("uri_format_rdf"):
+                return v
         return None
 
     def get_rdf_uri_prefix(self) -> str | None:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -91,6 +91,8 @@ URI_IRI_INFO = (
     "and IRI specification (https://www.ietf.org/rfc/rfc3987.txt) for more information."
 )
 
+OlsVersion: TypeAlias = Literal["3", "4"]
+
 X = TypeVar("X")
 
 #: A controlled vocabulary of domains.
@@ -1952,6 +1954,27 @@ class Resource(BaseModel):
         if ols_url_prefix is None:
             return None
         return f"{ols_url_prefix}$1"
+
+    def get_ols_iri(self, identifier: str, *, version: OlsVersion = "3") -> str | None:
+        """Get the OLS URL for the given local unique identifier, if possible."""
+        ols_prefix = self.get_ols_prefix()
+        if ols_prefix is None:
+            return None
+        if rdf_uri := self.get_rdf_uri(identifier):
+            ols_version = "ols4" if version == "4" else "ols"
+            return (
+                f"https://www.ebi.ac.uk/{ols_version}/ontologies/{ols_prefix}/terms?iri={rdf_uri}"
+            )
+        return None
+
+    def get_bioportal_iri(self, identifier: str) -> str | None:
+        """Get the Bioportal URL for the given local unique identifier, if possible."""
+        bioportal_prefix = self.get_mapped_prefix("bioportal")
+        if bioportal_prefix is None:
+            return None
+        if rdf_uri := self.get_rdf_uri(identifier):
+            return f"https://bioportal.bioontology.org/ontologies/{bioportal_prefix}/?p=classes&conceptid={rdf_uri}"
+        return None
 
     def get_rrid_uri_format(self) -> str | None:
         """Get the RRID URI format.

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1696,10 +1696,7 @@ class Resource(BaseModel):
         'http://purl.obolibrary.org/obo/NCBITaxon_'
         >>> assert get_resource("sty").get_obofoundry_uri_prefix() is None
         """
-        obo_prefix = self.get_obofoundry_prefix()
-        if obo_prefix is None:
-            return None
-        return f"http://purl.obolibrary.org/obo/{obo_prefix}_"
+        return self._get_external_uri_format("obofoundry")
 
     def get_bioregistry_uri_format(self) -> str | None:
         """Get the Bioregisry URI format string for this entry.

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1696,7 +1696,10 @@ class Resource(BaseModel):
         'http://purl.obolibrary.org/obo/NCBITaxon_'
         >>> assert get_resource("sty").get_obofoundry_uri_prefix() is None
         """
-        return self._get_external_uri_format("obofoundry")
+        rv = self._get_external_uri_format("obofoundry")
+        if rv is None:
+            return None
+        return rv.removesuffix("$1")
 
     def get_bioregistry_uri_format(self) -> str | None:
         """Get the Bioregisry URI format string for this entry.
@@ -1723,10 +1726,7 @@ class Resource(BaseModel):
         'http://purl.obolibrary.org/obo/NCBITaxon_$1'
         >>> assert get_resource("sty").get_obofoundry_uri_format() is None
         """
-        rv = self.get_obofoundry_uri_prefix()
-        if rv is None:
-            return None
-        return f"{rv}$1"
+        return self._get_external_uri_format("obofoundry")
 
     def _get_external_uri_format(self, metaprefix: str) -> str | None:
         return self.get_external(metaprefix).get(URI_FORMAT_KEY)

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1912,14 +1912,23 @@ class Resource(BaseModel):
         'https://www.ebi.ac.uk/ols/ontologies/go/terms?iri=http://purl.obolibrary.org/obo/GO_'
         >>> get_resource("ncbitaxon").get_ols_uri_prefix()  # mixed case
         'https://www.ebi.ac.uk/ols/ontologies/ncbitaxon/terms?iri=http://purl.obolibrary.org/obo/NCBITaxon_'
+
+        These are non-OBO ontologies indexed in OLS
+
+        >>> get_resource("cheminf").get_ols_prefix()
+        'https://www.ebi.ac.uk/ols/ontologies/ncbitaxon/terms?iri=http://semanticscience.org/resource/CHEMINF_'
+        >>> get_resource("efo").get_ols_prefix()
+        'https://www.ebi.ac.uk/ols/ontologies/ncbitaxon/terms?http://www.ebi.ac.uk/efo/EFO_'
+
+        These are not infexed in OLS
+
         >>> assert get_resource("sty").get_ols_uri_prefix() is None
         """
         ols_prefix = self.get_ols_prefix()
         if ols_prefix is None:
             return None
-        obo_format = self.get_obofoundry_uri_prefix()
-        if obo_format:
-            return f"https://www.ebi.ac.uk/ols/ontologies/{ols_prefix}/terms?iri={obo_format}"
+        if rdf_uri_prefix := self.get_rdf_uri_prefix():
+            return f"https://www.ebi.ac.uk/ols/ontologies/{ols_prefix}/terms?iri={rdf_uri_prefix}"
         # TODO find examples, like for EFO on when it's not based on OBO Foundry PURLs
         return None
 

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1975,8 +1975,8 @@ class Resource(BaseModel):
         if self.obofoundry:
             return self.get_obofoundry_uri_format()
         for metaprefix in ["wikidata", "prefixcommons"]:
-            if v := self.get_external(metaprefix).get("uri_format_rdf"):
-                return v
+            if uri_format_rdf := self.get_external(metaprefix).get("uri_format_rdf"):
+                return cast(str, uri_format_rdf)
         return None
 
     def get_rdf_uri_prefix(self) -> str | None:

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -1914,10 +1914,10 @@ class Resource(BaseModel):
 
         These are non-OBO ontologies indexed in OLS
 
-        >>> get_resource("cheminf").get_ols_prefix()
-        'https://www.ebi.ac.uk/ols/ontologies/ncbitaxon/terms?iri=http://semanticscience.org/resource/CHEMINF_'
-        >>> get_resource("efo").get_ols_prefix()
-        'https://www.ebi.ac.uk/ols/ontologies/ncbitaxon/terms?http://www.ebi.ac.uk/efo/EFO_'
+        >>> get_resource("cheminf").get_ols_uri_prefix()
+        'https://www.ebi.ac.uk/ols/ontologies/cheminf/terms?iri=http://semanticscience.org/resource/CHEMINF_'
+        >>> get_resource("efo").get_ols_uri_prefix()
+        'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http://www.ebi.ac.uk/efo/EFO_'
 
         These are not infexed in OLS
 

--- a/tests/test_struct/test_struct.py
+++ b/tests/test_struct/test_struct.py
@@ -36,7 +36,6 @@ class StructTest(unittest.TestCase):
         resource = Resource(
             prefix=internal_prefix,
             mappings={"ols": external_prefix},
-            ols={"prefix": external_prefix},
             rdf_uri_format=rdf_uri_format,
         )
         self.assertEqual(external_prefix, resource.get_ols_prefix())
@@ -44,19 +43,38 @@ class StructTest(unittest.TestCase):
             f"https://www.ebi.ac.uk/ols/ontologies/{external_prefix}/terms?iri={rdf_uri_prefix}",
             resource.get_ols_uri_prefix(),
         )
+        self.assertEqual(
+            f"https://www.ebi.ac.uk/ols/ontologies/{external_prefix}/terms?iri={rdf_uri_prefix}0000001",
+            resource.get_ols_iri("0000001"),
+        )
 
         # test shortcut for obofoundry
         resource = Resource(
             prefix=internal_prefix,
             mappings={"ols": external_prefix, "obofoundry": external_prefix},
-            ols={"prefix": external_prefix},
             obofoundry={"prefix": external_prefix},
         )
-        self.assertEqual(external_prefix, resource.get_ols_prefix())
         self.assertEqual(external_prefix, resource.get_ols_prefix())
         self.assertEqual(
             f"https://www.ebi.ac.uk/ols/ontologies/{external_prefix}/terms?iri=http://purl.obolibrary.org/obo/{external_prefix.upper()}_",
             resource.get_ols_uri_prefix(),
+        )
+
+    def test_get_bioportal(self) -> None:
+        """Test getting OLS URI prefix."""
+        internal_prefix = "test"
+        external_prefix = "tset"
+        rdf_uri_prefix = "https://example.com/test/"
+        rdf_uri_format = f"{rdf_uri_prefix}$1"
+
+        resource = Resource(
+            prefix=internal_prefix,
+            mappings={"bioportal": external_prefix},
+            rdf_uri_format=rdf_uri_format,
+        )
+        self.assertEqual(
+            f"https://bioportal.bioontology.org/ontologies/{external_prefix}/?p=classes&conceptid={rdf_uri_prefix}0000001",
+            resource.get_bioportal_iri("0000001"),
         )
 
     def test_record_accumulator(self) -> None:

--- a/tests/test_struct/test_struct.py
+++ b/tests/test_struct/test_struct.py
@@ -52,7 +52,10 @@ class StructTest(unittest.TestCase):
         resource = Resource(
             prefix=internal_prefix,
             mappings={"ols": external_prefix, "obofoundry": external_prefix},
-            obofoundry={"prefix": external_prefix},
+            obofoundry={
+                "prefix": external_prefix,
+                "uri_format": f"http://purl.obolibrary.org/obo/{external_prefix.upper()}_$1",
+            },
         )
         self.assertEqual(external_prefix, resource.get_ols_prefix())
         self.assertEqual(

--- a/tests/test_struct/test_struct.py
+++ b/tests/test_struct/test_struct.py
@@ -23,6 +23,42 @@ class StructTest(unittest.TestCase):
         resource = Resource(prefix="test", uri_format="https://example.com/$1.html")
         self.assertEqual("https://bioregistry.io/test:", resource.get_uri_prefix())
 
+    def test_get_ols_uri_prefix(self) -> None:
+        """Test getting OLS URI prefix."""
+        internal_prefix = "test"
+        external_prefix = "tset"
+        rdf_uri_prefix = "https://example.com/test/"
+        rdf_uri_format = f"{rdf_uri_prefix}$1"
+
+        resource = Resource(prefix=internal_prefix)
+        self.assertIsNone(resource.get_ols_uri_prefix())
+
+        resource = Resource(
+            prefix=internal_prefix,
+            mappings={"ols": external_prefix},
+            ols={"prefix": external_prefix},
+            rdf_uri_format=rdf_uri_format,
+        )
+        self.assertEqual(external_prefix, resource.get_ols_prefix())
+        self.assertEqual(
+            f"https://www.ebi.ac.uk/ols/ontologies/{external_prefix}/terms?iri={rdf_uri_prefix}",
+            resource.get_ols_uri_prefix(),
+        )
+
+        # test shortcut for obofoundry
+        resource = Resource(
+            prefix=internal_prefix,
+            mappings={"ols": external_prefix, "obofoundry": external_prefix},
+            ols={"prefix": external_prefix},
+            obofoundry={"prefix": external_prefix},
+        )
+        self.assertEqual(external_prefix, resource.get_ols_prefix())
+        self.assertEqual(external_prefix, resource.get_ols_prefix())
+        self.assertEqual(
+            f"https://www.ebi.ac.uk/ols/ontologies/{external_prefix}/terms?iri=http://purl.obolibrary.org/obo/{external_prefix.upper()}_",
+            resource.get_ols_uri_prefix(),
+        )
+
     def test_record_accumulator(self) -> None:
         """Test record accumulator."""
         resource = Resource(prefix="test")


### PR DESCRIPTION
Closes #1998

- [x] Previously, the OLS and BioPortal links were constructed by special casing if OBO Foundry URLs were constructable. Now, they check more broadly if RDF-focused URI format is available. Importantly, this fixes the OLS and BioPortal links.
- [x] Add explicit OBO Foundry overrides for the handful of resources that don't use OBO Foundry PURLs

cc @Ted-Bender @StroemPhi 

see also discussion at https://github.com/semanticchemistry/semanticchemistry/issues/76