### PR TITLE
Remove mismatches when linting

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -10505,17 +10505,9 @@
     },
     "homepage": "http://www.sparontologies.net/ontologies/bido",
     "mappings": {
-      "fairsharing": "FAIRsharing.d7f0a9",
-      "ontobee": "BIDO"
+      "fairsharing": "FAIRsharing.d7f0a9"
     },
     "name": "Bibliometric Data Ontology",
-    "ontobee": {
-      "keywords": [
-        "ontology"
-      ],
-      "name": "Bacteria Infectious Disease Ontology",
-      "prefix": "BIDO"
-    },
     "preferred_prefix": "BiDO",
     "repository": "https://github.com/sparontologies/bido",
     "uri_format": "http://purl.org/spar/bido/$1"
@@ -36009,17 +36001,6 @@
       "prefix": "DDI",
       "version": "$Revision$"
     },
-    "bioportal": {
-      "contact": {
-        "email": "soldatova.larisa@gmail.com",
-        "name": "Larisa Soldatova; Da Qi (ddq@aber.ac.uk)"
-      },
-      "description": "The goal of DDI project is to develop an ontology for the description of drug discovery investigations. DDI aims to follow to the OBO (Open Biomedical Ontologies) Foundry principles, uses relations laid down in the OBO Relation Ontology, and be compliant with Ontology for biomedical investigations (OBI).",
-      "homepage": "http://purl.org/ddi/home",
-      "name": "Ontology for Drug Discovery Investigations",
-      "prefix": "DDI",
-      "version": "$Revision$"
-    },
     "contributor": {
       "email": "cthoyt@gmail.com",
       "github": "cthoyt",
@@ -36053,33 +36034,9 @@
     ],
     "mappings": {
       "aberowl": "DDI",
-      "bioportal": "DDI",
-      "fairsharing": "FAIRsharing.pf2qyq",
-      "prefixcommons": "ddi"
+      "fairsharing": "FAIRsharing.pf2qyq"
     },
     "name": "Data Documentation Initiative Vocabulary",
-    "prefixcommons": {
-      "description": "The goal of DDI project is to develop an ontology for the description of drug discovery investigations. DDI aims to follow to the OBO (Open Biomedical Ontologies) Foundry principles, uses relations laid down in the OBO Relation Ontology, and be compliant with Ontology for biomedical investigations (OBI).",
-      "examples": [
-        "pharmacophore"
-      ],
-      "homepage": "http://purl.org/ddi/home",
-      "name": "Ontology for Drug Discovery Investigations",
-      "prefix": "ddi",
-      "providers": [
-        {
-          "code": "bio2rdf",
-          "description": "Bio2RDF is an open-source project that uses Semantic Web technologies to build and provide the largest network of Linked Data for the Life Sciences. Bio2RDF defines a set of simple conventions to create RDF(S) compatible Linked Data from a diverse set of heterogeneously formatted sources obtained from multiple data providers.",
-          "homepage": "https://bio2rdf.org",
-          "name": "Bio2RDF",
-          "uri_format": "http://bio2rdf.org/ddi:$1"
-        }
-      ],
-      "uri_format_rdf": "http://purl.org/ddi/owl#$1",
-      "xrefs": {
-        "bioportal": "1540"
-      }
-    },
     "uri_format": "http://rdf-vocabulary.ddialliance.org/lifecycle#$1"
   },
   "ddi.aggregationmethod": {
@@ -74641,20 +74598,7 @@
     },
     "mappings": {
       "lov": "hydra",
-      "re3data": "r3d100011525",
       "zazuko": "hydra"
-    },
-    "re3data": {
-      "description": "<<<!!!<<<We are moving content from our Hydra repository (hydra.hull.ac.uk) to new repositories.>>>!!!>>>  Hydra is a repository for digital materials at the University of Hull. It can hold and manage any type of digital material, and is being developed in response to the growth in the amount of digital material that is generated through the research, education and administrative activities within the University. Hydra contains different collections of datasets from University of Hull research projects as: ARCdoc, domesday dataset, History of Marine animal Populations (HMAP) and others.",
-      "homepage": "https://hydra.hull.ac.uk/",
-      "name": "Hydra",
-      "prefix": "r3d100011525",
-      "prefix_synonyms": [
-        "Hull's digital repository"
-      ],
-      "xrefs": {
-        "doi": "10.17616/R38D25"
-      }
     },
     "zazuko": {
       "prefix": "hydra",
@@ -133661,16 +133605,6 @@
       "repository": "https://github.com/Planteome/plant-stress-ontology",
       "version": "2026-01-08"
     },
-    "bioportal": {
-      "contact": {
-        "email": "schrader@th-brandenburg.de",
-        "name": "Thomas Schrader"
-      },
-      "description": "It is the ontology embedding PRIME (Prospective Risk Analysis in Medical Environments) in related issues of patient safety research and activities. It classifies terms and express relations between them. The ontology building in an ongoing process. Any comments are welcome.",
-      "name": "PatientSafetyOntology",
-      "prefix": "PSO",
-      "version": "008:2017-08-04: Einarbeitung der Zustände"
-    },
     "example": "0000013",
     "fairsharing": {
       "contact": {
@@ -133698,7 +133632,6 @@
     "mappings": {
       "aberowl": "PSO",
       "agroportal": "PSO",
-      "bioportal": "PSO",
       "fairsharing": "FAIRsharing.26d7f3",
       "obofoundry": "pso",
       "ols": "pso",
@@ -143893,7 +143826,6 @@
       "bioportal": "SCHEMA",
       "lov": "sdo",
       "ols": "schemaorg_http",
-      "prefixcommons": "sdo",
       "tib": "schema",
       "zazuko": "schema"
     },
@@ -143909,33 +143841,6 @@
       "uri_format": "http://schema.org/$1"
     },
     "preferred_prefix": "schema",
-    "prefixcommons": {
-      "description": "An application ontology for the domain of Sleep Medicine",
-      "examples": [
-        "CentralSleepApneaDisorder"
-      ],
-      "extras": {
-        "alt_uri_formats": [
-          "http://mimi.case.edu/ontologies/2009/9/DrugOntology#$1"
-        ]
-      },
-      "homepage": "https://mimi.case.edu/concepts",
-      "name": "Sleep Domain Ontology",
-      "prefix": "sdo",
-      "providers": [
-        {
-          "code": "bio2rdf",
-          "description": "Bio2RDF is an open-source project that uses Semantic Web technologies to build and provide the largest network of Linked Data for the Life Sciences. Bio2RDF defines a set of simple conventions to create RDF(S) compatible Linked Data from a diverse set of heterogeneously formatted sources obtained from multiple data providers.",
-          "homepage": "https://bio2rdf.org",
-          "name": "Bio2RDF",
-          "uri_format": "http://bio2rdf.org/sdo:$1"
-        }
-      ],
-      "uri_format_rdf": "http://mimi.case.edu/ontologies/2009/1/SDO.owl#$1",
-      "xrefs": {
-        "bioportal": "1651"
-      }
-    },
     "synonyms": [
       "schemaorg",
       "sdo"
@@ -174292,19 +174197,6 @@
       "prefix": "VSO",
       "version": "2012-04-25"
     },
-    "bartoc": {
-      "description": "The Vehicle Sales Ontology is a Web vocabulary for describings cars, boats, bikes, and other vehicles for e-commerce. The vocabulary is designed to be used in combination with GoodRelations, a standard vocabulary for the commercial aspects of offers for sale, rental, repair, or disposal. GoodRelations is a language (also known as \"schema\", \"data dictionary\", or \"ontology\") for product, price, and company data that can (1) be embedded into existing static and dynamic Web pages and that (2) can be processed by other computers. This increases the visibility of your products and services in the latest generation of search engines, recommender systems, and other novel applications.",
-      "homepage": "http://purl.org/vso/ns",
-      "license": {
-        "spdx": "CC-BY-3.0",
-        "url": "http://creativecommons.org/licenses/by/3.0/"
-      },
-      "name": "Vehicle Sales Ontology",
-      "prefix": "18355",
-      "short_names": [
-        "vso"
-      ]
-    },
     "bioportal": {
       "contact": {
         "email": "albertgoldfain@gmail.com",
@@ -174342,7 +174234,6 @@
     "license": "CC-BY-3.0",
     "mappings": {
       "aberowl": "VSO",
-      "bartoc": "18355",
       "bioportal": "VSO",
       "fairsharing": "FAIRsharing.jjb2p2",
       "prefixcommons": "vso",

--- a/src/bioregistry/data/curated_mappings.sssom.tsv
+++ b/src/bioregistry/data/curated_mappings.sssom.tsv
@@ -339,7 +339,6 @@ bioregistry:otl	skos:exactMatch	Not	lov:otl	semapv:ManualMappingCuration	orcid:0
 bioregistry:owl	skos:exactMatch	Not	integbio:nbdc00307	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:panther.family	skos:exactMatch		go:PANTHER	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:pathoplant	skos:exactMatch		pathguide:333	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-01		
-bioregistry:pathoplant	skos:exactMatch		pathguide:333	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:pdb	bioregistry.schema:0000030		uniprot:DB-0070	semapv:MappingReview	orcid:0000-0003-4423-4370			
 bioregistry:pdb	bioregistry.schema:0000030		uniprot:DB-0171	semapv:MappingReview	orcid:0000-0003-4423-4370			
 bioregistry:pdb	bioregistry.schema:0000030		uniprot:DB-0244	semapv:MappingReview	orcid:0000-0003-4423-4370			

--- a/src/bioregistry/data/curated_mappings.sssom.tsv
+++ b/src/bioregistry/data/curated_mappings.sssom.tsv
@@ -78,6 +78,7 @@ bioregistry:bcgo	skos:exactMatch	Not	fairsharing:FAIRsharing.2hzttx	semapv:Manua
 bioregistry:bcio	skos:exactMatch	Not	aberowl:BCI-O	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:bcio	skos:exactMatch	Not	bioportal:BCI-O	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:bcrc	skos:exactMatch		cellosaurus:BCRC	semapv:MappingReview	orcid:0009-0009-5240-7463			
+bioregistry:bido	skos:exactMatch	Not	ontobee:BIDO	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-01		
 bioregistry:bila	skos:exactMatch		prefixcommons:4dxpress	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:bind	skos:exactMatch		pathguide:1	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:bind	skos:exactMatch		prefixcommons:bind	semapv:MappingReview	orcid:0009-0009-5240-7463			
@@ -137,6 +138,8 @@ bioregistry:dbsnp	skos:exactMatch		go:dbSNP	semapv:ManualMappingCuration	orcid:0
 bioregistry:dbsnp	skos:exactMatch		ncbi:dbSNP	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:dc	skos:exactMatch		aberowl:dcelements	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:dcterms	skos:exactMatch		aberowl:dcterms	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
+bioregistry:ddi	skos:exactMatch	Not	bioportal:DDI	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-02		
+bioregistry:ddi	skos:exactMatch	Not	prefixcommons:ddi	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-02		
 bioregistry:dfg.fo	dcterms:hasVersion		tib:dfgfo2024	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-05-19	bioregistry.issue:1965	
 bioregistry:dicom	skos:exactMatch		fairsharing:FAIRsharing.b7z8by	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:dicom	skos:exactMatch	Not	lov:dicom	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
@@ -241,6 +244,7 @@ bioregistry:hpa	skos:exactMatch		uniprot:DB-0046	semapv:ManualMappingCuration	or
 bioregistry:hpath	skos:exactMatch	Not	fairsharing:FAIRsharing.kj336a	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
 bioregistry:hpm.protein	skos:exactMatch		ncbi:HPM	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:hsapdv	skos:exactMatch		ontobee:HsapDv	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
+bioregistry:hydra	skos:exactMatch	Not	re3data:r3d100011525	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-02		
 bioregistry:icd10cm	skos:exactMatch		aberowl:ICD10CM	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:icdc	skos:exactMatch	Not	fairsharing:FAIRsharing.d95034	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:icdc	skos:exactMatch	Not	re3data:r3d100010405	semapv:MappingReview	orcid:0009-0009-5240-7463			
@@ -334,6 +338,7 @@ bioregistry:orpha	dcterms:hasVersion		tib:ordo47	semapv:ManualMappingCuration	or
 bioregistry:otl	skos:exactMatch	Not	lov:otl	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
 bioregistry:owl	skos:exactMatch	Not	integbio:nbdc00307	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:panther.family	skos:exactMatch		go:PANTHER	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
+bioregistry:pathoplant	skos:exactMatch		pathguide:333	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-01		
 bioregistry:pathoplant	skos:exactMatch		pathguide:333	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:pdb	bioregistry.schema:0000030		uniprot:DB-0070	semapv:MappingReview	orcid:0000-0003-4423-4370			
 bioregistry:pdb	bioregistry.schema:0000030		uniprot:DB-0171	semapv:MappingReview	orcid:0000-0003-4423-4370			
@@ -369,6 +374,7 @@ bioregistry:pr	skos:exactMatch	Not	lov:pro	semapv:ManualMappingCuration	orcid:00
 bioregistry:pride	skos:exactMatch		aberowl:PRIDE	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:pride	skos:exactMatch	Not	integbio:nbdc00630	semapv:MappingReview	orcid:0000-0001-9439-5346		bioregistry.issue:1457	
 bioregistry:prosite	skos:exactMatch		togoid:Prosite	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
+bioregistry:pso	skos:exactMatch	Not	bioportal:PSO	semapv:ManualMappingCuration	orcid:0009-0009-5240-7463	2026-09-01		
 bioregistry:pso	skos:exactMatch	Not	bioportal:pso	semapv:MappingReview	orcid:0009-0009-5240-7463			
 bioregistry:pso	skos:exactMatch	Not	fairsharing:FAIRsharing.dyj433	semapv:MappingReview	orcid:0000-0001-9439-5346		bioregistry.issue:1457	
 bioregistry:pso	skos:exactMatch	Not	lov:pso	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
@@ -399,6 +405,7 @@ bioregistry:schema	skos:exactMatch	Not	aberowl:SDO	semapv:MappingReview	orcid:00
 bioregistry:schema	skos:exactMatch	Not	bioportal:SDO	semapv:MappingReview	orcid:0000-0003-4423-4370			
 bioregistry:schema	skos:exactMatch	Not	fairsharing:FAIRsharing.7s74s8	semapv:MappingReview	orcid:0000-0003-4423-4370			
 bioregistry:schema	skos:exactMatch	Not	lov:SDO	semapv:MappingReview	orcid:0000-0003-4423-4370			
+bioregistry:schema	skos:exactMatch	Not	prefixcommons:sdo	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	2026-09-01		
 bioregistry:sdbs	skos:exactMatch		integbio:nbdc01520	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:seed.subsystem	skos:exactMatch	Not	fairsharing:FAIRsharing.68b03f	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
 bioregistry:seed.subsystem	skos:exactMatch		ncbi:SEED	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
@@ -480,6 +487,7 @@ bioregistry:vcard	skos:exactMatch		lov:vcard	semapv:MappingReview	orcid:0009-000
 bioregistry:vgnc	skos:exactMatch		cellosaurus:VGNC	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:vgnc	skos:exactMatch		uniprot:DB-0226	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:vipr	skos:exactMatch		re3data:r3d100011931	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
+bioregistry:vso	skos:exactMatch	Not	bartoc:18355	semapv:ManualMappingCuration	orcid:0009-0009-5240-7463	2026-09-01		
 bioregistry:vso	skos:exactMatch	Not	lov:vso	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
 bioregistry:wbphenotype	skos:exactMatch		go:WBPhenotype	semapv:ManualMappingCuration	orcid:0009-0008-8406-631X		bioregistry.issue:1496	
 bioregistry:wikipathways	skos:exactMatch	Not	aberowl:wikipathways	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			

--- a/src/bioregistry/lint.py
+++ b/src/bioregistry/lint.py
@@ -19,6 +19,7 @@ def lint() -> None:
         read_contexts,
         read_mappings,
         read_metaregistry,
+        read_mismatches,
         read_registry,
         write_collections,
         write_contexts,
@@ -41,6 +42,7 @@ def lint() -> None:
     import pandas as pd
 
     registry = read_registry()
+    mismatches = read_mismatches()
     for resource in registry.values():
         if resource.synonyms:
             resource.synonyms = sorted(set(resource.synonyms))
@@ -61,6 +63,15 @@ def lint() -> None:
             resource.homepage = resource.homepage.rstrip("/")
         if resource.repository:
             resource.repository = resource.repository.rstrip("/")
+
+        if resource.mappings:
+            for external_registry, external_prefixes in mismatches.get(resource.prefix, {}).items():
+                if (
+                    external_registry in resource.mappings
+                    and resource.mappings[external_registry] in external_prefixes
+                ):
+                    del resource.mappings[external_registry]
+                    setattr(resource, external_registry, None)
 
     write_registry(registry)
     collections = read_collections()


### PR DESCRIPTION
This PR extends the lint command to look up mismatches and remove them from the main curation file. It also curates a few new mismatches to demonstrate.