### PR TITLE
Update `genecards.gene` record

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -60654,6 +60654,7 @@
       "uri_format": "http://identifiers.org/genecards/$1"
     },
     "deprecated": false,
+    "homepage": "https://www.genecards.org/",
     "integbio": {
       "description": "geneCards Version 3 is a database of human genes that provides brief but comprehensive genomic related data, on all known human genes.\nThe information consists of data on transcriptomes, proteomes, functions and disease involvement of human genes.\nThis content was obtained from a large number of relevant sources.\nApproved gene symbols and standard nomenclature is used.\nThe site provides information on a total of 122,413 genes, which include 21660 protein-coding genes, 79,344 RNA genes, 16,763 pseudogenes, 767 genetic loci, 146 gene clusters and 3,733 genes that cannot be placed in any of these categories.\nA simple keyword search option and an advanced search option are available.",
       "homepage": "https://www.genecards.org/",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -60653,6 +60653,7 @@
       "prefix": "GENECARDS",
       "uri_format": "http://identifiers.org/genecards/$1"
     },
+    "deprecated": false,
     "integbio": {
       "description": "geneCards Version 3 is a database of human genes that provides brief but comprehensive genomic related data, on all known human genes.\nThe information consists of data on transcriptomes, proteomes, functions and disease involvement of human genes.\nThis content was obtained from a large number of relevant sources.\nApproved gene symbols and standard nomenclature is used.\nThe site provides information on a total of 122,413 genes, which include 21660 protein-coding genes, 79,344 RNA genes, 16,763 pseudogenes, 767 genetic loci, 146 gene clusters and 3,733 genes that cannot be placed in any of these categories.\nA simple keyword search option and an advanced search option are available.",
       "homepage": "https://www.genecards.org/",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -60758,6 +60758,15 @@
       ],
       "uri_format": "http://www.genecards.org/cgi-bin/carddisp.pl?gene=$1"
     },
+    "providers": [
+      {
+        "code": "legacy",
+        "description": "Legacy URI used before switching to the card URL format",
+        "homepage": "https://www.genecards.org/",
+        "name": "Legacy",
+        "uri_format": "https://www.genecards.org/cgi-bin/carddisp.pl?gene=$1"
+      }
+    ],
     "publications": [
       {
         "doi": "10.1089/omi.2015.0168",
@@ -60847,7 +60856,8 @@
         "GeneCards"
       ],
       "uri_format": "https://www.genecards.org/cgi-bin/carddisp.pl?gene=$1"
-    }
+    },
+    "uri_format": "https://www.genecards.org/card/$1"
   },
   "genecards.geneannot": {
     "mappings": {

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -60653,6 +60653,27 @@
       "prefix": "GENECARDS",
       "uri_format": "http://identifiers.org/genecards/$1"
     },
+    "contact": {
+      "email": "yaron@genecards.org",
+      "github": "yarong-lifemap",
+      "name": "Yaron Guan Golan",
+      "orcid": "0009-0005-9793-6861"
+    },
+    "contact_group_email": "support@genecards.org",
+    "contributor_extras": [
+      {
+        "email": "b.gyori@northeastern.edu",
+        "github": "bgyori",
+        "name": "Benjamin M. Gyori",
+        "orcid": "0000-0001-9439-5346"
+      },
+      {
+        "email": "cthoyt@gmail.com",
+        "github": "cthoyt",
+        "name": "Charles Tapley Hoyt",
+        "orcid": "0000-0003-4423-4370"
+      }
+    ],
     "deprecated": false,
     "homepage": "https://www.genecards.org/",
     "integbio": {


### PR DESCRIPTION
This PR udpates the `genecards.gene` record:
- Explicitly mark as non-deprecated
- Override homepage entry
- Update to new URL, keeping the old one as a legacy provider

Resolves #2019 