### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.14", "3.10"]
+        python-version: ["3.14", "3.11"]
         tox-command: ["lint", "pyroma", "mypy"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.14", "3.10"]
+        python-version: ["3.14", "3.11"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Install uv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Framework :: tox",
     "Framework :: Sphinx",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -53,7 +52,7 @@ keywords = [
 license = "MIT"
 license-files = ["LICENSE"]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "requests",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ requires-python = ">=3.11"
 dependencies = [
     "requests",
     "tqdm",
-    "pystow>=0.8.2",
+    "pystow>=0.9.0",
     "click",
     "more_click>=0.1.2",
     "pydantic[email]>=2.0",
-    "curies>=0.13.9",
+    "curies>=0.15.0",
     "sssom-pydantic>=0.5.10",
     #
     "urllib3>=2.7.0",

--- a/src/bioregistry/alignment_model.py
+++ b/src/bioregistry/alignment_model.py
@@ -38,7 +38,7 @@ class License(BaseModel):
     url: str | None = None
 
 
-class Status(str, enum.Enum):
+class Status(enum.StrEnum):
     """Represents the project status."""
 
     active = "active"
@@ -66,7 +66,7 @@ class Publication(BaseModel):
     zenodo: str | None = None
 
 
-class ArtifactType(str, enum.Enum):
+class ArtifactType(enum.StrEnum):
     """A semantic space artifact type."""
 
     obo = "obo"

--- a/src/bioregistry/curation/literature.py
+++ b/src/bioregistry/curation/literature.py
@@ -18,7 +18,7 @@ COLUMNS = [
 ]
 
 
-class CurationRelevance(str, enum.Enum):
+class CurationRelevance(enum.StrEnum):
     """An enumeration for curation relevance."""
 
     #: A resource for new primary identifiers

--- a/src/bioregistry/external/ols/__init__.py
+++ b/src/bioregistry/external/ols/__init__.py
@@ -136,7 +136,7 @@ def _download(base_url: str, raw_path: Path, force: bool = False) -> None:
     raw_path.write_text(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
 
 
-class VersionType(str, enum.Enum):
+class VersionType(enum.StrEnum):
     """Types for OLS ontology versions."""
 
     date = "date"

--- a/src/bioregistry/schema/struct.py
+++ b/src/bioregistry/schema/struct.py
@@ -19,6 +19,7 @@ from typing import (
     ClassVar,
     Generic,
     Literal,
+    Self,
     TypeAlias,
     TypeVar,
     cast,
@@ -30,7 +31,6 @@ from curies import Reference
 from curies.w3c import NCNAME_RE
 from pydantic import BaseModel, EmailStr, Field, PrivateAttr
 from pydantic.json_schema import models_json_schema
-from typing_extensions import Self
 
 from bioregistry import constants as brc
 from bioregistry.constants import (

--- a/src/bioregistry/summary.py
+++ b/src/bioregistry/summary.py
@@ -8,11 +8,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from itertools import combinations
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import click
 from more_click import force_option
-from typing_extensions import Self
 
 from bioregistry import manager
 from bioregistry.constants import TABLES_SUMMARY_LATEX_PATH

--- a/src/bioregistry/validate/utils.py
+++ b/src/bioregistry/validate/utils.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TextIO, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TextIO, cast
 
 import click
 from pydantic import BaseModel
-from typing_extensions import NotRequired, TypedDict, Unpack
+from typing_extensions import TypedDict, Unpack
 
 if TYPE_CHECKING:
     from bioregistry import Context, Manager


### PR DESCRIPTION
Python 3.10 goes end of life in two months. This PR drops Python 3.10 support a bit early (e.g., Pandas already did this)

In the future, we might not want to support more than the last N versions (maybe with N=3)

Depends on:

- https://github.com/cthoyt/pystow/pull/159
- https://github.com/biopragmatics/curies/pull/235